### PR TITLE
fix(compute-envs): accept unknown list values across AWS Cloud / GCP Batch / Azure Batch configs

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 3624fa8fdd73e50a486be4704b356329
+  docChecksum: e51036b1043f54cbdc774b40538f0a59
   docVersion: 1.147.0
   speakeasyVersion: 1.761.9
   generationVersion: 2.881.4
@@ -456,9 +456,9 @@ trackedFiles:
     last_write_checksum: sha1:bf4dcb70e6072016cc6fb69e63532f19a62021b1
     pristine_git_object: fb79abddd43fc8a362ddaff379637c1def78665a
   internal/provider/azurebatchce_resource.go:
-    last_write_checksum: sha1:71237cc36136fb8029790f121dace98fc09bb60b
+    last_write_checksum: sha1:9492e6f02cfcd0a2b9a7115dd520886dff02276e
   internal/provider/azurebatchce_resource_sdk.go:
-    last_write_checksum: sha1:bec22132526cea70f8a0fc2ad3e1651dbf7a882f
+    last_write_checksum: sha1:61f525dff445b7f5b0077317634e9cd9b06f20e4
   internal/provider/azurecloudce_resource.go:
     last_write_checksum: sha1:cadf859e9d6be0b68b9c381a4772c332bb7ac8a6
   internal/provider/azurecloudce_resource_sdk.go:
@@ -489,11 +489,11 @@ trackedFiles:
     pristine_git_object: 0c1b43d5db49b023cf3c7408c198a4d66c795d8a
   internal/provider/computeenv_resource.go:
     id: f4162f219efd
-    last_write_checksum: sha1:1b1f21fa91f6781ba0d1b049b4baadf5b177fd8c
+    last_write_checksum: sha1:512843cddc3d2a9ff545aa462edc202b3a19253c
     pristine_git_object: d5550a0a3bc980d281c55531d71458e7e4968b48
   internal/provider/computeenv_resource_sdk.go:
     id: 1e29eea44332
-    last_write_checksum: sha1:3bb84f419b4715df49077586e2179ef36f9857fc
+    last_write_checksum: sha1:8b13a606852130ab4db352412a3766477434ce66
     pristine_git_object: 2e933070714e8aa8d9ab83f2e1b81abd6f262ade
   internal/provider/containerregistrycredential_resource.go:
     id: f0a18857f2ea
@@ -544,9 +544,9 @@ trackedFiles:
     last_write_checksum: sha1:2518480b1bf5983bf0d0fec9a47e654d138db587
     pristine_git_object: d3d10cadef9504a6a38441129ada6ccaf494496e
   internal/provider/gcpbatchce_resource.go:
-    last_write_checksum: sha1:d3faa04a9a0b9872af6d92083c64402d98cab752
+    last_write_checksum: sha1:62fbb0b6ea8034dc4af3b2fec6e11c4d42a1588f
   internal/provider/gcpbatchce_resource_sdk.go:
-    last_write_checksum: sha1:84c9032769575dcc405ecf0071b92585a11813e8
+    last_write_checksum: sha1:88b02e51dd70df6ce5f0e68a7e97ed45b781c584
   internal/provider/gcpcloudce_resource.go:
     last_write_checksum: sha1:fb9094ec5646da465fdd23343182e482e98d4b84
   internal/provider/gcpcloudce_resource_sdk.go:
@@ -777,7 +777,7 @@ trackedFiles:
     pristine_git_object: 7db3202471193f93826bdf67c90bd74b9dab4c88
   internal/provider/types/aws_cloud_configuration.go:
     id: db2f67953459
-    last_write_checksum: sha1:3f2033804e687d4a5cdeb84f535043bbe2b599df
+    last_write_checksum: sha1:06c0513a5c953407e31647c6f532b0e9bb73e82d
     pristine_git_object: 62842b6d7f36077a795bcfce869fcaff8d351e2d
   internal/provider/types/aws_code_commit_credentials.go:
     id: 78d63242bf3a
@@ -791,7 +791,7 @@ trackedFiles:
     last_write_checksum: sha1:8bdfd8657e00d9cd09490698ec5fbaad14a71637
   internal/provider/types/az_batch_forge_config.go:
     id: 43a33efe791e
-    last_write_checksum: sha1:57da81d424ecf867f4869a24a89bce791006bbcb
+    last_write_checksum: sha1:673d1d80d1b6a56bbbda1827521ec89b59483708
     pristine_git_object: 12c7bdfaa94860c8c611890dff13fd0635affd05
   internal/provider/types/az_batch_pool_config.go:
     last_write_checksum: sha1:59ae1cf1de55768255d7c0b7f15c8b3b1abddebc
@@ -894,10 +894,10 @@ trackedFiles:
     last_write_checksum: sha1:ff6b49342a436ca0e535a9fe804eaa7aefb4d522
     pristine_git_object: fee4f8219d9a79b52671130f3318f6aabdf28f25
   internal/provider/types/google_batch_config.go:
-    last_write_checksum: sha1:56c4a951881cb9605d12e76a89837d635e4872fe
+    last_write_checksum: sha1:2ea12c8796c60aef5282c4abaf10b92260fa1873
   internal/provider/types/google_batch_service_configuration.go:
     id: 5a581f1c4635
-    last_write_checksum: sha1:6d20fef7f4517576e8ee87b7b6885bb911e0cf1a
+    last_write_checksum: sha1:9468b518adc8e95315d52acc6d5df43935d287c3
     pristine_git_object: 3b1d18b5efc8fd5120b4d3f2f7a9a56feafa342c
   internal/provider/types/google_cloud_config.go:
     last_write_checksum: sha1:762ba11eb9cb01e6fefbf437652c73efaae0b69d
@@ -2365,7 +2365,7 @@ trackedFiles:
     last_write_checksum: sha1:9941a555d64a1555ebb2ecf32597536d924883a0
   internal/sdk/models/shared/azbatchforgeconfig.go:
     id: d13b3a409e31
-    last_write_checksum: sha1:b3c7d07e4a3e48b7244427a0322227d448e53077
+    last_write_checksum: sha1:6962a8e3f37043fd959fc4a82024400f66150d78
     pristine_git_object: dc5d7127f390fe2d4b560e69d3e2ac5ae3e97911
   internal/sdk/models/shared/azbatchplatformmetainfo.go:
     id: 26da3f95b1e5
@@ -2412,7 +2412,7 @@ trackedFiles:
     last_write_checksum: sha1:3441fcab6ab8f43df13f9d3cd4fdfc3f037c126f
     pristine_git_object: 168da50a9909ad4639d68c4ef0cb63bf647d949b
   internal/sdk/models/shared/computeconfiginput.go:
-    last_write_checksum: sha1:97759be68bd80a5e37b7547668ce7ae8ff85c370
+    last_write_checksum: sha1:47ec62a5e0da4aa7c6544fa1214374b37367de73
   internal/sdk/models/shared/computeenvcomputeconfiginput.go:
     last_write_checksum: sha1:6b0b8da8388d953401e7c6899c044e26e68aaedc
   internal/sdk/models/shared/computeenvqueryattribute.go:
