### PR TITLE
fix: Match speakeasy version to provider version

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 8f132ad9-4841-4d16-98f8-e2b5bdc8b848
 management:
-  docChecksum: 67a48a9cb1919de0a022c6d5d15b0f6c
+  docChecksum: fa09ddc3e7d0dad7e1b37179b574f9a0
   docVersion: 1.56.0
   speakeasyVersion: 1.600.2
   generationVersion: 2.677.3

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,10 +3,10 @@ id: 8f132ad9-4841-4d16-98f8-e2b5bdc8b848
 management:
   docChecksum: 67a48a9cb1919de0a022c6d5d15b0f6c
   docVersion: 1.56.0
-  speakeasyVersion: 1.600.0
-  generationVersion: 2.677.2
-  releaseVersion: 0.0.3
-  configChecksum: a51a17a3ff52bf583e5067c6ffd2d1f5
+  speakeasyVersion: 1.600.2
+  generationVersion: 2.677.3
+  releaseVersion: 0.25.3
+  configChecksum: 142ac7791bde47d0e562a6a1a28da2ac
 features:
   terraform:
     additionalDependencies: 0.1.0

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -22,7 +22,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 0.0.3
+  version: 0.25.3
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Seqera API
-  description: Seqera Platform services API
+  description: The Seqera Platform Terraform Provider enables infrastructure-as-code management of Seqera Platform resources. This provider allows you to programmatically create, configure, and manage organizations, workspaces, compute environments, pipelines, credentials, and other Seqera Platform components using Terraform.
   contact:
     url: https://seqera.io
     email: info@seqera.io

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.600.2
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:eca9654242c54d3b9deec8913850ef6e18bb87e21084175da7c94222e8fcccb1
-        sourceBlobDigest: sha256:48aacd598a3ce31383b3c212c6bd5e236e1bd97507afcba648fe96f2f9568a5d
+        sourceRevisionDigest: sha256:69c90e1c1b4ae6ef1c5dd43458b426f95ae48fef368635cc9dc43a8bedab28fc
+        sourceBlobDigest: sha256:f4e8713a4e274b159c2280f3a05faf078af3d1430071ba08020175e9a73ab323
         tags:
             - latest
             - 1.56.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:eca9654242c54d3b9deec8913850ef6e18bb87e21084175da7c94222e8fcccb1
-        sourceBlobDigest: sha256:48aacd598a3ce31383b3c212c6bd5e236e1bd97507afcba648fe96f2f9568a5d
+        sourceRevisionDigest: sha256:69c90e1c1b4ae6ef1c5dd43458b426f95ae48fef368635cc9dc43a8bedab28fc
+        sourceBlobDigest: sha256:f4e8713a4e274b159c2280f3a05faf078af3d1430071ba08020175e9a73ab323
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest
@@ -21,6 +21,7 @@ workflow:
             inputs:
                 - location: specs/seqera-api-cloud.yaml
             overlays:
+                - location: overlays/api-description.yaml
                 - location: overlays/speakeasy.yaml
                 - location: overlays/required.yaml
                 - location: overlays/schema-descriptions.yaml

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.600.0
+speakeasyVersion: 1.600.2
 sources:
     Seqera API:
         sourceNamespace: seqera-api

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -5,6 +5,7 @@ sources:
         inputs:
             - location: specs/seqera-api-cloud.yaml
         overlays:
+            - location: overlays/api-description.yaml
             - location: overlays/speakeasy.yaml
             - location: overlays/required.yaml
             - location: overlays/schema-descriptions.yaml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Terraform Provider for the Seqera Platform API.
 <!-- Start Summary [summary] -->
 ## Summary
 
