### PR TITLE
fix: Correct org memberships

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,10 +1,10 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 4abd56c9f698bfe42d54150f076440e1
+  docChecksum: 19c2530a69ad674b54f79873f3c0f2f1
   docVersion: 1.102.0
-  speakeasyVersion: 1.697.5
-  generationVersion: 2.799.0
+  speakeasyVersion: 1.700.2
+  generationVersion: 2.801.2
   releaseVersion: 0.30.1
   configChecksum: 3663426c09920a8ed6e46f26b60f87aa
 persistentEdits:
@@ -15,7 +15,7 @@ features:
   terraform:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.3.0
-    core: 3.46.28
+    core: 3.46.30
     deepObjectParams: 0.1.0
     deprecations: 2.82.0
     getRequestBodies: 2.81.1
@@ -406,7 +406,7 @@ trackedFiles:
     pristine_git_object: 4d4451329e274230a287210d496b8e03aea29724
   internal/provider/awscredential_resource.go:
     id: fd1fb9518f67
-    last_write_checksum: sha1:92fc8b7672ff6c6b50572b1fc45af9e89dcfc4dc
+    last_write_checksum: sha1:ce53b2efe9213e533c967f9c3e790ac46180ffb4
     pristine_git_object: 718916f70c62d6cdeb910a896ec32723c62f9346
   internal/provider/awscredential_resource_sdk.go:
     id: 6dd3171fbbcc
@@ -414,7 +414,7 @@ trackedFiles:
     pristine_git_object: fb79abddd43fc8a362ddaff379637c1def78665a
   internal/provider/azurecredential_resource.go:
     id: 4e14a60d78ce
-    last_write_checksum: sha1:8c62d2ec6e62f93001c2b450c6872255d37de208
+    last_write_checksum: sha1:9af11da5c6b93fba0c7d759e76e53b4539805a89
     pristine_git_object: 0eb0896ee9fe4eed104d1d66e3c5b72221a8e8c1
   internal/provider/azurecredential_resource_sdk.go:
     id: 1cff49867392
@@ -422,7 +422,7 @@ trackedFiles:
     pristine_git_object: 62f301e24df9501920ae8a9afe8ae7927b82a862
   internal/provider/bitbucketcredential_resource.go:
     id: 99461a76ba60
-    last_write_checksum: sha1:d3b09a412e742a4cda8a305f20996b17e252d318
+    last_write_checksum: sha1:6a1c989eb965698dece2204ff49c79f590bed6a4
     pristine_git_object: ef48989850ba46b7641a28a14055504c1737a53c
   internal/provider/bitbucketcredential_resource_sdk.go:
     id: ea250abc2a72
@@ -430,7 +430,7 @@ trackedFiles:
     pristine_git_object: 8a0bebdcdd3d64be9a83a6a75aa5bc0422f8f3ff
   internal/provider/codecommitcredential_resource.go:
     id: 22c2e9aa4b13
-    last_write_checksum: sha1:7839cc9108e151a42e5f29ab9493742051e61c54
+    last_write_checksum: sha1:91ba276d980dec86c551157b03d87f6421191c5a
     pristine_git_object: 58dcb06c3f42ed4aa8f5bf250a2b70ed4ad235ed
   internal/provider/codecommitcredential_resource_sdk.go:
     id: dcc60e154878
@@ -446,7 +446,7 @@ trackedFiles:
     pristine_git_object: 2e933070714e8aa8d9ab83f2e1b81abd6f262ade
   internal/provider/containerregistrycredential_resource.go:
     id: f0a18857f2ea
-    last_write_checksum: sha1:3686b9a8753cb7c76dd9fd875a45d782fee0e815
+    last_write_checksum: sha1:21746c11ae8477e75f51d6eaf17e1a0fc02f6b7d
     pristine_git_object: e6a9866eacb679ff8d1567624763412dcb61f0d1
   internal/provider/containerregistrycredential_resource_sdk.go:
     id: 84a1496699d8
@@ -494,7 +494,7 @@ trackedFiles:
     pristine_git_object: d3d10cadef9504a6a38441129ada6ccaf494496e
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
-    last_write_checksum: sha1:c7ae29818b4cd1d646d44e222de73b62cdfd7c79
+    last_write_checksum: sha1:6e9d3d0ffab28691453989717156baee9e43a03b
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
@@ -502,7 +502,7 @@ trackedFiles:
     pristine_git_object: 71e29ff10c22205eab4418ac0b8a92152cc5b23d
   internal/provider/githubcredential_resource.go:
     id: e1f090a0cb9e