@@ -3138,7 +3138,7 @@ trackedFiles:
     last_write_checksum: sha1:3bbceb36b0f1a5ae35c59650dd1458501167441f
     pristine_git_object: d93e4f9224bfcf068b716b3e11f95edf7cf26158
   internal/sdk/models/shared/googlebatchconfig.go:
-    last_write_checksum: sha1:1778bcb2db53cb0d6622e26bf681bf2cf13c76b2
+    last_write_checksum: sha1:fb5e0fab2a40048b3688de2f11a6efe8795c1afa
   internal/sdk/models/shared/googlecloudconfig.go:
     last_write_checksum: sha1:8faa0b55d4302dee0e8cf3fc6137b906224249cd
   internal/sdk/models/shared/googlecredential.go:

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -13644,6 +13644,11 @@ components:
             List of additional S3 bucket names that compute jobs are allowed to access.
             The work directory bucket is automatically included.
           x-speakeasy-param-force-new: true
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+            schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+            valueType: basetypes.ListValue
         arm64Enabled:
           type: boolean
           description: |
@@ -13752,6 +13757,11 @@ components:
             Security groups must allow necessary network access.
           example: ["sg-12345678"]
           x-speakeasy-param-force-new: true
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+            schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+            valueType: basetypes.ListValue
         subnetId:
           type: string
           description: |
@@ -13959,6 +13969,14 @@ components:
           type: array
           items:
             type: string
+          description: |
+            List of Azure Container Registry IDs whose images compute jobs may pull.
+          x-speakeasy-param-force-new: true
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+            schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+            valueType: basetypes.ListValue
         disposeOnDeletion:
           type: boolean
         dualPoolConfig:
@@ -17030,6 +17048,14 @@ components:
           type: array
           items:
             type: string
+          description: |
+            List of Google Cloud machine types compute jobs may use.
+          x-speakeasy-param-force-new: true
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+            schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+            valueType: basetypes.ListValue
         copyImage:
           type: string
           description: |
@@ -17120,6 +17146,14 @@ components:
           type: array
           items:
             type: string
+          description: |
+            Network tags applied to compute instances for VPC firewall rule targeting.
+          x-speakeasy-param-force-new: true
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+            schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+            valueType: basetypes.ListValue
         nextflowConfig:
           type: string
         nfsMount:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.761.9
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:2e8a0762e3e04f5cd154d25613eee21ad4cfbc24b1b1889d04d8c42e770fdb37
-        sourceBlobDigest: sha256:79b97356ed6c125bb1a834e90510ed51077fe079c9e4393f1f8c239c6c3c7146
+        sourceRevisionDigest: sha256:e8c26285b3224283043ae7537b97d53b59634658af74dfced55a2d47404fc5ad
+        sourceBlobDigest: sha256:b2215866dd6a40284d98bd4362c8388448343bd234a74f71402b5d3be0b4a5cf
         tags:
             - latest
             - 1.147.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:2e8a0762e3e04f5cd154d25613eee21ad4cfbc24b1b1889d04d8c42e770fdb37
-        sourceBlobDigest: sha256:79b97356ed6c125bb1a834e90510ed51077fe079c9e4393f1f8c239c6c3c7146
+        sourceRevisionDigest: sha256:e8c26285b3224283043ae7537b97d53b59634658af74dfced55a2d47404fc5ad
+        sourceBlobDigest: sha256:b2215866dd6a40284d98bd4362c8388448343bd234a74f71402b5d3be0b4a5cf
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ DEPRECATIONS:
 
 BUGFIXES:
 