-Seqera API: Seqera Platform services API
+Seqera API: The Seqera Platform Terraform Provider enables infrastructure-as-code management of Seqera Platform resources. This provider allows you to programmatically create, configure, and manage organizations, workspaces, compute environments, pipelines, credentials, and other Seqera Platform components using Terraform.
 <!-- End Summary [summary] -->
 
 <!-- Start Table of Contents [toc] -->

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ terraform {
   required_providers {
     seqera = {
       source  = "seqeralabs/seqera"
-      version = "0.0.3"
+      version = "0.25.3"
     }
   }
 }

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -6,7 +6,7 @@ This document shows the compatibility between Seqera platform versions, Seqera p
 
 | Platform Type | Platform Version | API Version | Terraform Provider Version |
 |---------------|------------------|-------------|----------------------------|
-| **Seqera Platform** | Latest | 1.56.0 | 0.25.0  |
+| **Seqera Platform** | Latest | 1.56.0 | 0.25.3  |
 | **Seqera Platform** | v23.4 | 1.56.0 | 0.23.0 |
 | **Seqera Platform** | v24.2 | 1.45.0 | 0.24.0  |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,12 @@
 page_title: "seqera Provider"
 subcategory: ""
 description: |-
-  Seqera API: Seqera Platform services API
+  Seqera API: The Seqera Platform Terraform Provider enables infrastructure-as-code management of Seqera Platform resources. This provider allows you to programmatically create, configure, and manage organizations, workspaces, compute environments, pipelines, credentials, and other Seqera Platform components using Terraform.
 ---
 
 # seqera Provider
 
-Seqera API: Seqera Platform services API
+Seqera API: The Seqera Platform Terraform Provider enables infrastructure-as-code management of Seqera Platform resources. This provider allows you to programmatically create, configure, and manage organizations, workspaces, compute environments, pipelines, credentials, and other Seqera Platform components using Terraform.
 
 ## Example Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     seqera = {
       source  = "seqeralabs/seqera"
-      version = "0.0.3"
+      version = "0.25.3"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     seqera = {
       source  = "seqeralabs/seqera"
-      version = "0.0.3"
+      version = "0.25.3"
     }
   }
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,7 +48,7 @@ func (p *SeqeraProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 				Optional:    true,
 			},
 		},
-		MarkdownDescription: `Seqera API: Seqera Platform services API`,
+		MarkdownDescription: `Seqera API: The Seqera Platform Terraform Provider enables infrastructure-as-code management of Seqera Platform resources. This provider allows you to programmatically create, configure, and manage organizations, workspaces, compute environments, pipelines, credentials, and other Seqera Platform components using Terraform.`,
 	}
 }
 

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.56.0 and generator version 2.677.2
+// Generated from OpenAPI doc version 1.56.0 and generator version 2.677.3
 
 import (
 	"context"
@@ -168,9 +168,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
-		SDKVersion: "0.0.3",
+		SDKVersion: "0.25.3",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.0.3 2.677.2 1.56.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.25.3 2.677.3 1.56.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -47,7 +47,7 @@ func Float64(f float64) *float64 { return &f }
 // Pointer provides a helper function to return a pointer to a type
 func Pointer[T any](v T) *T { return &v }
 
-// Seqera API: Seqera Platform services API
+// Seqera API: The Seqera Platform Terraform Provider enables infrastructure-as-code management of Seqera Platform resources. This provider allows you to programmatically create, configure, and manage organizations, workspaces, compute environments, pipelines, credentials, and other Seqera Platform components using Terraform.
 type Seqera struct {
 	SDKVersion string
 	// Pipeline actions

--- a/overlays/api-description.yaml
+++ b/overlays/api-description.yaml
@@ -1,0 +1,10 @@
+overlay: 1.0.0
+x-speakeasy-jsonpath: rfc9535
+info:
+  title: API Description Overlay
+  version: 0.0.0
+actions:
+  # Update main API description
+  - target: $.info.description
+    update: |
+      The Seqera Platform Terraform Provider enables infrastructure-as-code management of Seqera Platform resources. This provider allows you to programmatically create, configure, and manage organizations, workspaces, compute environments, pipelines, credentials, and other Seqera Platform components using Terraform.


### PR DESCRIPTION
Speakeasy version needs to match the provider version. 

Also adds a better description to the provider. 