### PR TITLE
fix!: mark workspace date fields as readonly

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,10 +1,10 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 3e0396bea33d83962daa0bbe83d843a4
+  docChecksum: 01318fe35f2b468ba80afe08088bd970
   docVersion: 1.147.0
-  speakeasyVersion: 1.761.9
-  generationVersion: 2.881.4
+  speakeasyVersion: 1.761.11
+  generationVersion: 2.881.17
   releaseVersion: 0.40.0-RC2
   configChecksum: c77908dbe8aa95c668e0cdc1862e3c7f
 persistentEdits:
@@ -301,7 +301,7 @@ trackedFiles:
     pristine_git_object: fd5a27e12a4fe32fb7817dd93d51447a7d67f58d
   examples/resources/seqera_workspace/resource.tf:
     id: 0861dd715211
-    last_write_checksum: sha1:10de1f50ce5de7b4bd85c53da8e3023337fa7607
+    last_write_checksum: sha1:6aea6fceaab2cb3beda2a79ce58aeadf8d67116d
     pristine_git_object: 6cdb08cff8d5e98c92183f577fc8fbe059d61ff7
   go.mod:
     id: c47645c391ad
@@ -1017,7 +1017,7 @@ trackedFiles:
     pristine_git_object: 32dd5a54a21939c3cfa3c2ada55b841cb54032f9
   internal/provider/workspace_resource.go:
     id: 4255ab3c913f
-    last_write_checksum: sha1:83ed411f57d7db1956a365687777ab1da6d01ee9
+    last_write_checksum: sha1:4bf6ad93820be0b88c973503918a062924020608
     pristine_git_object: 3a254498bdb26fe0a1be5e3afd3452978bba12da
   internal/provider/workspace_resource_sdk.go:
     id: 6b7b5772bf74
@@ -3911,7 +3911,7 @@ trackedFiles:
     last_write_checksum: sha1:84fef173ddc771401f52a4c084d5a3e1b07f776e
   internal/sdk/seqera.go:
     id: b1c23bc5193c
-    last_write_checksum: sha1:973300f124fc25552584224ab5d338d68e06b140
+    last_write_checksum: sha1:d5642398b46a0fd953805293f4e72713a552e0e3
     pristine_git_object: 89364ed6208c4c999b317d23d7d954d63ac46bc5
   internal/sdk/serviceinfo.go:
     id: 085db9a15b34

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -21692,6 +21692,7 @@ components:
         dateCreated:
           type: string
           format: date-time
+          x-speakeasy-param-readonly: true
         description:
           type: string
           maxLength: 1000
@@ -21712,6 +21713,7 @@ components:
         lastUpdated:
           type: string
           format: date-time
+          x-speakeasy-param-readonly: true
         name:
           type: string
           maxLength: 40

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.761.9
+speakeasyVersion: 1.761.11
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:78ba2cda8bdad5aebc63eb2be65f9cfd1d6f57463f17d336053b6c1c5895c27f
-        sourceBlobDigest: sha256:7a2466bd2eb647ca48d824e2abb652be7a5b2b4fb5705dec4ed684bd79947ec9
+        sourceRevisionDigest: sha256:e790b833ab8aa0defb152b8d491dbfe92c9f62041e91026fd7322ea0ed1e153c
+        sourceBlobDigest: sha256:54f3b7833ee129c5b6d833b8e51dfc235dd96dec52e24a73f1f5ac45d1ad3769
         tags:
             - latest
             - 1.147.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:78ba2cda8bdad5aebc63eb2be65f9cfd1d6f57463f17d336053b6c1c5895c27f
-        sourceBlobDigest: sha256:7a2466bd2eb647ca48d824e2abb652be7a5b2b4fb5705dec4ed684bd79947ec9
+        sourceRevisionDigest: sha256:e790b833ab8aa0defb152b8d491dbfe92c9f62041e91026fd7322ea0ed1e153c
+        sourceBlobDigest: sha256:54f3b7833ee129c5b6d833b8e51dfc235dd96dec52e24a73f1f5ac45d1ad3769
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -39,14 +39,12 @@ Organizations consist of members, while workspaces consist of participants.
 
 ```terraform
 resource "seqera_workspace" "my_workspace" {
-  date_created = "2022-12-28T06:42:48.248Z"
-  description  = "Workspace for genomics research projects and computational biology workflows"
-  full_name    = "Genomics Research Workspace"
-  id           = 1
-  last_updated = "2021-06-30T04:32:09.681Z"
-  name         = "genomics-research"
-  org_id       = 7
-  visibility   = "SHARED"
+  description = "Workspace for genomics research projects and computational biology workflows"
+  full_name   = "Genomics Research Workspace"
+  id          = 1
+  name        = "genomics-research"
+  org_id      = 7
+  visibility  = "SHARED"
 }
 ```
 