+- Extended the unknown-value list-type fix from #186 to the remaining list-of-string fields across the AWS Cloud, Google Cloud Batch, and Azure Batch compute configurations: `AwsCloudConfig.allow_buckets`, `AwsCloudConfig.security_groups`, `GoogleBatchConfig.compute_jobs_machine_type`, `GoogleBatchConfig.network_tags`, and `AzBatchForgeConfig.container_reg_ids`. These fields can now accept unknown collections from data sources (e.g. `network_tags = data.google_compute_network.x.tags`) without failing at plan time.
+
 - [#186](https://github.com/seqeralabs/terraform-provider-seqera/issues/186) - Fixed `forge.subnets`, `security_groups`, `allow_buckets`, and `instance_types` so they accept unknown collections from data sources (e.g. `subnets = data.aws_subnets.public.ids`). Previously these failed at plan time with `Received unknown value, however the target type cannot handle unknown values`. Affects all three resources that share `ForgeConfig`: `seqera_aws_compute_env`, `seqera_aws_batch_ce`, and the legacy `seqera_compute_env`.
 
 - [#159](https://github.com/seqeralabs/terraform-provider-seqera/issues/159) - Fixed EBS field descriptions in AWS compute environments. `ebs_block_size` was incorrectly described as "Size of EBS root volume" when it is actually the auto-expandable block size. `ebs_boot_size` (the actual root/boot volume size) had no description at all.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ terraform {
   required_providers {
     seqera = {
       source  = "seqeralabs/seqera"
-      version = "0.40.1"
+      version = "0.40.0-RC2"
     }
   }
 }

--- a/docs/resources/azure_batch_ce.md
+++ b/docs/resources/azure_batch_ce.md
@@ -182,7 +182,7 @@ Default: false; Requires replacement if changed.
 Optional:
 
 - `auto_scale` (Boolean) Requires replacement if changed.
-- `container_reg_ids` (List of String) Requires replacement if changed.
+- `container_reg_ids` (List of String) List of Azure Container Registry IDs whose images compute jobs may pull. Requires replacement if changed.
 - `dispose_on_deletion` (Boolean) Requires replacement if changed.
 - `dual_pool_config` (Boolean) Requires replacement if changed.
 - `head_pool` (Attributes) Head pool configuration for dual pool mode. Requires replacement if changed. (see [below for nested schema](#nestedatt--config--forge--head_pool))

--- a/docs/resources/compute_env.md
+++ b/docs/resources/compute_env.md
@@ -531,7 +531,7 @@ Default: false; Requires replacement if changed.
 Optional:
 
 - `auto_scale` (Boolean) Requires replacement if changed.
-- `container_reg_ids` (List of String) Requires replacement if changed.
+- `container_reg_ids` (List of String) List of Azure Container Registry IDs whose images compute jobs may pull. Requires replacement if changed.
 - `dispose_on_deletion` (Boolean) Requires replacement if changed.
 - `dual_pool_config` (Boolean) Requires replacement if changed.
 - `head_pool` (Attributes) Head pool configuration for dual pool mode. Requires replacement if changed. (see [below for nested schema](#nestedatt--compute_env--config--azure_batch--forge--head_pool))
@@ -750,7 +750,7 @@ Optional:
 - `compute_jobs_instance_template` (String) Google Cloud instance template name or self-link for compute job VMs.
 Overrides other VM configuration settings for compute jobs.
 Requires replacement if changed.
-- `compute_jobs_machine_type` (List of String) Requires replacement if changed.
+- `compute_jobs_machine_type` (List of String) List of Google Cloud machine types compute jobs may use. Requires replacement if changed.
 - `copy_image` (String) Container image used for file staging (copying data to/from Cloud Storage). Requires replacement if changed.
 - `cpu_platform` (String) Minimum CPU platform for compute instances (e.g., "Intel Cascade Lake").
 See Google Cloud documentation for available CPU platforms per region.
@@ -783,7 +783,7 @@ Requires replacement if changed.
 Supports patterns like "c2-*" to allow any machine in a family.
 Requires replacement if changed.
 - `network` (String) Google Cloud VPC network name or self-link for compute instances. Requires replacement if changed.
-- `network_tags` (List of String) Requires replacement if changed.
+- `network_tags` (List of String) Network tags applied to compute instances for VPC firewall rule targeting. Requires replacement if changed.
 - `nextflow_config` (String) Nextflow configuration settings and parameters. Requires replacement if changed.
 - `nfs_mount` (String) Local mount path for the NFS file system on compute instances. Requires replacement if changed.
 - `nfs_target` (String) NFS server hostname or IP address for shared file system access.

--- a/docs/resources/gcp_batch_ce.md
+++ b/docs/resources/gcp_batch_ce.md
@@ -123,7 +123,7 @@ Optional:
 - `compute_jobs_instance_template` (String) Google Cloud instance template name or self-link for compute job VMs.
 Overrides other VM configuration settings for compute jobs.
 Requires replacement if changed.
-- `compute_jobs_machine_type` (List of String) Requires replacement if changed.
+- `compute_jobs_machine_type` (List of String) List of Google Cloud machine types compute jobs may use. Requires replacement if changed.
 - `copy_image` (String) Container image used for file staging (copying data to/from Cloud Storage). Requires replacement if changed.
 - `cpu_platform` (String) Minimum CPU platform for compute instances (e.g., "Intel Cascade Lake").
 See Google Cloud documentation for available CPU platforms per region.
@@ -155,7 +155,7 @@ Requires replacement if changed.
 Supports patterns like "c2-*" to allow any machine in a family.
 Requires replacement if changed.
 - `network` (String) Google Cloud VPC network name or self-link for compute instances. Requires replacement if changed.
-- `network_tags` (List of String) Requires replacement if changed.
+- `network_tags` (List of String) Network tags applied to compute instances for VPC firewall rule targeting. Requires replacement if changed.
 - `nextflow_config` (String) Requires replacement if changed.
 - `nfs_mount` (String) Local mount path for the NFS file system on compute instances. Requires replacement if changed.
 - `nfs_target` (String) NFS server hostname or IP address for shared file system access.

--- a/internal/provider/azurebatchce_resource.go
+++ b/internal/provider/azurebatchce_resource.go
@@ -243,14 +243,15 @@ func (r *AzureBatchCEResource) Schema(ctx context.Context, req resource.SchemaRe
 								Description: `Requires replacement if changed.`,
 							},
 							"container_reg_ids": schema.ListAttribute{
-								Computed: true,
-								Optional: true,
+								CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
+								Computed:   true,
+								Optional:   true,
 								PlanModifiers: []planmodifier.List{
 									listplanmodifier.RequiresReplaceIfConfigured(),
 									speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
 								},
 								ElementType: types.StringType,
-								Description: `Requires replacement if changed.`,
+								Description: `List of Azure Container Registry IDs whose images compute jobs may pull. Requires replacement if changed.`,
 							},
 							"dispose_on_deletion": schema.BoolAttribute{
 								Computed: true,

--- a/internal/provider/azurebatchce_resource_sdk.go
+++ b/internal/provider/azurebatchce_resource_sdk.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/provider/typeconvert"
 	tfTypes "github.com/seqeralabs/terraform-provider-seqera/internal/provider/types"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/models/operations"
@@ -46,10 +47,11 @@ func (r *AzureBatchCEResourceModel) RefreshFromSharedAzureBatchCEComputeConfig(c
 		} else {
 			r.Config.Forge = &tfTypes.AzBatchForgeConfig{}
 			r.Config.Forge.AutoScale = types.BoolPointerValue(resp.Config.Forge.AutoScale)
-			r.Config.Forge.ContainerRegIds = make([]types.String, 0, len(resp.Config.Forge.ContainerRegIds))
-			for _, v := range resp.Config.Forge.ContainerRegIds {
-				r.Config.Forge.ContainerRegIds = append(r.Config.Forge.ContainerRegIds, types.StringValue(v))
-			}
+			containerRegIdsValue, containerRegIdsDiags := types.ListValueFrom(ctx, types.StringType, resp.Config.Forge.ContainerRegIds)
+			diags.Append(containerRegIdsDiags...)
+			containerRegIdsValuable, containerRegIdsDiags := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, containerRegIdsValue)
+			diags.Append(containerRegIdsDiags...)
+			r.Config.Forge.ContainerRegIds, _ = containerRegIdsValuable.(basetypes.ListValue)
 			r.Config.Forge.DisposeOnDeletion = types.BoolPointerValue(resp.Config.Forge.DisposeOnDeletion)
 			r.Config.Forge.DualPoolConfig = types.BoolPointerValue(resp.Config.Forge.DualPoolConfig)
 			if resp.Config.Forge.HeadPool == nil {
@@ -311,9 +313,9 @@ func (r *AzureBatchCEResourceModel) ToSharedAzureBatchCEComputeConfigInput(ctx c
 		} else {
 			autoScale = nil
 		}
-		containerRegIds := make([]string, 0, len(r.Config.Forge.ContainerRegIds))
-		for containerRegIdsIndex := range r.Config.Forge.ContainerRegIds {
-			containerRegIds = append(containerRegIds, r.Config.Forge.ContainerRegIds[containerRegIdsIndex].ValueString())
+		var containerRegIds []string
+		if !r.Config.Forge.ContainerRegIds.IsUnknown() && !r.Config.Forge.ContainerRegIds.IsNull() {
+			diags.Append(r.Config.Forge.ContainerRegIds.ElementsAs(ctx, &containerRegIds, true)...)
 		}
 		disposeOnDeletion := new(bool)
 		if !r.Config.Forge.DisposeOnDeletion.IsUnknown() && !r.Config.Forge.DisposeOnDeletion.IsNull() {

--- a/internal/provider/computeenv_resource.go
+++ b/internal/provider/computeenv_resource.go
@@ -1022,8 +1022,9 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 								},
 								Attributes: map[string]schema.Attribute{
 									"allow_buckets": schema.ListAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.List{
 											listplanmodifier.RequiresReplaceIfConfigured(),
 										},
@@ -1267,8 +1268,9 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 										Description: `Requires replacement if changed.`,
 									},
 									"security_groups": schema.ListAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.List{
 											listplanmodifier.RequiresReplaceIfConfigured(),
 										},
@@ -1465,13 +1467,14 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 												Description: `Requires replacement if changed.`,
 											},
 											"container_reg_ids": schema.ListAttribute{
-												Computed: true,
-												Optional: true,
+												CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
+												Computed:   true,
+												Optional:   true,
 												PlanModifiers: []planmodifier.List{
 													listplanmodifier.RequiresReplaceIfConfigured(),
 												},
 												ElementType: types.StringType,
-												Description: `Requires replacement if changed.`,
+												Description: `List of Azure Container Registry IDs whose images compute jobs may pull. Requires replacement if changed.`,
 											},
 											"dispose_on_deletion": schema.BoolAttribute{
 												Computed: true,
@@ -2608,13 +2611,14 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 											`Requires replacement if changed.`,
 									},
 									"compute_jobs_machine_type": schema.ListAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.List{
 											listplanmodifier.RequiresReplaceIfConfigured(),
 										},
 										ElementType: types.StringType,
-										Description: `Requires replacement if changed.`,
+										Description: `List of Google Cloud machine types compute jobs may use. Requires replacement if changed.`,
 									},
 									"copy_image": schema.StringAttribute{
 										Computed: true,
@@ -2805,13 +2809,14 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 										Description: `Google Cloud VPC network name or self-link for compute instances. Requires replacement if changed.`,
 									},
 									"network_tags": schema.ListAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.List{
 											listplanmodifier.RequiresReplaceIfConfigured(),
 										},
 										ElementType: types.StringType,
-										Description: `Requires replacement if changed.`,
+										Description: `Network tags applied to compute instances for VPC firewall rule targeting. Requires replacement if changed.`,
 									},
 									"nextflow_config": schema.StringAttribute{
 										Computed: true,

--- a/internal/provider/computeenv_resource_sdk.go
+++ b/internal/provider/computeenv_resource_sdk.go
@@ -129,10 +129,11 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 				}
 				if resp.ComputeEnv.Config.AWSCloudConfiguration != nil {
 					r.ComputeEnv.Config.AwsCloud = &tfTypes.AWSCloudConfiguration{}
-					r.ComputeEnv.Config.AwsCloud.AllowBuckets = make([]types.String, 0, len(resp.ComputeEnv.Config.AWSCloudConfiguration.AllowBuckets))
-					for _, v := range resp.ComputeEnv.Config.AWSCloudConfiguration.AllowBuckets {
-						r.ComputeEnv.Config.AwsCloud.AllowBuckets = append(r.ComputeEnv.Config.AwsCloud.AllowBuckets, types.StringValue(v))
-					}
+					allowBucketsValue1, allowBucketsDiags1 := types.ListValueFrom(ctx, types.StringType, resp.ComputeEnv.Config.AWSCloudConfiguration.AllowBuckets)
+					diags.Append(allowBucketsDiags1...)
+					allowBucketsValuable1, allowBucketsDiags1 := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, allowBucketsValue1)
+					diags.Append(allowBucketsDiags1...)
+					r.ComputeEnv.Config.AwsCloud.AllowBuckets, _ = allowBucketsValuable1.(basetypes.ListValue)
 					r.ComputeEnv.Config.AwsCloud.Arm64Enabled = types.BoolPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.Arm64Enabled)
 					r.ComputeEnv.Config.AwsCloud.EbsBootSize = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.AWSCloudConfiguration.EbsBootSize))
 					r.ComputeEnv.Config.AwsCloud.Ec2KeyPair = types.StringPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.Ec2KeyPair)
@@ -170,10 +171,11 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 						}
 					}
 					r.ComputeEnv.Config.AwsCloud.SchedEnabled = types.BoolPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.SchedEnabled)
