### PR TITLE
Edit instructions for updating OpenAPI specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ go build
 ```bash
 
 # Create a new overaly file from the update openAPI spec (example). The file must be name seqera-final.yaml for speakeasy to pick it up.
-speakeasy overlay compare --before=seqera-api-latest.yml --after=seqera-final.yaml > overlay_new.yaml
+speakeasy overlay compare --before=seqera-api-latest-flattened.yml --after=seqera-final.yaml > overlay_new.yaml
 # Regenerate provider code using Speakeasy
 speakeasy run --skip-versioning 
 
@@ -108,7 +108,7 @@ speakeasy run --skip-versioning
 
 ### Code Generation Workflow
 1. Only modify the OpenAPI specifications in `schemas/seqera-final.yaml` to add speakeasy annotations.
-2. Generate the overlay file from the edited specification using `speakeasy overlay compare --before=seqera-api-latest.yml --after=seqera-final.yaml > overlay_new.yaml`.
+2. Generate the overlay file from the edited specification using `speakeasy overlay compare --before=seqera-api-latest-flattened.yml --after=seqera-final.yaml > overlay_new.yaml`.
 3. Edit overlay files in `overlays/` directory following patterns in `internal-docs/OVERLAY_GUIDE.md`
 4. Create custom examples in `examples/resources/seqera_[resource]/resource.tf` and protect them with `.genignore`
 5. Run `speakeasy run --skip-versioning` to regenerate provider code

--- a/docs/internal/adding-new-resources.md
+++ b/docs/internal/adding-new-resources.md
@@ -67,7 +67,7 @@ actions:
 To apply an overlay to your OpenAPI schema:
 
 ```bash
-speakeasy overlay apply --schema seqera-api-latest.yml --overlay overlay_new.yaml
+speakeasy overlay apply --schema seqera-api-latest-flattened.yml --overlay overlay_new.yaml
 ```
 
 ### Generating Overlays
@@ -75,7 +75,7 @@ speakeasy overlay apply --schema seqera-api-latest.yml --overlay overlay_new.yam
 You can generate an overlay by comparing two OpenAPI specifications. This is useful when you've manually edited a schema and want to create a reusable overlay:
 
 ```bash
-speakeasy overlay compare --before=seqera-api-latest.yml --after=seqera-final.yaml > overlay_new.yaml
+speakeasy overlay compare --before=seqera-api-latest-flattened.yml --after=seqera-final.yaml > overlay_new.yaml
 ```
 
 > **Note**: As documented in CLAUDE.md, the final schema file must be named `seqera-final.yaml` for Speakeasy to pick it up during generation.

--- a/docs/internal/project-structure.md
+++ b/docs/internal/project-structure.md
@@ -39,7 +39,7 @@ internal/
 
 ```
 schemas/
-├── seqera-api-latest.yml   # Base OpenAPI specification
+├── seqera-api-latest-flattened.yml   # Base OpenAPI specification
 ├── seqera-final.yaml       # Modified OpenAPI spec with Speakeasy annotations
 └── overlay.yaml            # Speakeasy overlay for customizations
 

--- a/overlays/required.yaml
+++ b/overlays/required.yaml
@@ -1,7 +1,7 @@
 overlay: 1.0.0
 x-speakeasy-jsonpath: rfc9535
 info:
-  title: Overlay seqera-api-latest.yml => seqera-final.yaml
+  title: Overlay seqera-api-latest-flattened.yml => seqera-final.yaml
   version: 0.0.0
 actions:
   - target: $.components.schemas.CreateComputeEnvRequest

--- a/overlays/speakeasy.yaml
+++ b/overlays/speakeasy.yaml
@@ -1,7 +1,7 @@
 overlay: 1.0.0
 x-speakeasy-jsonpath: rfc9535
 info:
-  title: Overlay seqera-api-latest.yml => seqera-final.yaml
+  title: Overlay seqera-api-latest-flattened.yml => seqera-final.yaml
   version: 0.0.0
 actions:
   - target: $["components"]["schemas"]["AgentSecurityKeys"]["properties"]["discriminator"]["readOnly"]


### PR DESCRIPTION
Closes [PLAT-4368](https://seqera.atlassian.net/browse/PLAT-4368).

Once the PR that applies some tweaks to the OpenAPI specs to fix the SDK generation is merged (https://github.com/seqeralabs/platform/pull/9831), the Terraform provider should use the `seqera-api-latest-flattened.yml` version of the specs, as `seqera-api-latest.yml` contains recursive references that might not be accepted by the [`ogen`](https://github.com/ogen-go/ogen) tool.

### Guidelines for testing

- [ ] Test SDK generation for the Terraform provider with `seqera-api-latest-flattened.yml`: it works successfully.
- [ ] Test some Terraform provider definitions with the generated SDK: they work successfully.

[PLAT-4368]: https://seqera.atlassian.net/browse/PLAT-4368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