### PR TITLE
chore: add vscode and claude settings files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ terraform-provider-seqera
 terraform-provider-* # We should not include the provider binary in the repository
 *.tfvars
 !*.tfvars.example
+*.code-workspace
+settings.local.json


### PR DESCRIPTION
Adds two files to `.gitignore`:
- ***.code-workspace**: I tend to have the provider open next to some Terraform repos/
- **settings.local.json**: A common local settings file, but more importantly Claude will use this to whitelist bash commands which is a security vulnerability.