-    last_write_checksum: sha1:2b5e9eab7ee5b69c4964e3a60eb1ac7c661a4f56
+    last_write_checksum: sha1:f7c0ac091da11ab1b7cffeee9005d9d260267122
     pristine_git_object: c6a4da7de3d8a1ca06c268021bcb56ba09f3c9f1
   internal/provider/githubcredential_resource_sdk.go:
     id: bc2bee614a62
@@ -510,7 +510,7 @@ trackedFiles:
     pristine_git_object: 01c4b02c388b5caf56516bd71e9a2176973234b2
   internal/provider/gitlabcredential_resource.go:
     id: fcb86103d097
-    last_write_checksum: sha1:d2a79bc70c2d2398d662c792071395fc05153267
+    last_write_checksum: sha1:26e159d4c1efa4d86328d8c068aa000c700f7a09
     pristine_git_object: 5b27290c979fb073cf156f1babc37c36cde9ab8e
   internal/provider/gitlabcredential_resource_sdk.go:
     id: a6c217015659
@@ -518,7 +518,7 @@ trackedFiles:
     pristine_git_object: 0f3d5604b62f838d2b0b79919f08bc65e5c9cf5b
   internal/provider/googlecredential_resource.go:
     id: 8822521a4af3
-    last_write_checksum: sha1:5806fa7d0a572c0ade898638c387c4716bfc5cf2
+    last_write_checksum: sha1:650195b7c3096575e018efcfce4d3770dbbf3347
     pristine_git_object: 026226dc9ef3d464025bca768181bcaa0a4e6f7f
   internal/provider/googlecredential_resource_sdk.go:
     id: b4c881561996
@@ -526,7 +526,7 @@ trackedFiles:
     pristine_git_object: a25a2b110b86b9bffc9496f89bf92a4e5e452bce
   internal/provider/kubernetescredential_resource.go:
     id: 9cca06635b9e
-    last_write_checksum: sha1:a3e4f35a8d389cf8a2fa0cbb4ad05a88240e0a40
+    last_write_checksum: sha1:5aa78db4aff4126ea5d14a1f25591d6489ae29ba
     pristine_git_object: 1be6769e629c348b8cf88a2f4898baf75b3da740
   internal/provider/kubernetescredential_resource_sdk.go:
     id: ea2832ecd302
@@ -550,7 +550,7 @@ trackedFiles:
     pristine_git_object: 2200507ea00d48e6fa7ee4f3f2e51571f17226c3
   internal/provider/orgs_resource.go:
     id: 28df60f6d9c9
-    last_write_checksum: sha1:38c29a90e47588cfeeaf56ccc1bb336fc44f1ea7
+    last_write_checksum: sha1:514c0487300be0d8452911c526f54991917dddc3
     pristine_git_object: e73b7ac164d81f97838d8b785505471601e1ccb1
   internal/provider/orgs_resource_sdk.go:
     id: 473d7fede1ee
@@ -642,7 +642,7 @@ trackedFiles:
     pristine_git_object: c588f768bd7b39be33962188f97d81e1c4c25f4b
   internal/provider/sshcredential_resource.go:
     id: 7eb281c9649c
-    last_write_checksum: sha1:cde92f5993e67825b24389f8be950e99156813d5
+    last_write_checksum: sha1:9bc4c3ace521b928f4c7c7dfbcf0f864ca9b3a1a
     pristine_git_object: 47f7c6e152f7cecdcbd982d27de12746f870a355
   internal/provider/sshcredential_resource_sdk.go:
     id: 3c25312d23ab
@@ -650,7 +650,7 @@ trackedFiles:
     pristine_git_object: a633929e19d2c86fc43fdc96a586954c0992048c
   internal/provider/studios_resource.go:
     id: d5d4f38592d9
-    last_write_checksum: sha1:1ac270a3880914064b212d370382544ba3aef62b
+    last_write_checksum: sha1:fb0cd2f60a91a5ba7a0d3d4c7ea59896bd439989
     pristine_git_object: b69af57c1f895efdf781dd1ccf3aa900a68744e2
   internal/provider/studios_resource_sdk.go:
     id: 3f2ecca255e3
@@ -658,7 +658,7 @@ trackedFiles:
     pristine_git_object: 5bfc8970d75b9bf9e6a0729b69f9a3cd9ad0eaeb
   internal/provider/teams_resource.go:
     id: 6e0e94a85c68
