### PR TITLE
feat: Add org-member pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.30.2
+
+ENHANCEMENTS:
+
+- **Refactored Member and Participant Resources** - Updated `seqera_organization_member`, `seqera_team_member`, and `seqera_workspace_participant` resources to use the new `PaginatedSearch` helper. This refactoring ensures consistent pagination behavior across all membership resources ensuring that in large organizations all resources work as intended.
+
+
 # v0.30.1
 
 FIX:

--- a/internal/seqera/common/utils.go
+++ b/internal/seqera/common/utils.go
@@ -2,6 +2,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -27,4 +28,61 @@ func DebugResponse(response *http.Response) string {
 		}
 	}
 	return fmt.Sprintf("**Request**:\n%s\n**Response**:\n%s", string(dumpReq), string(dumpRes))
+}
+
+// PaginatedSearch performs a paginated search through API results.
+// It handles pagination automatically, calling fetchPage for each page until the item is found
+// or all pages have been searched.
+//
+// Parameters:
+//   - ctx: Context for the search
+//   - fetchPage: Function that fetches a single page of results given max and offset parameters.
+//     Returns (items, totalSize, error). If totalSize is unknown, return 0.
+//   - matchItem: Function that returns true if the item matches the search criteria
+//
+// Returns the first matching item or nil if not found.
+func PaginatedSearch[T any](
+	ctx context.Context,
+	fetchPage func(ctx context.Context, max, offset int) (items []T, totalSize int64, err error),
+	matchItem func(item *T) bool,
+) (*T, error) {
+	pageSize := 100
+	offset := 0
+
+	for {
+		items, totalSize, err := fetchPage(ctx, pageSize, offset)
+		if err != nil {
+			return nil, err
+		}
+
+		// Search for matching item in current page
+		for i := range items {
+			if matchItem(&items[i]) {
+				return &items[i], nil
+			}
+		}
+
+		// Check pagination stopping conditions
+		itemsInPage := len(items)
+
+		// Stop if no items in this page
+		if itemsInPage == 0 {
+			break
+		}
+
+		// Stop if we've fetched all items based on totalSize
+		if totalSize > 0 && int64(offset)+int64(itemsInPage) >= totalSize {
+			break
+		}
+
+		// Stop if we got a partial page (less than requested) - indicates last page
+		if itemsInPage < pageSize {
+			break
+		}
+
+		// Move to next page
+		offset += pageSize
+	}
+
+	return nil, nil
 }

--- a/internal/seqera/team_member/resource.go
+++ b/internal/seqera/team_member/resource.go
@@ -240,8 +240,14 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	// Use empty email since we have member_id from state - triggers ID-based lookup optimization
-	member, err := r.findMember(ctx, data.OrgID.ValueInt64(), data.TeamID.ValueInt64(), "", data.MemberID.ValueInt64())
+	// Pass email from state for import case (when member_id is not yet known)
+	// Once we have member_id, pass empty string to optimize the API call
+	email := ""
+	if data.MemberID.IsNull() || data.MemberID.IsUnknown() {
+		email = data.Email.ValueString()
+	}
+
+	member, err := r.findMember(ctx, data.OrgID.ValueInt64(), data.TeamID.ValueInt64(), email, data.MemberID.ValueInt64())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to read team member", err.Error())
 		return
@@ -316,33 +322,43 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 }
 
 // findOrgMember looks up an organization member by member_id.