-					r.ComputeEnv.Config.AwsCloud.SecurityGroups = make([]types.String, 0, len(resp.ComputeEnv.Config.AWSCloudConfiguration.SecurityGroups))
-					for _, v := range resp.ComputeEnv.Config.AWSCloudConfiguration.SecurityGroups {
-						r.ComputeEnv.Config.AwsCloud.SecurityGroups = append(r.ComputeEnv.Config.AwsCloud.SecurityGroups, types.StringValue(v))
-					}
+					securityGroupsValue1, securityGroupsDiags1 := types.ListValueFrom(ctx, types.StringType, resp.ComputeEnv.Config.AWSCloudConfiguration.SecurityGroups)
+					diags.Append(securityGroupsDiags1...)
+					securityGroupsValuable1, securityGroupsDiags1 := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, securityGroupsValue1)
+					diags.Append(securityGroupsDiags1...)
+					r.ComputeEnv.Config.AwsCloud.SecurityGroups, _ = securityGroupsValuable1.(basetypes.ListValue)
 					r.ComputeEnv.Config.AwsCloud.SubnetID = types.StringPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.SubnetID)
 					r.ComputeEnv.Config.AwsCloud.WorkDir = types.StringPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.WorkDir)
 				}
@@ -274,10 +276,11 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 					} else {
 						r.ComputeEnv.Config.AzureBatch.Forge = &tfTypes.AzBatchForgeConfig{}
 						r.ComputeEnv.Config.AzureBatch.Forge.AutoScale = types.BoolPointerValue(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.AutoScale)
-						r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds = make([]types.String, 0, len(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.ContainerRegIds))
-						for _, v := range resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.ContainerRegIds {
-							r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds = append(r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds, types.StringValue(v))
-						}
+						containerRegIdsValue, containerRegIdsDiags := types.ListValueFrom(ctx, types.StringType, resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.ContainerRegIds)
+						diags.Append(containerRegIdsDiags...)
+						containerRegIdsValuable, containerRegIdsDiags := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, containerRegIdsValue)
+						diags.Append(containerRegIdsDiags...)
+						r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds, _ = containerRegIdsValuable.(basetypes.ListValue)
 						r.ComputeEnv.Config.AzureBatch.Forge.DisposeOnDeletion = types.BoolPointerValue(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.DisposeOnDeletion)
 						r.ComputeEnv.Config.AzureBatch.Forge.DualPoolConfig = types.BoolPointerValue(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.DualPoolConfig)
 						if resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.HeadPool == nil {
@@ -364,10 +367,11 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 					r.ComputeEnv.Config.GoogleBatch.BootDiskImage = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.BootDiskImage)
 					r.ComputeEnv.Config.GoogleBatch.BootDiskSizeGb = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.BootDiskSizeGb))
 					r.ComputeEnv.Config.GoogleBatch.ComputeJobsInstanceTemplate = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.ComputeJobsInstanceTemplate)
-					r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType = make([]types.String, 0, len(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.ComputeJobsMachineType))
-					for _, v := range resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.ComputeJobsMachineType {
-						r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType = append(r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType, types.StringValue(v))
-					}
+					computeJobsMachineTypeValue, computeJobsMachineTypeDiags := types.ListValueFrom(ctx, types.StringType, resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.ComputeJobsMachineType)
+					diags.Append(computeJobsMachineTypeDiags...)
+					computeJobsMachineTypeValuable, computeJobsMachineTypeDiags := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, computeJobsMachineTypeValue)
+					diags.Append(computeJobsMachineTypeDiags...)
+					r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType, _ = computeJobsMachineTypeValuable.(basetypes.ListValue)
 					r.ComputeEnv.Config.GoogleBatch.CopyImage = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.CopyImage)
 					r.ComputeEnv.Config.GoogleBatch.CPUPlatform = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.CPUPlatform)
 					r.ComputeEnv.Config.GoogleBatch.DebugMode = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.DebugMode))