-    last_write_checksum: sha1:f550d9ec09150001015225a80b33ff079437eec5
+    last_write_checksum: sha1:41666cafa16927ba125bb14c145da4b9e86b586e
     pristine_git_object: 5d8d2ee60c142b7c8d7b5fd44dc886e4bfee5df7
   internal/provider/teams_resource_sdk.go:
     id: 7638a674c722
@@ -666,7 +666,7 @@ trackedFiles:
     pristine_git_object: 26f268ef8a33992e5cedbb0dbbe25ccb26ffb14a
   internal/provider/toweragentcredential_resource.go:
     id: 9596670e4f16
-    last_write_checksum: sha1:caea72d14756a80af32253e7608588ac1eaf103f
+    last_write_checksum: sha1:e57a72c5aa0cd7d6986b077d8a179f24bbaa1e93
     pristine_git_object: d91d65ea5bffdb82659601bb5f8c37780e55e998
   internal/provider/toweragentcredential_resource_sdk.go:
     id: 139ea0cf9bf1
@@ -3606,7 +3606,7 @@ trackedFiles:
     pristine_git_object: aa809fccb3445b1e2530a979dad620512f50e70f
   internal/sdk/seqera.go:
     id: b1c23bc5193c
-    last_write_checksum: sha1:bf1445f19e0e0b59316f7a2a230ca31887c3626a
+    last_write_checksum: sha1:08191b44a99516795b84b317e4ec164bad145979
     pristine_git_object: 89364ed6208c4c999b317d23d7d954d63ac46bc5
   internal/sdk/serviceinfo.go:
     id: 085db9a15b34

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -15956,6 +15956,22 @@ components:
         You can create multiple organizations, each of which can contain multiple workspaces
         with shared users and resources. This means you can customize and organize the use of
         resources while maintaining an access control layer for users associated with a workspace.
+
+        ~> **Warning:** Destroying an organization resource will permanently delete the organization
+        and all its associated resources including workspaces, members, teams, compute environments,
+        pipelines, and credentials. This action cannot be undone. Use Terraform lifecycle rules to
+        protect critical organizations from accidental deletion:
+
+        ```terraform
+        resource "seqera_orgs" "production" {
+          name      = "production-org"
+          full_name = "Production Organization"
+
+          lifecycle {
+            prevent_destroy = true
+          }
+        }
+        ```
     OrganizationDbDto:
       type: object
       properties:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.697.5
+speakeasyVersion: 1.700.2
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:7df0353d87e066f85628499343a98b5eb200b31bc717fcecbc2f5c05b4f80bca
-        sourceBlobDigest: sha256:9f3f1698362418d351e84863ff5c6e79e263de31e1ccf6ea9cbfe417d4ebc772
+        sourceRevisionDigest: sha256:40543fd512ad2d9d7ed91fec688810387a28d8d9fb8f46747a7e0178b5f1bf46
+        sourceBlobDigest: sha256:15f899f3a2be868797f5a1c9d2673c854fd4f5034e0d59bc64a7ef8bc4eeab72
         tags:
             - latest
             - 1.102.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:7df0353d87e066f85628499343a98b5eb200b31bc717fcecbc2f5c05b4f80bca
-        sourceBlobDigest: sha256:9f3f1698362418d351e84863ff5c6e79e263de31e1ccf6ea9cbfe417d4ebc772
+        sourceRevisionDigest: sha256:40543fd512ad2d9d7ed91fec688810387a28d8d9fb8f46747a7e0178b5f1bf46
+        sourceBlobDigest: sha256:15f899f3a2be868797f5a1c9d2673c854fd4f5034e0d59bc64a7ef8bc4eeab72
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ FIX:
 
 - **Compute Environment Lifecycle** - Improve the lifecycle management from Creating -> Created & Deleting -> Deleted for compatibility accross all Seqera Versions and handle both api.XXX & XXX/api endpoints.
 
