### PR TITLE
Use less misleading examples for "entry_name" field

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -31,7 +31,7 @@ resource "seqera_action" "my_action" {
     ]
     config_text        = "process {\n  executor = 'awsbatch'\n  queue = 'my-queue'\n}\n"
     date_created       = "2024-07-23T10:30:00Z"
-    entry_name         = "main.nf"
+    entry_name         = "my_secondary_workflow"
     head_job_cpus      = 2
     head_job_memory_mb = 4096
     label_ids = [

--- a/docs/resources/workflows.md
+++ b/docs/resources/workflows.md
@@ -28,7 +28,7 @@ resource "seqera_workflows" "my_workflows" {
   ]
   config_text        = "process {\n  executor = 'awsbatch'\n  queue = 'my-queue'\n}\n"
   date_created       = "2024-07-23T10:30:00Z"
-  entry_name         = "main.nf"
+  entry_name         = "my_secondary_workflow"
   force              = false
   head_job_cpus      = 2
   head_job_memory_mb = 4096

--- a/examples/resources/seqera_action/resource.tf
+++ b/examples/resources/seqera_action/resource.tf
@@ -7,7 +7,7 @@ resource "seqera_action" "my_action" {
     ]
     config_text        = "process {\n  executor = 'awsbatch'\n  queue = 'my-queue'\n}\n"
     date_created       = "2024-07-23T10:30:00Z"
-    entry_name         = "main.nf"
+    entry_name         = "my_secondary_workflow"
     head_job_cpus      = 2
     head_job_memory_mb = 4096
     label_ids = [

--- a/examples/resources/seqera_pipeline/resource.tf
+++ b/examples/resources/seqera_pipeline/resource.tf
@@ -12,7 +12,7 @@ resource "seqera_pipeline" "my_pipeline" {
     ]
     config_text        = "process {\n  executor = 'awsbatch'\n  queue = 'my-queue'\n}\n"
     date_created       = "2024-07-23T10:30:00Z"
-    entry_name         = "main.nf"
+    entry_name         = "my_secondary_workflow"
     head_job_cpus      = 2
     head_job_memory_mb = 4096
     label_ids = [

--- a/examples/resources/seqera_workflows/resource.tf
+++ b/examples/resources/seqera_workflows/resource.tf
@@ -6,7 +6,7 @@ resource "seqera_workflows" "my_workflows" {
   ]
   config_text        = "process {\n  executor = 'awsbatch'\n  queue = 'my-queue'\n}\n"
   date_created       = "2024-07-23T10:30:00Z"
-  entry_name         = "main.nf"
+  entry_name         = "my_secondary_workflow"
   force              = false
   head_job_cpus      = 2
   head_job_memory_mb = 4096


### PR DESCRIPTION
The "entry_name" field is used as the (deprecated) Nextflow -entry CLI argument. The previous examples implied that it should point to a file path or file name, but in reality, it should refer to the name of the workflow or process to be executed.