@@ -398,10 +402,11 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 					r.ComputeEnv.Config.GoogleBatch.Location = types.StringValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.Location)
 					r.ComputeEnv.Config.GoogleBatch.MachineType = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.MachineType)
 					r.ComputeEnv.Config.GoogleBatch.Network = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.Network)
-					r.ComputeEnv.Config.GoogleBatch.NetworkTags = make([]types.String, 0, len(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.NetworkTags))
-					for _, v := range resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.NetworkTags {
-						r.ComputeEnv.Config.GoogleBatch.NetworkTags = append(r.ComputeEnv.Config.GoogleBatch.NetworkTags, types.StringValue(v))
-					}
+					networkTagsValue, networkTagsDiags := types.ListValueFrom(ctx, types.StringType, resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.NetworkTags)
+					diags.Append(networkTagsDiags...)
+					networkTagsValuable, networkTagsDiags := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, networkTagsValue)
+					diags.Append(networkTagsDiags...)
+					r.ComputeEnv.Config.GoogleBatch.NetworkTags, _ = networkTagsValuable.(basetypes.ListValue)
 					r.ComputeEnv.Config.GoogleBatch.NextflowConfig = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.NextflowConfig)
 					r.ComputeEnv.Config.GoogleBatch.NfsMount = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.NfsMount)
 					r.ComputeEnv.Config.GoogleBatch.NfsTarget = types.StringPointerValue(resp.ComputeEnv.Config.GoogleBatchServiceConfiguration.NfsTarget)