+- **Organization Member Role Management** - Fixed "Provider produced inconsistent result after apply" error when creating or updating members with non-default roles. The issue had two causes: (1) during creation, the desired role from the plan was being overwritten before the role update logic executed, and (2) during updates, eventual consistency in the API meant the list endpoint returned stale role data. The provider now saves the desired role before any API operations and preserves it after updates.
+
+- **Workspace Participant Role Management** - Fixed "Provider produced inconsistent result after apply" error when creating or updating participants with non-default roles. Applied the same fixes as organization members: saving desired role before API operations and preserving it after updates to avoid eventual consistency issues.
+
+- **Team Member Unnecessary Replacements** - Fixed issue where `seqera_team_member` resources were forcing unnecessary replacements when computed fields (role, avatar, name, etc.) changed externally. Added `UseStateForUnknown()` plan modifiers to all computed fields to prevent drift in read-only attributes from triggering resource recreation.
+
+- **Computed Field Plan Modifiers** - Added `UseStateForUnknown()` plan modifiers to all computed fields in `seqera_organization_member`, `seqera_team_member`, and `seqera_workspace_participant` resources to prevent Terraform from forcing replacements when only read-only fields change.
+
+- **Member Lookup Optimization** - Optimized all operations (Create, Read, Update) for `seqera_organization_member`, `seqera_team_member`, and `seqera_workspace_participant` resources to use ID-based filtering instead of email search when the ID is available. This eliminates unnecessary email lookup latency on every API call after initial creation, significantly improving performance and reducing API load. Email search is now only used during import operations when the ID is not yet known.
+
+- **Organization Member Role Validation** - Fixed role validation for `seqera_organization_member` resource. The valid roles are now correctly set to: owner, member, view. Previously incorrectly allowed "collaborator" which is not a valid organization role.
+
 
 # v0.30.0
 

