### PR TITLE
fix: Support credential recreation

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,10 +1,10 @@
 lockVersion: 2.0.0
 id: 8f132ad9-4841-4d16-98f8-e2b5bdc8b848
 management:
-  docChecksum: 2100b157d037db724beb67208ca70807
+  docChecksum: 949062ad9c8cbb3e270411e43e359c20
   docVersion: 1.56.0
-  speakeasyVersion: 1.642.1
-  generationVersion: 2.731.4
+  speakeasyVersion: 1.642.2
+  generationVersion: 2.731.6
   releaseVersion: 0.25.4
   configChecksum: 853d1b859009f3eb0de1df23d43a5fac
 features:
@@ -22,7 +22,7 @@ features:
     nameOverrides: 2.81.3
     nullables: 0.0.0
     retries: 2.81.4
-    unions: 2.82.1
+    unions: 2.82.2
 generatedFiles:
   - .gitattributes
   - USAGE.md

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -7797,6 +7797,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "403":
           description: Operation not allowed
+        "404":
+          description: Not Found - Credential does not exist or has been deleted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
       security:
         - BearerAuth: []
     put:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.642.1
+speakeasyVersion: 1.642.2
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:e84d5e0510d1723de6934badc407b33e30dbe4bcaaa272a8a174efdd6b134299
-        sourceBlobDigest: sha256:0c4876e770a7119f69cb5631cc257b52a294a32e4b0771a2e49da1e9f69537dd
+        sourceRevisionDigest: sha256:7efd95ffc1cfb1f3f1218b728015fd932b9fa3793cd02033364a760551a72a40
+        sourceBlobDigest: sha256:f4f89d4c338b877417861be5d1c513f30b0782307d6e1411cb6d1d4f84cbf6af
         tags:
             - latest
             - 1.56.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:e84d5e0510d1723de6934badc407b33e30dbe4bcaaa272a8a174efdd6b134299
-        sourceBlobDigest: sha256:0c4876e770a7119f69cb5631cc257b52a294a32e4b0771a2e49da1e9f69537dd
+        sourceRevisionDigest: sha256:7efd95ffc1cfb1f3f1218b728015fd932b9fa3793cd02033364a760551a72a40
+        sourceBlobDigest: sha256:f4f89d4c338b877417861be5d1c513f30b0782307d6e1411cb6d1d4f84cbf6af
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/docs/resources/compute_env.md
+++ b/docs/resources/compute_env.md
@@ -3,9 +3,9 @@
 page_title: "seqera_compute_env Resource - terraform-provider-seqera"
 subcategory: ""
 description: |-
+  This resource allows the management of Seqera compute environments.
   Seqera Platform compute environments define the execution platform where a pipeline will run.
-  Compute environments enable users to launch pipelines on a growing number of cloud and
-  on-premises platforms. Each compute environment must be configured to enable Seqera to submit tasks.
+  Compute environments enable users to launch pipelines on a growing number of cloud and on-premises platforms.
   Compute environments define the computational resources and configuration needed
   to run Nextflow workflows, including cloud provider settings, resource limits,
   and execution parameters.
@@ -13,9 +13,10 @@ description: |-
 
 # seqera_compute_env (Resource)
 
+This resource allows the management of Seqera compute environments.
+
 Seqera Platform compute environments define the execution platform where a pipeline will run.
-Compute environments enable users to launch pipelines on a growing number of cloud and
-on-premises platforms. Each compute environment must be configured to enable Seqera to submit tasks.
+Compute environments enable users to launch pipelines on a growing number of cloud and on-premises platforms.
 
 Compute environments define the computational resources and configuration needed
 to run Nextflow workflows, including cloud provider settings, resource limits,