@@ -1292,9 +1297,9 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 	}
 	var awsCloudConfiguration *shared.AWSCloudConfiguration
 	if r.ComputeEnv.Config.AwsCloud != nil {
-		allowBuckets1 := make([]string, 0, len(r.ComputeEnv.Config.AwsCloud.AllowBuckets))
-		for allowBucketsIndex := range r.ComputeEnv.Config.AwsCloud.AllowBuckets {
-			allowBuckets1 = append(allowBuckets1, r.ComputeEnv.Config.AwsCloud.AllowBuckets[allowBucketsIndex].ValueString())
+		var allowBuckets1 []string
+		if !r.ComputeEnv.Config.AwsCloud.AllowBuckets.IsUnknown() && !r.ComputeEnv.Config.AwsCloud.AllowBuckets.IsNull() {
+			diags.Append(r.ComputeEnv.Config.AwsCloud.AllowBuckets.ElementsAs(ctx, &allowBuckets1, true)...)
 		}
 		arm64Enabled1 := new(bool)
 		if !r.ComputeEnv.Config.AwsCloud.Arm64Enabled.IsUnknown() && !r.ComputeEnv.Config.AwsCloud.Arm64Enabled.IsNull() {
@@ -1422,9 +1427,9 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			schedEnabled = nil
 		}
-		securityGroups1 := make([]string, 0, len(r.ComputeEnv.Config.AwsCloud.SecurityGroups))
-		for securityGroupsIndex := range r.ComputeEnv.Config.AwsCloud.SecurityGroups {
-			securityGroups1 = append(securityGroups1, r.ComputeEnv.Config.AwsCloud.SecurityGroups[securityGroupsIndex].ValueString())
+		var securityGroups1 []string
+		if !r.ComputeEnv.Config.AwsCloud.SecurityGroups.IsUnknown() && !r.ComputeEnv.Config.AwsCloud.SecurityGroups.IsNull() {
+			diags.Append(r.ComputeEnv.Config.AwsCloud.SecurityGroups.ElementsAs(ctx, &securityGroups1, true)...)
 		}
 		subnetID := new(string)
 		if !r.ComputeEnv.Config.AwsCloud.SubnetID.IsUnknown() && !r.ComputeEnv.Config.AwsCloud.SubnetID.IsNull() {
@@ -1583,9 +1588,9 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			computeJobsInstanceTemplate = nil
 		}
-		computeJobsMachineType := make([]string, 0, len(r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType))
-		for computeJobsMachineTypeIndex := range r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType {
-			computeJobsMachineType = append(computeJobsMachineType, r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType[computeJobsMachineTypeIndex].ValueString())
+		var computeJobsMachineType []string
+		if !r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType.IsUnknown() && !r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType.IsNull() {
+			diags.Append(r.ComputeEnv.Config.GoogleBatch.ComputeJobsMachineType.ElementsAs(ctx, &computeJobsMachineType, true)...)
 		}
 		copyImage := new(string)
 		if !r.ComputeEnv.Config.GoogleBatch.CopyImage.IsUnknown() && !r.ComputeEnv.Config.GoogleBatch.CopyImage.IsNull() {
@@ -1690,9 +1695,9 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			network = nil
 		}
-		networkTags := make([]string, 0, len(r.ComputeEnv.Config.GoogleBatch.NetworkTags))
-		for networkTagsIndex := range r.ComputeEnv.Config.GoogleBatch.NetworkTags {
-			networkTags = append(networkTags, r.ComputeEnv.Config.GoogleBatch.NetworkTags[networkTagsIndex].ValueString())
+		var networkTags []string
+		if !r.ComputeEnv.Config.GoogleBatch.NetworkTags.IsUnknown() && !r.ComputeEnv.Config.GoogleBatch.NetworkTags.IsNull() {
+			diags.Append(r.ComputeEnv.Config.GoogleBatch.NetworkTags.ElementsAs(ctx, &networkTags, true)...)
 		}
 		nextflowConfig3 := new(string)
 		if !r.ComputeEnv.Config.GoogleBatch.NextflowConfig.IsUnknown() && !r.ComputeEnv.Config.GoogleBatch.NextflowConfig.IsNull() {
@@ -2044,9 +2049,9 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			} else {
 				autoScale = nil
 			}
-			containerRegIds := make([]string, 0, len(r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds))
-			for containerRegIdsIndex := range r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds {
-				containerRegIds = append(containerRegIds, r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds[containerRegIdsIndex].ValueString())
+			var containerRegIds []string
+			if !r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds.IsNull() {
+				diags.Append(r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds.ElementsAs(ctx, &containerRegIds, true)...)
 			}
 			disposeOnDeletion1 := new(bool)
 			if !r.ComputeEnv.Config.AzureBatch.Forge.DisposeOnDeletion.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.Forge.DisposeOnDeletion.IsNull() {

--- a/internal/provider/gcpbatchce_resource.go
+++ b/internal/provider/gcpbatchce_resource.go
@@ -122,14 +122,15 @@ func (r *GCPBatchCEResource) Schema(ctx context.Context, req resource.SchemaRequ
 							`Requires replacement if changed.`,
 					},
 					"compute_jobs_machine_type": schema.ListAttribute{
-						Computed: true,
-						Optional: true,
+						CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
+						Computed:   true,
+						Optional:   true,
 						PlanModifiers: []planmodifier.List{
 							listplanmodifier.RequiresReplaceIfConfigured(),
 							speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
 						},
 						ElementType: types.StringType,
-						Description: `Requires replacement if changed.`,
+						Description: `List of Google Cloud machine types compute jobs may use. Requires replacement if changed.`,
 					},
 					"copy_image": schema.StringAttribute{
 						Computed: true,
@@ -335,14 +336,15 @@ func (r *GCPBatchCEResource) Schema(ctx context.Context, req resource.SchemaRequ
 						Description: `Google Cloud VPC network name or self-link for compute instances. Requires replacement if changed.`,
 					},
 					"network_tags": schema.ListAttribute{
-						Computed: true,
-						Optional: true,
+						CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
+						Computed:   true,
+						Optional:   true,
 						PlanModifiers: []planmodifier.List{
 							listplanmodifier.RequiresReplaceIfConfigured(),
 							speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
 						},
 						ElementType: types.StringType,
-						Description: `Requires replacement if changed.`,
+						Description: `Network tags applied to compute instances for VPC firewall rule targeting. Requires replacement if changed.`,
 					},
 					"nextflow_config": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gcpbatchce_resource_sdk.go
+++ b/internal/provider/gcpbatchce_resource_sdk.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/provider/typeconvert"
 	tfTypes "github.com/seqeralabs/terraform-provider-seqera/internal/provider/types"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/models/operations"
@@ -46,10 +47,11 @@ func (r *GCPBatchCEResourceModel) RefreshFromSharedGCPBatchCEComputeConfig(ctx c
 		r.Config.BootDiskImage = types.StringPointerValue(resp.Config.BootDiskImage)
 		r.Config.BootDiskSizeGb = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.BootDiskSizeGb))
 		r.Config.ComputeJobsInstanceTemplate = types.StringPointerValue(resp.Config.ComputeJobsInstanceTemplate)
-		r.Config.ComputeJobsMachineType = make([]types.String, 0, len(resp.Config.ComputeJobsMachineType))
-		for _, v := range resp.Config.ComputeJobsMachineType {
-			r.Config.ComputeJobsMachineType = append(r.Config.ComputeJobsMachineType, types.StringValue(v))
-		}
+		computeJobsMachineTypeValue, computeJobsMachineTypeDiags := types.ListValueFrom(ctx, types.StringType, resp.Config.ComputeJobsMachineType)
+		diags.Append(computeJobsMachineTypeDiags...)
+		computeJobsMachineTypeValuable, computeJobsMachineTypeDiags := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, computeJobsMachineTypeValue)
+		diags.Append(computeJobsMachineTypeDiags...)
+		r.Config.ComputeJobsMachineType, _ = computeJobsMachineTypeValuable.(basetypes.ListValue)
 		r.Config.CopyImage = types.StringPointerValue(resp.Config.CopyImage)
 		r.Config.CPUPlatform = types.StringPointerValue(resp.Config.CPUPlatform)
 		r.Config.DebugMode = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.DebugMode))
@@ -80,10 +82,11 @@ func (r *GCPBatchCEResourceModel) RefreshFromSharedGCPBatchCEComputeConfig(ctx c
 		r.Config.Location = types.StringValue(resp.Config.Location)
 		r.Config.MachineType = types.StringPointerValue(resp.Config.MachineType)
 		r.Config.Network = types.StringPointerValue(resp.Config.Network)
-		r.Config.NetworkTags = make([]types.String, 0, len(resp.Config.NetworkTags))
-		for _, v := range resp.Config.NetworkTags {
-			r.Config.NetworkTags = append(r.Config.NetworkTags, types.StringValue(v))
-		}
+		networkTagsValue, networkTagsDiags := types.ListValueFrom(ctx, types.StringType, resp.Config.NetworkTags)
+		diags.Append(networkTagsDiags...)
+		networkTagsValuable, networkTagsDiags := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, networkTagsValue)
+		diags.Append(networkTagsDiags...)
+		r.Config.NetworkTags, _ = networkTagsValuable.(basetypes.ListValue)
 		r.Config.NextflowConfig = types.StringPointerValue(resp.Config.NextflowConfig)
 		r.Config.NfsMount = types.StringPointerValue(resp.Config.NfsMount)
 		r.Config.NfsTarget = types.StringPointerValue(resp.Config.NfsTarget)
@@ -270,9 +273,9 @@ func (r *GCPBatchCEResourceModel) ToSharedGCPBatchCEComputeConfigInput(ctx conte
 	} else {
 		computeJobsInstanceTemplate = nil
 	}
-	computeJobsMachineType := make([]string, 0, len(r.Config.ComputeJobsMachineType))
-	for computeJobsMachineTypeIndex := range r.Config.ComputeJobsMachineType {
-		computeJobsMachineType = append(computeJobsMachineType, r.Config.ComputeJobsMachineType[computeJobsMachineTypeIndex].ValueString())
+	var computeJobsMachineType []string
+	if !r.Config.ComputeJobsMachineType.IsUnknown() && !r.Config.ComputeJobsMachineType.IsNull() {
+		diags.Append(r.Config.ComputeJobsMachineType.ElementsAs(ctx, &computeJobsMachineType, true)...)
 	}
 	copyImage := new(string)
 	if !r.Config.CopyImage.IsUnknown() && !r.Config.CopyImage.IsNull() {
@@ -377,9 +380,9 @@ func (r *GCPBatchCEResourceModel) ToSharedGCPBatchCEComputeConfigInput(ctx conte
 	} else {
 		network = nil
 	}
-	networkTags := make([]string, 0, len(r.Config.NetworkTags))
-	for networkTagsIndex := range r.Config.NetworkTags {
-		networkTags = append(networkTags, r.Config.NetworkTags[networkTagsIndex].ValueString())
+	var networkTags []string
+	if !r.Config.NetworkTags.IsUnknown() && !r.Config.NetworkTags.IsNull() {
+		diags.Append(r.Config.NetworkTags.ElementsAs(ctx, &networkTags, true)...)
 	}
 	nextflowConfig := new(string)
 	if !r.Config.NextflowConfig.IsUnknown() && !r.Config.NextflowConfig.IsNull() {

--- a/internal/provider/types/aws_cloud_configuration.go
+++ b/internal/provider/types/aws_cloud_configuration.go
@@ -4,10 +4,11 @@ package types
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type AWSCloudConfiguration struct {
-	AllowBuckets       []types.String      `tfsdk:"allow_buckets"`
+	AllowBuckets       basetypes.ListValue `tfsdk:"allow_buckets"`
 	Arm64Enabled       types.Bool          `tfsdk:"arm64_enabled"`
 	EbsBootSize        types.Int32         `tfsdk:"ebs_boot_size"`
 	Ec2KeyPair         types.String        `tfsdk:"ec2_key_pair"`
@@ -25,7 +26,7 @@ type AWSCloudConfiguration struct {
 	Region             types.String        `tfsdk:"region"`
 	SchedConfig        *SchedConfig        `tfsdk:"sched_config"`
 	SchedEnabled       types.Bool          `tfsdk:"sched_enabled"`
-	SecurityGroups     []types.String      `tfsdk:"security_groups"`
+	SecurityGroups     basetypes.ListValue `tfsdk:"security_groups"`
 	SubnetID           types.String        `tfsdk:"subnet_id"`
 	WorkDir            types.String        `tfsdk:"work_dir"`
 }

--- a/internal/provider/types/az_batch_forge_config.go
+++ b/internal/provider/types/az_batch_forge_config.go
@@ -4,15 +4,16 @@ package types
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type AzBatchForgeConfig struct {
-	AutoScale         types.Bool         `tfsdk:"auto_scale"`
-	ContainerRegIds   []types.String     `tfsdk:"container_reg_ids"`
-	DisposeOnDeletion types.Bool         `tfsdk:"dispose_on_deletion"`
-	DualPoolConfig    types.Bool         `tfsdk:"dual_pool_config"`
-	HeadPool          *AzBatchPoolConfig `tfsdk:"head_pool"`
-	VMCount           types.Int32        `tfsdk:"vm_count"`
-	VMType            types.String       `tfsdk:"vm_type"`
-	WorkerPool        *AzBatchPoolConfig `tfsdk:"worker_pool"`
+	AutoScale         types.Bool          `tfsdk:"auto_scale"`
+	ContainerRegIds   basetypes.ListValue `tfsdk:"container_reg_ids"`
+	DisposeOnDeletion types.Bool          `tfsdk:"dispose_on_deletion"`
+	DualPoolConfig    types.Bool          `tfsdk:"dual_pool_config"`
+	HeadPool          *AzBatchPoolConfig  `tfsdk:"head_pool"`
+	VMCount           types.Int32         `tfsdk:"vm_count"`
+	VMType            types.String        `tfsdk:"vm_type"`
+	WorkerPool        *AzBatchPoolConfig  `tfsdk:"worker_pool"`
 }

--- a/internal/provider/types/google_batch_config.go
+++ b/internal/provider/types/google_batch_config.go
@@ -4,13 +4,14 @@ package types
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type GoogleBatchConfig struct {
 	BootDiskImage               types.String            `tfsdk:"boot_disk_image"`
 	BootDiskSizeGb              types.Int32             `tfsdk:"boot_disk_size_gb"`
 	ComputeJobsInstanceTemplate types.String            `tfsdk:"compute_jobs_instance_template"`
-	ComputeJobsMachineType      []types.String          `tfsdk:"compute_jobs_machine_type"`
+	ComputeJobsMachineType      basetypes.ListValue     `tfsdk:"compute_jobs_machine_type"`
 	CopyImage                   types.String            `tfsdk:"copy_image"`
 	CPUPlatform                 types.String            `tfsdk:"cpu_platform"`
 	DebugMode                   types.Int32             `tfsdk:"debug_mode"`
@@ -25,7 +26,7 @@ type GoogleBatchConfig struct {
 	Location                    types.String            `tfsdk:"location"`
 	MachineType                 types.String            `tfsdk:"machine_type"`
 	Network                     types.String            `tfsdk:"network"`
-	NetworkTags                 []types.String          `tfsdk:"network_tags"`
+	NetworkTags                 basetypes.ListValue     `tfsdk:"network_tags"`
 	NextflowConfig              types.String            `tfsdk:"nextflow_config"`
 	NfsMount                    types.String            `tfsdk:"nfs_mount"`
 	NfsTarget                   types.String            `tfsdk:"nfs_target"`

--- a/internal/provider/types/google_batch_service_configuration.go
+++ b/internal/provider/types/google_batch_service_configuration.go
@@ -4,13 +4,14 @@ package types
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type GoogleBatchServiceConfiguration struct {
 	BootDiskImage               types.String            `tfsdk:"boot_disk_image"`
 	BootDiskSizeGb              types.Int32             `tfsdk:"boot_disk_size_gb"`
 	ComputeJobsInstanceTemplate types.String            `tfsdk:"compute_jobs_instance_template"`
-	ComputeJobsMachineType      []types.String          `tfsdk:"compute_jobs_machine_type"`
+	ComputeJobsMachineType      basetypes.ListValue     `tfsdk:"compute_jobs_machine_type"`
 	CopyImage                   types.String            `tfsdk:"copy_image"`
 	CPUPlatform                 types.String            `tfsdk:"cpu_platform"`
 	DebugMode                   types.Int32             `tfsdk:"debug_mode"`
@@ -25,7 +26,7 @@ type GoogleBatchServiceConfiguration struct {
 	Location                    types.String            `tfsdk:"location"`
 	MachineType                 types.String            `tfsdk:"machine_type"`
 	Network                     types.String            `tfsdk:"network"`
-	NetworkTags                 []types.String          `tfsdk:"network_tags"`
+	NetworkTags                 basetypes.ListValue     `tfsdk:"network_tags"`
 	NextflowConfig              types.String            `tfsdk:"nextflow_config"`
 	NfsMount                    types.String            `tfsdk:"nfs_mount"`
 	NfsTarget                   types.String            `tfsdk:"nfs_target"`

--- a/internal/sdk/models/shared/azbatchforgeconfig.go
+++ b/internal/sdk/models/shared/azbatchforgeconfig.go
@@ -7,7 +7,9 @@ import (
 )
 
 type AzBatchForgeConfig struct {
-	AutoScale         *bool    `json:"autoScale,omitempty"`
+	AutoScale *bool `json:"autoScale,omitempty"`
+	// List of Azure Container Registry IDs whose images compute jobs may pull.
+	//
 	ContainerRegIds   []string `json:"containerRegIds,omitempty"`
 	DisposeOnDeletion *bool    `json:"disposeOnDeletion,omitempty"`
 	DualPoolConfig    *bool    `json:"dualPoolConfig,omitempty"`

--- a/internal/sdk/models/shared/computeconfiginput.go
+++ b/internal/sdk/models/shared/computeconfiginput.go
@@ -2353,8 +2353,10 @@ type GoogleBatchServiceConfiguration struct {
 	// Google Cloud instance template name or self-link for compute job VMs.
 	// Overrides other VM configuration settings for compute jobs.
 	//
-	ComputeJobsInstanceTemplate *string  `json:"computeJobsInstanceTemplate,omitempty"`
-	ComputeJobsMachineType      []string `json:"computeJobsMachineType,omitempty"`
+	ComputeJobsInstanceTemplate *string `json:"computeJobsInstanceTemplate,omitempty"`
+	// List of Google Cloud machine types compute jobs may use.
+	//
+	ComputeJobsMachineType []string `json:"computeJobsMachineType,omitempty"`
 	// Container image used for file staging (copying data to/from Cloud Storage).
 	//
 	CopyImage *string `json:"copyImage,omitempty"`
@@ -2400,7 +2402,9 @@ type GoogleBatchServiceConfiguration struct {
 	MachineType *string `json:"machineType,omitempty"`
 	// Google Cloud VPC network name or self-link for compute instances.
 	//
-	Network     *string  `json:"network,omitempty"`
+	Network *string `json:"network,omitempty"`
+	// Network tags applied to compute instances for VPC firewall rule targeting.
+	//
 	NetworkTags []string `json:"networkTags,omitempty"`
 	// Nextflow configuration settings and parameters
 	NextflowConfig *string `json:"nextflowConfig,omitempty"`

--- a/internal/sdk/models/shared/googlebatchconfig.go
+++ b/internal/sdk/models/shared/googlebatchconfig.go
@@ -10,8 +10,10 @@ type GoogleBatchConfig struct {
 	// Google Cloud instance template name or self-link for compute job VMs.
 	// Overrides other VM configuration settings for compute jobs.
 	//
-	ComputeJobsInstanceTemplate *string  `json:"computeJobsInstanceTemplate,omitempty"`
-	ComputeJobsMachineType      []string `json:"computeJobsMachineType,omitempty"`
+	ComputeJobsInstanceTemplate *string `json:"computeJobsInstanceTemplate,omitempty"`
+	// List of Google Cloud machine types compute jobs may use.
+	//
+	ComputeJobsMachineType []string `json:"computeJobsMachineType,omitempty"`
 	// Container image used for file staging (copying data to/from Cloud Storage).
 	//
 	CopyImage *string `json:"copyImage,omitempty"`
@@ -56,7 +58,9 @@ type GoogleBatchConfig struct {
 	MachineType *string `json:"machineType,omitempty"`
 	// Google Cloud VPC network name or self-link for compute instances.
 	//
-	Network        *string  `json:"network,omitempty"`
+	Network *string `json:"network,omitempty"`
+	// Network tags applied to compute instances for VPC firewall rule targeting.
+	//
 	NetworkTags    []string `json:"networkTags,omitempty"`
 	NextflowConfig *string  `json:"nextflowConfig,omitempty"`
 	// Local mount path for the NFS file system on compute instances.

--- a/overlays/compute-env-azure-batch.yaml
+++ b/overlays/compute-env-azure-batch.yaml
@@ -333,3 +333,21 @@ actions:
   - target: $.components.schemas.AzureBatchCE_ComputeConfig.properties.config
     update:
       x-speakeasy-param-force-new: true
+
+  # ============================================================================
+  # AZBATCHFORGECONFIG LIST-OF-STRING CUSTOM TYPES
+  # ============================================================================
+  # Without this Speakeasy generates `[]types.String`, which the framework
+  # cannot decode when the whole list is unknown at plan time (e.g. fed from a
+  # data source).
+
+  - target: $.components.schemas.AzBatchForgeConfig.properties.containerRegIds
+    update:
+      description: |
+        List of Azure Container Registry IDs whose images compute jobs may pull.
+      x-speakeasy-param-force-new: true
+      x-speakeasy-terraform-custom-type:
+        imports:
+          - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+        schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+        valueType: basetypes.ListValue

--- a/overlays/compute-env-gcp-batch.yaml
+++ b/overlays/compute-env-gcp-batch.yaml
@@ -350,3 +350,29 @@ actions:
       pattern: "^gs://.+"
       x-speakeasy-param-force-new: true
       x-speakeasy-param-optional: false
+
+  # List-of-string fields need a custom type so they can hold "unknown" lists
+  # produced by Terraform data sources at plan time. Without this Speakeasy
+  # generates `[]types.String`, which the framework cannot decode when the
+  # whole list is unknown (e.g. `network_tags = data.google_compute_network.x.tags`).
+  - target: $.components.schemas.GoogleBatchConfig.properties.computeJobsMachineType
+    update:
+      description: |
+        List of Google Cloud machine types compute jobs may use.
+      x-speakeasy-param-force-new: true
+      x-speakeasy-terraform-custom-type:
+        imports:
+          - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+        schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+        valueType: basetypes.ListValue
+
+  - target: $.components.schemas.GoogleBatchConfig.properties.networkTags
+    update:
+      description: |
+        Network tags applied to compute instances for VPC firewall rule targeting.
+      x-speakeasy-param-force-new: true
+      x-speakeasy-terraform-custom-type:
+        imports:
+          - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+        schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+        valueType: basetypes.ListValue

--- a/overlays/compute-env.yaml
+++ b/overlays/compute-env.yaml
@@ -555,6 +555,11 @@ actions:
         List of additional S3 bucket names that compute jobs are allowed to access.
         The work directory bucket is automatically included.
       x-speakeasy-param-force-new: true
+      x-speakeasy-terraform-custom-type:
+        imports:
+          - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+        schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+        valueType: basetypes.ListValue
 
   - target: $.components.schemas.AwsCloudConfig.properties.instanceType
     update:
@@ -626,6 +631,11 @@ actions:
         Security groups must allow necessary network access.
       example: ["sg-12345678"]
       x-speakeasy-param-force-new: true
+      x-speakeasy-terraform-custom-type:
+        imports:
+          - github.com/hashicorp/terraform-plugin-framework/types/basetypes
+        schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
+        valueType: basetypes.ListValue
 
   # ============================================================================
   # GOOGLE BATCH CONFIG FIELD DESCRIPTIONS


### PR DESCRIPTION
## Summary

Extends the unknown-list fix from #188 (which solved `subnets = data.aws_subnets.public.ids` style failures for `ForgeConfig`) to the remaining list-of-string fields across the multi-cloud compute environment configs.

## Affected fields

| Schema | Field | Resources that consume it |
| --- | --- | --- |
| `AwsCloudConfig` | `allow_buckets` | `seqera_compute_env` |
| `AwsCloudConfig` | `security_groups` | `seqera_compute_env` |
| `GoogleBatchConfig` | `compute_jobs_machine_type` | `seqera_gcp_batch_ce`, `seqera_compute_env` |
| `GoogleBatchConfig` | `network_tags` | `seqera_gcp_batch_ce`, `seqera_compute_env` |
| `AzBatchForgeConfig` | `container_reg_ids` | `seqera_azure_batch_ce`, `seqera_compute_env` |

`GoogleCloudConfig` and `AzCloudConfig` were audited and have no list-of-string fields — nothing to do there.

## Why

The Speakeasy generator emits `[]types.String` for a list-of-string field. The Plugin Framework can decode that only when the list length is known at plan time; an unknown collection from a data source (e.g. `network_tags = data.google_compute_network.x.tags`) fails with:

```
Received unknown value, however the target type cannot handle unknown values.
Path: ...
Target Type: []basetypes.StringValue
Suggested Type: basetypes.ListValue
```

## Fix

Each field gets the same `x-speakeasy-terraform-custom-type` overlay PR #188 introduced for `ForgeConfig`:

```yaml
x-speakeasy-terraform-custom-type:
  imports:
    - github.com/hashicorp/terraform-plugin-framework/types/basetypes
  schemaType: "basetypes.ListType{ElemType: basetypes.StringType{}}"
  valueType: basetypes.ListValue
```

Pure overlay change — no hand-edits to generated code. Speakeasy emits `basetypes.ListValue` in the model and the matching `types.ListValueFrom` / `IsUnknown` plumbing in `_resource_sdk.go`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` reports `0 issues`
- [x] Verified the five model fields are now `basetypes.ListValue` in `internal/provider/types/`
- [ ] CI build + integration tests
- [ ] `terraform plan` against a config feeding each field from a data source (deferred — real GCP/Azure workspace creds needed)

## CHANGELOG

New entry under `v0.40.0` BUGFIXES referencing the field list above. (Kept in `v0.40.0` since RC's are still in progress.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)