--- a/docs/data-sources/credentials.md
+++ b/docs/data-sources/credentials.md
@@ -52,8 +52,8 @@ locals {
 
 # Use filtered credentials in resources
 resource "seqera_aws_batch_ce" "example" {
-  name         = "my-compute-env"
-  workspace_id = seqera_workspace.my_workspace.id
+  name           = "my-compute-env"
+  workspace_id   = seqera_workspace.my_workspace.id
   credentials_id = local.credentials["production-aws-account"].id
   # ... other configuration
 }

--- a/docs/resources/labels.md
+++ b/docs/resources/labels.md
@@ -76,11 +76,11 @@ resource "seqera_labels" "experimental" {
 # Use workspace resource references for dynamic workspace IDs.
 
 resource "seqera_workspace" "my_workspace" {
-  name          = "my-workspace"
-  org_id        = 123456
-  full_name     = "my-org/my-workspace"
-  visibility    = "PRIVATE"
-  description   = "Example workspace"
+  name        = "my-workspace"
+  org_id      = 123456
+  full_name   = "my-org/my-workspace"
+  visibility  = "PRIVATE"
+  description = "Example workspace"
 }
 
 resource "seqera_labels" "workspace_label" {

--- a/docs/resources/organization_member.md
+++ b/docs/resources/organization_member.md
@@ -7,7 +7,7 @@ description: |-
   Organization members are users who have access to an organization. Each member
   has a role that determines their permissions within the organization.
   Available roles:
-  owner: Full control over the organizationmember: Standard member access (default)collaborator: Limited collaboration access
+  owner: Full control over the organizationmember: Standard member access (default)
   Import format: org_id/email (e.g., "12345/user@example.com")
 ---
 
@@ -21,7 +21,6 @@ has a role that determines their permissions within the organization.
 Available roles:
 - owner: Full control over the organization
 - member: Standard member access (default)
-- collaborator: Limited collaboration access
 
 Import format: org_id/email (e.g., "12345/user@example.com")
 
@@ -37,7 +36,7 @@ Import format: org_id/email (e.g., "12345/user@example.com")
 
 ### Optional
 
-- `role` (String) Role of the member. Valid values: owner, member, collaborator. Defaults to "member".
+- `role` (String) Role of the member. Valid values: owner, member. Defaults to "member".
 
 ### Read-Only
 

--- a/docs/resources/orgs.md
+++ b/docs/resources/orgs.md
@@ -8,6 +8,19 @@ description: |-
   You can create multiple organizations, each of which can contain multiple workspaces
   with shared users and resources. This means you can customize and organize the use of
   resources while maintaining an access control layer for users associated with a workspace.
+  ~> Warning: Destroying an organization resource will permanently delete the organization
+  and all its associated resources including workspaces, members, teams, compute environments,
+  pipelines, and credentials. This action cannot be undone. Use Terraform lifecycle rules to
+  protect critical organizations from accidental deletion:
+  
+  resource "seqera_orgs" "production" {
+    name      = "production-org"
+    full_name = "Production Organization"
+  
+    lifecycle {
+      prevent_destroy = true
+    }
+  }
 ---
 
 # seqera_orgs (Resource)
@@ -18,6 +31,22 @@ Organizations are the top-level structure and contain workspaces, members, and t
 You can create multiple organizations, each of which can contain multiple workspaces
 with shared users and resources. This means you can customize and organize the use of
 resources while maintaining an access control layer for users associated with a workspace.
+
+~> **Warning:** Destroying an organization resource will permanently delete the organization
+and all its associated resources including workspaces, members, teams, compute environments,
+pipelines, and credentials. This action cannot be undone. Use Terraform lifecycle rules to
+protect critical organizations from accidental deletion:
+
+```terraform
+resource "seqera_orgs" "production" {
+  name      = "production-org"
+  full_name = "Production Organization"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
 
 ## Example Usage
 
@@ -34,6 +63,10 @@ resources while maintaining an access control layer for users associated with a 
 resource "seqera_orgs" "basic" {
   name      = "my-org"
   full_name = "My Organization"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Example 2: Organization with optional metadata
@@ -45,6 +78,10 @@ resource "seqera_orgs" "research" {
   description = "Organization for computational research"
   location    = "San Francisco, CA"
   website     = "https://www.research-lab.org"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 ```
 

--- a/docs/resources/studios.md
+++ b/docs/resources/studios.md
@@ -56,9 +56,9 @@ resource "seqera_studios" "jupyter_with_conda_heredoc" {
           - matplotlib==3.10.*
           - seaborn>=0.13
     EOT
-    cpu            = 2
-    memory         = 4096
-    lifespan_hours = 8
+    cpu               = 2
+    memory            = 4096
+    lifespan_hours    = 8
     # gpu defaults to 0 (disabled)
   }
   data_studio_tool_url = "public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.8"
@@ -111,9 +111,9 @@ resource "seqera_studios" "jupyter_with_conda_labels" {
     lifespan_hours = 8
     # gpu defaults to 0 (disabled)
   }
-  data_studio_tool_url  = "public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.8"
-  description           = "Jupyter studio for data analysis and visualization"
-  is_private            = true
+  data_studio_tool_url = "public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.8"
+  description          = "Jupyter studio for data analysis and visualization"
+  is_private           = true
   # Reference label IDs from seqera_labels resources
   label_ids = [
     seqera_labels.environment_prod.id,

--- a/examples/data-sources/seqera_credentials/data-source.tf
+++ b/examples/data-sources/seqera_credentials/data-source.tf
@@ -30,8 +30,8 @@ locals {
 
 # Use filtered credentials in resources
 resource "seqera_aws_batch_ce" "example" {
-  name         = "my-compute-env"
-  workspace_id = seqera_workspace.my_workspace.id
+  name           = "my-compute-env"
+  workspace_id   = seqera_workspace.my_workspace.id
   credentials_id = local.credentials["production-aws-account"].id
   # ... other configuration
 }

--- a/examples/resources/seqera_awsbatch_compute_env/resource.tf
+++ b/examples/resources/seqera_awsbatch_compute_env/resource.tf
@@ -94,13 +94,13 @@ resource "seqera_awsbatch_compute_env" "gpu" {
   region         = "us-east-1"
   work_directory = "s3://gpu-bucket/work"
 
-  forge_type      = "EC2"
-  gpu_enabled     = true
-  instance_types  = ["p3.2xlarge", "p3.8xlarge"]
-  max_cpus        = 256
-  ebs_block_size  = 200
-  enable_fusion   = true
-  enable_wave     = true
+  forge_type     = "EC2"
+  gpu_enabled    = true
+  instance_types = ["p3.2xlarge", "p3.8xlarge"]
+  max_cpus       = 256
+  ebs_block_size = 200
+  enable_fusion  = true
+  enable_wave    = true
 }
 
 # Example 5: Fargate head job configuration

--- a/examples/resources/seqera_bitbucket_credential/seqera_bitbucketcredential/resource.tf
+++ b/examples/resources/seqera_bitbucket_credential/seqera_bitbucketcredential/resource.tf
@@ -127,7 +127,7 @@ resource "seqera_pipeline" "from_bitbucket" {
   workspace_id = seqera_workspace.main.id
 
   # Reference the BitBucket repository
-  repository   = "https://bitbucket.org/myorg/my-repo"
+  repository = "https://bitbucket.org/myorg/my-repo"
 
   # Use the BitBucket credentials
   credentials_id = seqera_bitbucket_credential.pipeline_creds.credentials_id

--- a/examples/resources/seqera_labels/resource.tf
+++ b/examples/resources/seqera_labels/resource.tf
@@ -54,11 +54,11 @@ resource "seqera_labels" "experimental" {
 # Use workspace resource references for dynamic workspace IDs.
 
 resource "seqera_workspace" "my_workspace" {
-  name          = "my-workspace"
-  org_id        = 123456
-  full_name     = "my-org/my-workspace"
-  visibility    = "PRIVATE"
-  description   = "Example workspace"
+  name        = "my-workspace"
+  org_id      = 123456
+  full_name   = "my-org/my-workspace"
+  visibility  = "PRIVATE"
+  description = "Example workspace"
 }
 
 resource "seqera_labels" "workspace_label" {

--- a/examples/resources/seqera_orgs/resource.tf
+++ b/examples/resources/seqera_orgs/resource.tf
@@ -10,6 +10,10 @@
 resource "seqera_orgs" "basic" {
   name      = "my-org"
   full_name = "My Organization"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Example 2: Organization with optional metadata
@@ -21,4 +25,8 @@ resource "seqera_orgs" "research" {
   description = "Organization for computational research"
   location    = "San Francisco, CA"
   website     = "https://www.research-lab.org"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/examples/resources/seqera_studios/resource.tf
+++ b/examples/resources/seqera_studios/resource.tf
@@ -26,9 +26,9 @@ resource "seqera_studios" "jupyter_with_conda_heredoc" {
           - matplotlib==3.10.*
           - seaborn>=0.13
     EOT
-    cpu            = 2
-    memory         = 4096
-    lifespan_hours = 8
+    cpu               = 2
+    memory            = 4096
+    lifespan_hours    = 8
     # gpu defaults to 0 (disabled)
   }
   data_studio_tool_url = "public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.8"
@@ -81,9 +81,9 @@ resource "seqera_studios" "jupyter_with_conda_labels" {
     lifespan_hours = 8
     # gpu defaults to 0 (disabled)
   }
-  data_studio_tool_url  = "public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.8"
-  description           = "Jupyter studio for data analysis and visualization"
-  is_private            = true
+  data_studio_tool_url = "public.cr.seqera.io/platform/data-studio-jupyter:4.2.5-0.8"
+  description          = "Jupyter studio for data analysis and visualization"
+  is_private           = true
   # Reference label IDs from seqera_labels resources
   label_ids = [
     seqera_labels.environment_prod.id,

--- a/internal/provider/awscredential_resource.go
+++ b/internal/provider/awscredential_resource.go
@@ -203,43 +203,6 @@ func (r *AWSCredentialResource) Create(ctx context.Context, req resource.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeAWSCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeAWSCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeAWSCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeAWSCredentialsResponse(ctx, res1.DescribeAWSCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -337,43 +300,6 @@ func (r *AWSCredentialResource) Update(ctx context.Context, req resource.UpdateR
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeAWSCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeAWSCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeAWSCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeAWSCredentialsResponse(ctx, res1.DescribeAWSCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/azurecredential_resource.go
+++ b/internal/provider/azurecredential_resource.go
@@ -227,43 +227,6 @@ func (r *AzureCredentialResource) Create(ctx context.Context, req resource.Creat
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeAzureCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeAzureCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeAzureCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeAzureCredentialsResponse(ctx, res1.DescribeAzureCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -361,43 +324,6 @@ func (r *AzureCredentialResource) Update(ctx context.Context, req resource.Updat
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeAzureCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeAzureCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeAzureCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeAzureCredentialsResponse(ctx, res1.DescribeAzureCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/bitbucketcredential_resource.go
+++ b/internal/provider/bitbucketcredential_resource.go
@@ -190,43 +190,6 @@ func (r *BitbucketCredentialResource) Create(ctx context.Context, req resource.C
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeBitbucketCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeBitbucketCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeBitbucketCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeBitbucketCredentialsResponse(ctx, res1.DescribeBitbucketCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -324,43 +287,6 @@ func (r *BitbucketCredentialResource) Update(ctx context.Context, req resource.U
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeBitbucketCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeBitbucketCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeBitbucketCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeBitbucketCredentialsResponse(ctx, res1.DescribeBitbucketCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/codecommitcredential_resource.go
+++ b/internal/provider/codecommitcredential_resource.go
@@ -190,43 +190,6 @@ func (r *CodecommitCredentialResource) Create(ctx context.Context, req resource.
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeCodecommitCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeCodecommitCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeCodecommitCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeCodecommitCredentialsResponse(ctx, res1.DescribeCodecommitCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -324,43 +287,6 @@ func (r *CodecommitCredentialResource) Update(ctx context.Context, req resource.
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeCodecommitCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeCodecommitCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeCodecommitCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeCodecommitCredentialsResponse(ctx, res1.DescribeCodecommitCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/containerregistrycredential_resource.go
+++ b/internal/provider/containerregistrycredential_resource.go
@@ -189,43 +189,6 @@ func (r *ContainerRegistryCredentialResource) Create(ctx context.Context, req re
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeContainerRegistryCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeContainerRegistryCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeContainerRegistryCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeContainerRegistryCredentialsResponse(ctx, res1.DescribeContainerRegistryCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -323,43 +286,6 @@ func (r *ContainerRegistryCredentialResource) Update(ctx context.Context, req re
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeContainerRegistryCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeContainerRegistryCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeContainerRegistryCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeContainerRegistryCredentialsResponse(ctx, res1.DescribeContainerRegistryCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/giteacredential_resource.go
+++ b/internal/provider/giteacredential_resource.go
@@ -190,43 +190,6 @@ func (r *GiteaCredentialResource) Create(ctx context.Context, req resource.Creat
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeGiteaCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeGiteaCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeGiteaCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGiteaCredentialsResponse(ctx, res1.DescribeGiteaCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -324,43 +287,6 @@ func (r *GiteaCredentialResource) Update(ctx context.Context, req resource.Updat
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeGiteaCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeGiteaCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeGiteaCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGiteaCredentialsResponse(ctx, res1.DescribeGiteaCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/githubcredential_resource.go
+++ b/internal/provider/githubcredential_resource.go
@@ -190,43 +190,6 @@ func (r *GithubCredentialResource) Create(ctx context.Context, req resource.Crea
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeGithubCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeGithubCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeGithubCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGithubCredentialsResponse(ctx, res1.DescribeGithubCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -324,43 +287,6 @@ func (r *GithubCredentialResource) Update(ctx context.Context, req resource.Upda
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeGithubCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeGithubCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeGithubCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGithubCredentialsResponse(ctx, res1.DescribeGithubCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/gitlabcredential_resource.go
+++ b/internal/provider/gitlabcredential_resource.go
@@ -190,43 +190,6 @@ func (r *GitlabCredentialResource) Create(ctx context.Context, req resource.Crea
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeGitlabCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeGitlabCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeGitlabCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGitlabCredentialsResponse(ctx, res1.DescribeGitlabCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -324,43 +287,6 @@ func (r *GitlabCredentialResource) Update(ctx context.Context, req resource.Upda
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeGitlabCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeGitlabCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeGitlabCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGitlabCredentialsResponse(ctx, res1.DescribeGitlabCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/googlecredential_resource.go
+++ b/internal/provider/googlecredential_resource.go
@@ -179,43 +179,6 @@ func (r *GoogleCredentialResource) Create(ctx context.Context, req resource.Crea
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeGoogleCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeGoogleCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeGoogleCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGoogleCredentialsResponse(ctx, res1.DescribeGoogleCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -313,43 +276,6 @@ func (r *GoogleCredentialResource) Update(ctx context.Context, req resource.Upda
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeGoogleCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeGoogleCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeGoogleCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGoogleCredentialsResponse(ctx, res1.DescribeGoogleCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/kubernetescredential_resource.go
+++ b/internal/provider/kubernetescredential_resource.go
@@ -191,43 +191,6 @@ func (r *KubernetesCredentialResource) Create(ctx context.Context, req resource.
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeKubernetesCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeKubernetesCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeKubernetesCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeKubernetesCredentialsResponse(ctx, res1.DescribeKubernetesCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -325,43 +288,6 @@ func (r *KubernetesCredentialResource) Update(ctx context.Context, req resource.
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeKubernetesCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeKubernetesCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeKubernetesCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeKubernetesCredentialsResponse(ctx, res1.DescribeKubernetesCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/orgs_resource.go
+++ b/internal/provider/orgs_resource.go
@@ -49,7 +49,7 @@ func (r *OrgsResource) Metadata(ctx context.Context, req resource.MetadataReques
 
 func (r *OrgsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage your organization in Seqera platform using this resource.\n\nOrganizations are the top-level structure and contain workspaces, members, and teams.\nYou can create multiple organizations, each of which can contain multiple workspaces\nwith shared users and resources. This means you can customize and organize the use of\nresources while maintaining an access control layer for users associated with a workspace.\n",
+		MarkdownDescription: "Manage your organization in Seqera platform using this resource.\n\nOrganizations are the top-level structure and contain workspaces, members, and teams.\nYou can create multiple organizations, each of which can contain multiple workspaces\nwith shared users and resources. This means you can customize and organize the use of\nresources while maintaining an access control layer for users associated with a workspace.\n\n~> **Warning:** Destroying an organization resource will permanently delete the organization\nand all its associated resources including workspaces, members, teams, compute environments,\npipelines, and credentials. This action cannot be undone. Use Terraform lifecycle rules to\nprotect critical organizations from accidental deletion:\n\n```terraform\nresource \"seqera_orgs\" \"production\" {\n  name      = \"production-org\"\n  full_name = \"Production Organization\"\n\n  lifecycle {\n    prevent_destroy = true\n  }\n}\n```\n",
 		Attributes: map[string]schema.Attribute{
 			"description": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/sshcredential_resource.go
+++ b/internal/provider/sshcredential_resource.go
@@ -185,43 +185,6 @@ func (r *SSHCredentialResource) Create(ctx context.Context, req resource.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeSSHCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeSSHCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeSSHCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeSSHCredentialsResponse(ctx, res1.DescribeSSHCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -319,43 +282,6 @@ func (r *SSHCredentialResource) Update(ctx context.Context, req resource.UpdateR
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeSSHCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeSSHCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeSSHCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeSSHCredentialsResponse(ctx, res1.DescribeSSHCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/studios_resource.go
+++ b/internal/provider/studios_resource.go
@@ -335,46 +335,6 @@ func (r *StudiosResource) Create(ctx context.Context, req resource.CreateRequest
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeDataStudioRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Studios.DescribeDataStudio(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	switch res1.StatusCode {
-	case 200, 202:
-		break
-	default:
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DataStudioDto != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDataStudioDto(ctx, res1.DataStudioDto)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/teams_resource.go
+++ b/internal/provider/teams_resource.go
@@ -172,43 +172,6 @@ func (r *TeamsResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeOrganizationTeamRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Teams.DescribeOrganizationTeam(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeTeamResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeTeamResponse(ctx, res1.DescribeTeamResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/toweragentcredential_resource.go
+++ b/internal/provider/toweragentcredential_resource.go
@@ -186,43 +186,6 @@ func (r *TowerAgentCredentialResource) Create(ctx context.Context, req resource.
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	request1, request1Diags := data.ToOperationsDescribeTowerAgentCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeTowerAgentCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeTowerAgentCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeTowerAgentCredentialsResponse(ctx, res1.DescribeTowerAgentCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -320,43 +283,6 @@ func (r *TowerAgentCredentialResource) Update(ctx context.Context, req resource.
 	}
 	if res.StatusCode != 204 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	request1, request1Diags := data.ToOperationsDescribeTowerAgentCredentialsRequest(ctx)
-	resp.Diagnostics.Append(request1Diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res1, err := r.client.Credentials.DescribeTowerAgentCredentials(ctx, *request1)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res1 != nil && res1.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res1.RawResponse))
-		}
-		return
-	}
-	if res1 == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res1))
-		return
-	}
-	if res1.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res1.StatusCode), debugResponse(res1.RawResponse))
-		return
-	}
-	if !(res1.DescribeTowerAgentCredentialsResponse != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res1.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromSharedDescribeTowerAgentCredentialsResponse(ctx, res1.DescribeTowerAgentCredentialsResponse)...)
-
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.102.0 and generator version 2.799.0
+// Generated from OpenAPI doc version 1.102.0 and generator version 2.801.2
 
 import (
 	"context"
@@ -171,7 +171,7 @@ func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
 		SDKVersion: "0.30.1",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.30.1 2.799.0 1.102.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.30.1 2.801.2 1.102.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/overlays/orgs.yaml
+++ b/overlays/orgs.yaml
@@ -49,6 +49,23 @@ actions:
         with shared users and resources. This means you can customize and organize the use of
         resources while maintaining an access control layer for users associated with a workspace.
 
+        ~> **Warning:** Destroying an organization resource will permanently delete the organization
+        and all its associated resources including workspaces, members, teams, compute environments,
+        pipelines, and credentials. This action cannot be undone. Use Terraform lifecycle rules to
+        protect critical organizations from accidental deletion:
+
+        ```terraform
+        resource "seqera_orgs" "production" {
+          name      = "production-org"
+          full_name = "Production Organization"
+
+          lifecycle {
+            prevent_destroy = true
+          }
+        }
+        ```
+
+
   - target: $["components"]["schemas"]["OrganizationDbDto"]
     update:
       x-speakeasy-entity: Orgs


### PR DESCRIPTION
The following addresses a data-race issue between the email based lookup and id based lookup for organization roles for the member resources.

Also the following now prevents user recreation where the role is updated , without having to add & remove a user from an organization. 