--- a/internal/provider/computeenv_resource.go
+++ b/internal/provider/computeenv_resource.go
@@ -67,7 +67,7 @@ func (r *ComputeEnvResource) Metadata(ctx context.Context, req resource.Metadata
 
 func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Seqera Platform compute environments define the execution platform where a pipeline will run.\nCompute environments enable users to launch pipelines on a growing number of cloud and\non-premises platforms. Each compute environment must be configured to enable Seqera to submit tasks.\n\nCompute environments define the computational resources and configuration needed\nto run Nextflow workflows, including cloud provider settings, resource limits,\nand execution parameters.\n",
+		MarkdownDescription: "This resource allows the management of Seqera compute environments.\n\nSeqera Platform compute environments define the execution platform where a pipeline will run.\nCompute environments enable users to launch pipelines on a growing number of cloud and on-premises platforms.\n\nCompute environments define the computational resources and configuration needed\nto run Nextflow workflows, including cloud provider settings, resource limits,\nand execution parameters.\n",
 		Attributes: map[string]schema.Attribute{
 			"compute_env": schema.SingleNestedAttribute{
 				Required: true,

--- a/internal/sdk/credentials.go
+++ b/internal/sdk/credentials.go
@@ -1229,7 +1229,10 @@ func (s *Credentials) DescribeAWSCredentials(ctx context.Context, request operat
 			}
 			return nil, errors.NewAPIError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 403:
 	case httpRes.StatusCode == 400:
+		fallthrough
+	case httpRes.StatusCode == 404:
 		switch {
 		case utils.MatchContentType(httpRes.Header.Get("Content-Type"), `application/json`):
 			rawBody, err := utils.ConsumeRawBody(httpRes)
@@ -1250,7 +1253,6 @@ func (s *Credentials) DescribeAWSCredentials(ctx context.Context, request operat
 			}
 			return nil, errors.NewAPIError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
-	case httpRes.StatusCode == 403:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/internal/hooks/credential_error_hook.go
+++ b/internal/sdk/internal/hooks/credential_error_hook.go
@@ -1,0 +1,47 @@
+package hooks
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// CredentialErrorHook transforms 403 responses to 404 for credential read operations
+// to allow Terraform to properly handle deleted credentials
+type CredentialErrorHook struct{}
+
+// AfterSuccess implements the afterSuccessHook interface
+// When a credential is deleted in the web UI, the API returns 403 instead of 404.
+// This hook converts 403 responses to 404 for credential read operations so that
+// Terraform removes the resource from state instead of showing an error.
+func (h *CredentialErrorHook) AfterSuccess(hookCtx AfterSuccessContext, res *http.Response) (*http.Response, error) {
+	// Only process if we have a response
+	if res == nil {
+		return res, nil
+	}
+
+	// Check if this is a 403 response
+	if res.StatusCode != 403 {
+		return res, nil
+	}
+
+	// Check if this is a credential describe/read operation
+	// All credential read operations follow the pattern "Describe*Credentials"
+	if !strings.HasPrefix(hookCtx.OperationID, "Describe") || !strings.HasSuffix(hookCtx.OperationID, "Credentials") {
+		return res, nil
+	}
+
+	// Convert 403 to 404 so Terraform treats it as "not found"
+	// Create a valid JSON error response body for the SDK to parse
+	res.StatusCode = 404
+	res.Status = "404 Not Found"
+
+	// Create a valid JSON error response body
+	errorBody := `{"message":"Resource not found or has been deleted"}`
+	res.Body = io.NopCloser(bytes.NewBufferString(errorBody))
+	res.ContentLength = int64(len(errorBody))
+	res.Header.Set("Content-Type", "application/json")
+
+	return res, nil
+}

--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -9,6 +9,10 @@ package hooks
  */
 
 func initHooks(h *Hooks) {
+	// Register credential error hook to treat 403 as 404 for deleted credentials
+	credentialErrorHook := &CredentialErrorHook{}
+	h.registerAfterSuccessHook(credentialErrorHook)
+
 	// exampleHook := &ExampleHook{}
 
 	// h.registerSDKInitHook(exampleHook)

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.56.0 and generator version 2.731.4
+// Generated from OpenAPI doc version 1.56.0 and generator version 2.731.6
 
 import (
 	"context"
@@ -170,7 +170,7 @@ func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
 		SDKVersion: "0.25.4",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.25.4 2.731.4 1.56.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.25.4 2.731.6 1.56.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/overlays/credentials-aws.yaml
+++ b/overlays/credentials-aws.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-azure.yaml
+++ b/overlays/credentials-azure.yaml
@@ -86,6 +86,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
           - BearerAuth: []
         put:

--- a/overlays/credentials-bitbucket.yaml
+++ b/overlays/credentials-bitbucket.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-codecommit.yaml
+++ b/overlays/credentials-codecommit.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-container-registry.yaml
+++ b/overlays/credentials-container-registry.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-gcp.yaml
+++ b/overlays/credentials-gcp.yaml
@@ -123,6 +123,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
           - BearerAuth: []
         put:

--- a/overlays/credentials-gitea.yaml
+++ b/overlays/credentials-gitea.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-github.yaml
+++ b/overlays/credentials-github.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-gitlab.yaml
+++ b/overlays/credentials-gitlab.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-kubernetes.yaml
+++ b/overlays/credentials-kubernetes.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-ssh.yaml
+++ b/overlays/credentials-ssh.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:

--- a/overlays/credentials-tower-agent.yaml
+++ b/overlays/credentials-tower-agent.yaml
@@ -88,6 +88,12 @@ actions:
                     $ref: "#/components/schemas/ErrorResponse"
             "403":
               description: Operation not allowed
+            "404":
+              description: Not Found - Credential does not exist or has been deleted
+              content:
+                application/json:
+                  schema:
+                    $ref: "#/components/schemas/ErrorResponse"
           security:
             - BearerAuth: []
         put:


### PR DESCRIPTION
The following implements an `AfterError` hook within the speakeasy SDK https://www.speakeasy.com/docs/customize/code/sdk-hooks to address issues with our API.

Currently our credentials endpoint returns a 403 error unauthorized vs a 404 when a resource is not found and aligning to https://www.speakeasy.com/api-design/status-codes#ambiguity-in-error-code

There is a request into the appropriate engineering team to align our status codes so that a 404 is returned unless a user does not have permission to get or list resources in the context of the request.

## Use Case 

- Resources are created via Terraform
- User deletes a resource outside of Terraform (e.g., Web UI, direct API call, Seqerakit)
- Terraform attempts to describe the resource and receives a 403 error
- Without this fix: Terraform throws an unexpected error
- With this fix: The AfterError hook transforms the 403 to 404, allowing Terraform to recognize the resource as deleted and handle it gracefully

**Note: If a user genuinely lacks permissions, they will encounter the appropriate authorization error during resource creation.**