-// Note: The API does not support pagination. Large organizations may not return all members.
+// This function handles pagination to ensure all members are searched, even in large organizations.
 func (r *Resource) findOrgMember(ctx context.Context, orgID, memberID int64) (*shared.MemberDbDto, error) {
-	listRes, err := r.client.Orgs.ListOrganizationMembers(ctx, operations.ListOrganizationMembersRequest{
-		OrgID: orgID,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if listRes.StatusCode != 200 {
-		return nil, fmt.Errorf("unexpected status code %d listing organization members", listRes.StatusCode)
-	}
-	if listRes.ListMembersResponse == nil {
-		return nil, fmt.Errorf("empty response listing organization members")
-	}
+	// Use common pagination helper
+	return common.PaginatedSearch(ctx,
+		// Fetch page function
+		func(ctx context.Context, max, offset int) ([]shared.MemberDbDto, int64, error) {
+			listRes, err := r.client.Orgs.ListOrganizationMembers(ctx, operations.ListOrganizationMembersRequest{
+				OrgID:  orgID,
+				Max:    &max,
+				Offset: &offset,
+			})
+			if err != nil {
+				return nil, 0, err
+			}
+			if listRes.StatusCode != 200 {
+				return nil, 0, fmt.Errorf("unexpected status code %d listing organization members", listRes.StatusCode)
+			}
+			if listRes.ListMembersResponse == nil {
+				return nil, 0, fmt.Errorf("empty response listing organization members")
+			}
 
-	for i := range listRes.ListMembersResponse.Members {
-		m := &listRes.ListMembersResponse.Members[i]
-		if m.MemberID != nil && *m.MemberID == memberID {
-			return m, nil
-		}
-	}
-	return nil, nil
+			totalSize := int64(0)
+			if listRes.ListMembersResponse.TotalSize != nil {
+				totalSize = *listRes.ListMembersResponse.TotalSize
+			}
+			return listRes.ListMembersResponse.Members, totalSize, nil
+		},
+		// Match function
+		func(m *shared.MemberDbDto) bool {
+			return m.MemberID != nil && *m.MemberID == memberID
+		},
+	)
 }
 
 // findMember searches for a team member by email or member_id.
 // When member_id is provided (non-zero), it searches without email filter for better performance.
-// Note: The API does not support pagination. Large teams may not return all members.
+// This function handles pagination to ensure all members are searched, even in large teams.
 func (r *Resource) findMember(ctx context.Context, orgID, teamID int64, email string, memberID int64) (*shared.MemberDbDto, error) {
 	// If we have a member_id, don't use email search - just get all members and filter by ID
 	// This avoids email lookup latency and is more efficient
@@ -356,32 +372,45 @@ func (r *Resource) findMember(ctx context.Context, orgID, teamID int64, email st
 		searchParam = &email
 	}
 
-	listRes, err := r.client.Teams.ListOrganizationTeamMembers(ctx, operations.ListOrganizationTeamMembersRequest{
-		OrgID:  orgID,
-		TeamID: teamID,
-		Search: searchParam,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if listRes.StatusCode != 200 {
-		return nil, fmt.Errorf("unexpected status code %d listing team members", listRes.StatusCode)
-	}
-	if listRes.ListMembersResponse == nil {
-		return nil, fmt.Errorf("empty response listing team members")
-	}
+	// Use common pagination helper
+	return common.PaginatedSearch(ctx,
+		// Fetch page function
+		func(ctx context.Context, max, offset int) ([]shared.MemberDbDto, int64, error) {
+			listRes, err := r.client.Teams.ListOrganizationTeamMembers(ctx, operations.ListOrganizationTeamMembersRequest{
+				OrgID:  orgID,
+				TeamID: teamID,
+				Search: searchParam,
+				Max:    &max,
+				Offset: &offset,
+			})
+			if err != nil {
+				return nil, 0, err
+			}
+			if listRes.StatusCode != 200 {
+				return nil, 0, fmt.Errorf("unexpected status code %d listing team members", listRes.StatusCode)
+			}
+			if listRes.ListMembersResponse == nil {
+				return nil, 0, fmt.Errorf("empty response listing team members")
+			}
 
-	for i := range listRes.ListMembersResponse.Members {
-		m := &listRes.ListMembersResponse.Members[i]
-		// Prefer matching by member_id if available, fallback to email
-		if memberID > 0 && m.MemberID != nil && *m.MemberID == memberID {
-			return m, nil
-		}
-		if memberID == 0 && m.Email != nil && *m.Email == email {
-			return m, nil
-		}
-	}
-	return nil, nil
+			totalSize := int64(0)
+			if listRes.ListMembersResponse.TotalSize != nil {
+				totalSize = *listRes.ListMembersResponse.TotalSize
+			}
+			return listRes.ListMembersResponse.Members, totalSize, nil
+		},
+		// Match function
+		func(m *shared.MemberDbDto) bool {
+			// Prefer matching by member_id if available, fallback to email
+			if memberID > 0 && m.MemberID != nil && *m.MemberID == memberID {
+				return true
+			}
+			if memberID == 0 && m.Email != nil && *m.Email == email {
+				return true
+			}
+			return false
+		},
+	)
 }
 
 // refreshFromMember updates the ResourceModel from API response.


### PR DESCRIPTION
## Summary

The following adds pagination to the API for member resources to help handle larger organizations under the SDK. 

## Testing

The following was tested by 

Creating 50 Org members , 20 teams and then adding all 50 members to each of the 20 teams then testing subsequent plans, a basic representation is below. 

This previously would result in inconsistent state and result in some team members being re-added to the org resulting in apply failures. 

```
resource "seqera_organization_member" "example" {
    count  = 50
  org_id = seqera_orgs.test_org.org_id
  email  = "exampe-user-${count.index + 1}@example.io"
  role =  "member"
}


resource "seqera_teams" "example" { #Dislike this it should be seqera_team
  count  = 20
  org_id = seqera_orgs.test_org.org_id
  name   = "test_team_${count.index + 1}"
}

locals {
  team_member_combinations = {
    for pair in setproduct(range(20), range(50)) :
    "${pair[0]}-${pair[1]}" => {
      team_index   = pair[0]
      member_index = pair[1]
    }
  }
}

resource "seqera_team_member" "all_members" {
  for_each = local.team_member_combinations

  org_id    = seqera_teams.example[each.value.team_index].org_id
  team_id   = seqera_teams.example[each.value.team_index].team_id
  member_id = seqera_organization_member.example[each.value.member_index].member_id
}
```