@@ -62,10 +60,13 @@ resource "seqera_workspace" "my_workspace" {
 
 ### Optional
 
-- `date_created` (String) Requires replacement if changed.
 - `description` (String) Workspace description
 - `id` (Number) Workspace numeric identifier
-- `last_updated` (String) Requires replacement if changed.
+
+### Read-Only
+
+- `date_created` (String)
+- `last_updated` (String)
 
 ## Import
 

--- a/examples/resources/seqera_workspace/resource.tf
+++ b/examples/resources/seqera_workspace/resource.tf
@@ -1,10 +1,8 @@
 resource "seqera_workspace" "my_workspace" {
-  date_created = "2022-12-28T06:42:48.248Z"
-  description  = "Workspace for genomics research projects and computational biology workflows"
-  full_name    = "Genomics Research Workspace"
-  id           = 1
-  last_updated = "2021-06-30T04:32:09.681Z"
-  name         = "genomics-research"
-  org_id       = 7
-  visibility   = "SHARED"
+  description = "Workspace for genomics research projects and computational biology workflows"
+  full_name   = "Genomics Research Workspace"
+  id          = 1
+  name        = "genomics-research"
+  org_id      = 7
+  visibility  = "SHARED"
 }

--- a/internal/provider/workspace_resource.go
+++ b/internal/provider/workspace_resource.go
@@ -12,13 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/seqeralabs/terraform-provider-seqera/internal/planmodifiers/stringplanmodifier"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk"
-	"github.com/seqeralabs/terraform-provider-seqera/internal/validators"
 	"regexp"
 )
 
@@ -58,14 +56,8 @@ func (r *WorkspaceResource) Schema(ctx context.Context, req resource.SchemaReque
 		Attributes: map[string]schema.Attribute{
 			"date_created": schema.StringAttribute{
 				Computed: true,
-				Optional: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Description: `Requires replacement if changed.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 			"description": schema.StringAttribute{
@@ -89,14 +81,8 @@ func (r *WorkspaceResource) Schema(ctx context.Context, req resource.SchemaReque
 			},
 			"last_updated": schema.StringAttribute{
 				Computed: true,
-				Optional: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Description: `Requires replacement if changed.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 			"name": schema.StringAttribute{

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.147.0 and generator version 2.881.4
+// Generated from OpenAPI doc version 1.147.0 and generator version 2.881.17
 
 import (
 	"context"
@@ -175,7 +175,7 @@ func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
 		SDKVersion: "0.40.0-RC2",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC2 2.881.4 1.147.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC2 2.881.17 1.147.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/overlays/workspaces.yaml
+++ b/overlays/workspaces.yaml
@@ -20,6 +20,12 @@ actions:
   - target: $["components"]["schemas"]["Workspace"]["properties"]["visibility"]
     update:
       x-speakeasy-param-readonly: false
+  - target: $["components"]["schemas"]["Workspace"]["properties"]["dateCreated"]
+    update:
+      x-speakeasy-param-readonly: true
+  - target: $["components"]["schemas"]["Workspace"]["properties"]["lastUpdated"]
+    update:
+      x-speakeasy-param-readonly: true
   - target: $["components"]["schemas"]["Workspace"]
     update:
       x-speakeasy-entity: Workspace


### PR DESCRIPTION
## Description

Mark dateCreated and lastUpdated fields of workspaces as read only with a speakeasy overlay. While the Seqera Platform API accepts a payload containing these values, they are ignored by Seqera Platform and are automatically generated. This would cause constant drifting in terraform, if specified, since the state would contain the auto generated values. Technically this is a breaking change, because projects supplying values for those fields will fail at the plan phase. Migration would be simply removing those fields form the resource definition, but I doubt anybody is setting these values or they would constantly delete and recreate workspaces at every apply.

### Alternative approach

We could (and should) mark these fields as read-only in the API schema directly, but that also could be considered a breaking change, and API breaking change might have more unforseen consequences