### PR TITLE
fix(bitbucket-credential): expose password for app-password auth; refine git credential docs

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -13,6 +13,8 @@ internal/sdk/internal/hooks/token_list_error_hook.go
 # Custom validators
 internal/validators/mapvalidators/studio_environment_variable_validator.go
 internal/validators/objectvalidators/config_env_variable_validator.go
+internal/validators/stringvalidators/bitbucket_password_validator.go
+internal/validators/stringvalidators/bitbucket_token_validator.go
 internal/validators/stringvalidators/aws_credential_keys_validator.go
 internal/validators/stringvalidators/google_credential_keys_validator.go
 internal/validators/stringvalidators/instance_type_size_validator.go

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 2dcbcb273547e2b56e9375cff6cbf8a5
+  docChecksum: 3f9b445fa37f16d3aec24b217ee643e3
   docVersion: 1.147.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
@@ -473,7 +473,7 @@ trackedFiles:
     pristine_git_object: 62f301e24df9501920ae8a9afe8ae7927b82a862
   internal/provider/bitbucketcredential_resource.go:
     id: 99461a76ba60
-    last_write_checksum: sha1:34aacbd1bf955f7bccc4b66e43fea69abc8feeb9
+    last_write_checksum: sha1:e0429d833c03de274091ee5b19de3038d564b592
     pristine_git_object: ef48989850ba46b7641a28a14055504c1737a53c
   internal/provider/bitbucketcredential_resource_sdk.go:
     id: ea250abc2a72
@@ -481,7 +481,7 @@ trackedFiles:
     pristine_git_object: 8a0bebdcdd3d64be9a83a6a75aa5bc0422f8f3ff
   internal/provider/codecommitcredential_resource.go:
     id: 22c2e9aa4b13
-    last_write_checksum: sha1:9a496a9dcd5e9800675e2f44603a5d1bb30edb58
+    last_write_checksum: sha1:e91652ea75fd58954aab173c976e5f309d24b5ff
     pristine_git_object: 58dcb06c3f42ed4aa8f5bf250a2b70ed4ad235ed
   internal/provider/codecommitcredential_resource_sdk.go:
     id: dcc60e154878
@@ -553,7 +553,7 @@ trackedFiles:
     last_write_checksum: sha1:412c24d954db792925ec76ad94c227be0a624308
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
-    last_write_checksum: sha1:b8109cc363fff3bf33b3ad462f7f3ce01927ab68
+    last_write_checksum: sha1:d020d1a14e329671676b008504023424d5aa1c5c
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
@@ -561,7 +561,7 @@ trackedFiles:
     pristine_git_object: 71e29ff10c22205eab4418ac0b8a92152cc5b23d
   internal/provider/githubcredential_resource.go:
     id: e1f090a0cb9e
-    last_write_checksum: sha1:4c930421baa51adf6863b0415b7df297d90e378b
+    last_write_checksum: sha1:51e774b13b7ae0ea1c96ff69ce07f5964ea5171a
     pristine_git_object: c6a4da7de3d8a1ca06c268021bcb56ba09f3c9f1
   internal/provider/githubcredential_resource_sdk.go:
     id: bc2bee614a62
@@ -569,7 +569,7 @@ trackedFiles:
     pristine_git_object: 01c4b02c388b5caf56516bd71e9a2176973234b2
   internal/provider/gitlabcredential_resource.go:
     id: fcb86103d097
-    last_write_checksum: sha1:f0a497d414dffb5bc37777668cf8886f69b33fa3
+    last_write_checksum: sha1:ded1df7d5778dd4b89755c235b25fdd9e4b0d80f
     pristine_git_object: 5b27290c979fb073cf156f1babc37c36cde9ab8e
   internal/provider/gitlabcredential_resource_sdk.go:
     id: a6c217015659
@@ -2383,7 +2383,7 @@ trackedFiles:
     pristine_git_object: a19c8ae0ccb9dac4d7e8a63edfa348c0b6b3b3b2
   internal/sdk/models/shared/bitbucketcredential.go:
     id: 7dd213344297
-    last_write_checksum: sha1:6dc4790f50754b97608e2e455c9ed1ccca330279
+    last_write_checksum: sha1:0e6dd2e4f2f0cf6d81d6cef5ec8d314ff76451dd
     pristine_git_object: 4640c93ca517620630d52210c4f3c131d9acdd31
   internal/sdk/models/shared/bucket.go:
     id: c799c619a5f3
@@ -2407,7 +2407,7 @@ trackedFiles:
     pristine_git_object: cc8547dd4b50e53073c00a2e2f3181a9fd23786a
   internal/sdk/models/shared/codecommitcredential.go:
     id: 5344cf634ea1
-    last_write_checksum: sha1:71a626893d98e9deb7568e66ed1625fcfdf31abb
+    last_write_checksum: sha1:9a8ff7eeea5d4e4fc537a4e7ba2ad7ad598490b9
     pristine_git_object: 168da50a9909ad4639d68c4ef0cb63bf647d949b
   internal/sdk/models/shared/computeconfig.go:
     last_write_checksum: sha1:4ff1675b2e7a0ecc77570aeb5dabf311f751b2cb
@@ -3113,7 +3113,7 @@ trackedFiles:
     pristine_git_object: f2dfcf01b5586b5f4fabf4179fc9f48717d201d9
   internal/sdk/models/shared/giteacredential.go:
     id: dfce6a8fcdf0
-    last_write_checksum: sha1:93fcbd4e53ef344a2601980c081b2bd799a52326
+    last_write_checksum: sha1:e62e82ec596c84892d1d46402511c998ca0dde07
     pristine_git_object: 7637ba2ec7d6a8ecf7312350d60e081f096f9a96
   internal/sdk/models/shared/githubactionconfig.go:
     id: f9c267b87cce
@@ -3125,11 +3125,11 @@ trackedFiles:
     pristine_git_object: 17c90fd61a9fdd0f3467eccfeab719d950ad8d75
   internal/sdk/models/shared/githubcredential.go:
     id: ff7ad720d02c
-    last_write_checksum: sha1:11593582fcd11e54941f472ffdaf3fb9b912e434
+    last_write_checksum: sha1:40f553bdfc808f94b2c511e9521b1631d386dcae
     pristine_git_object: 79b31488d52fa8ac1243a3872b8897e67b34dd4b
   internal/sdk/models/shared/gitlabcredential.go:
     id: 22d18787c458
-    last_write_checksum: sha1:d3b81298c874a7901d0fd934f1ca4b959576a702
+    last_write_checksum: sha1:43f9370a5b6bb106e153100e436d7ed980003404
     pristine_git_object: 05f9c000d0738657deb5c5f3bee3445ac5780f92
   internal/sdk/models/shared/gkeplatformmetainfo.go:
     id: e8e0a0401118

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,10 +1,10 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 01318fe35f2b468ba80afe08088bd970
+  docChecksum: 2dcbcb273547e2b56e9375cff6cbf8a5
   docVersion: 1.147.0
-  speakeasyVersion: 1.761.11
-  generationVersion: 2.881.17
+  speakeasyVersion: 1.762.0
+  generationVersion: 2.882.0
   releaseVersion: 0.40.0-RC2
   configChecksum: c77908dbe8aa95c668e0cdc1862e3c7f
 persistentEdits:
@@ -473,15 +473,15 @@ trackedFiles:
     pristine_git_object: 62f301e24df9501920ae8a9afe8ae7927b82a862
   internal/provider/bitbucketcredential_resource.go:
     id: 99461a76ba60
-    last_write_checksum: sha1:1d5dae518b5de9ed6a3b9ace4a4b1c3df7301962
+    last_write_checksum: sha1:34aacbd1bf955f7bccc4b66e43fea69abc8feeb9
     pristine_git_object: ef48989850ba46b7641a28a14055504c1737a53c
   internal/provider/bitbucketcredential_resource_sdk.go:
     id: ea250abc2a72
-    last_write_checksum: sha1:4d21f18905224f7273dd1087df0656331ac860f0
+    last_write_checksum: sha1:155f0083160e07ce4ad7dad16aa9cc63e1570d5e
     pristine_git_object: 8a0bebdcdd3d64be9a83a6a75aa5bc0422f8f3ff
   internal/provider/codecommitcredential_resource.go:
     id: 22c2e9aa4b13
-    last_write_checksum: sha1:e919dfed021e52087fc3b4df37aff92ec2a175de
+    last_write_checksum: sha1:9a496a9dcd5e9800675e2f44603a5d1bb30edb58
     pristine_git_object: 58dcb06c3f42ed4aa8f5bf250a2b70ed4ad235ed
   internal/provider/codecommitcredential_resource_sdk.go:
     id: dcc60e154878
@@ -553,7 +553,7 @@ trackedFiles:
     last_write_checksum: sha1:412c24d954db792925ec76ad94c227be0a624308
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
-    last_write_checksum: sha1:6ae8d03e115448f05d1455a0ee2f1f6811ab29f9
+    last_write_checksum: sha1:b8109cc363fff3bf33b3ad462f7f3ce01927ab68
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
@@ -561,7 +561,7 @@ trackedFiles:
     pristine_git_object: 71e29ff10c22205eab4418ac0b8a92152cc5b23d
   internal/provider/githubcredential_resource.go:
     id: e1f090a0cb9e
-    last_write_checksum: sha1:188312fea5a86ad334c087ac2392ba63d38f2c2a
+    last_write_checksum: sha1:4c930421baa51adf6863b0415b7df297d90e378b
     pristine_git_object: c6a4da7de3d8a1ca06c268021bcb56ba09f3c9f1
   internal/provider/githubcredential_resource_sdk.go:
     id: bc2bee614a62
@@ -569,7 +569,7 @@ trackedFiles:
     pristine_git_object: 01c4b02c388b5caf56516bd71e9a2176973234b2
   internal/provider/gitlabcredential_resource.go:
     id: fcb86103d097
-    last_write_checksum: sha1:62ad11d73226d6163a03a9bb3262194871bb3453
+    last_write_checksum: sha1:f0a497d414dffb5bc37777668cf8886f69b33fa3
     pristine_git_object: 5b27290c979fb073cf156f1babc37c36cde9ab8e
   internal/provider/gitlabcredential_resource_sdk.go:
     id: a6c217015659
@@ -2383,7 +2383,7 @@ trackedFiles:
     pristine_git_object: a19c8ae0ccb9dac4d7e8a63edfa348c0b6b3b3b2
   internal/sdk/models/shared/bitbucketcredential.go:
     id: 7dd213344297
-    last_write_checksum: sha1:82cca74f0f2ce6d853aa3d9cf905de1073578ec4
+    last_write_checksum: sha1:6dc4790f50754b97608e2e455c9ed1ccca330279
     pristine_git_object: 4640c93ca517620630d52210c4f3c131d9acdd31
   internal/sdk/models/shared/bucket.go:
     id: c799c619a5f3
@@ -2407,7 +2407,7 @@ trackedFiles:
     pristine_git_object: cc8547dd4b50e53073c00a2e2f3181a9fd23786a
   internal/sdk/models/shared/codecommitcredential.go:
     id: 5344cf634ea1
-    last_write_checksum: sha1:3441fcab6ab8f43df13f9d3cd4fdfc3f037c126f
+    last_write_checksum: sha1:71a626893d98e9deb7568e66ed1625fcfdf31abb
     pristine_git_object: 168da50a9909ad4639d68c4ef0cb63bf647d949b
   internal/sdk/models/shared/computeconfig.go:
     last_write_checksum: sha1:4ff1675b2e7a0ecc77570aeb5dabf311f751b2cb
@@ -3113,7 +3113,7 @@ trackedFiles:
     pristine_git_object: f2dfcf01b5586b5f4fabf4179fc9f48717d201d9
   internal/sdk/models/shared/giteacredential.go:
     id: dfce6a8fcdf0
-    last_write_checksum: sha1:11aa2dfc12378b7538670c6872af00bf1ccef2f8
+    last_write_checksum: sha1:93fcbd4e53ef344a2601980c081b2bd799a52326
     pristine_git_object: 7637ba2ec7d6a8ecf7312350d60e081f096f9a96
   internal/sdk/models/shared/githubactionconfig.go:
     id: f9c267b87cce
@@ -3125,11 +3125,11 @@ trackedFiles:
     pristine_git_object: 17c90fd61a9fdd0f3467eccfeab719d950ad8d75
   internal/sdk/models/shared/githubcredential.go:
     id: ff7ad720d02c
-    last_write_checksum: sha1:69684164e86bc1ec2d46f22de13455756be17867
+    last_write_checksum: sha1:11593582fcd11e54941f472ffdaf3fb9b912e434
     pristine_git_object: 79b31488d52fa8ac1243a3872b8897e67b34dd4b
   internal/sdk/models/shared/gitlabcredential.go:
     id: 22d18787c458
-    last_write_checksum: sha1:1e9b87549b018de105bc8fd9e6805f01faedc8e3
+    last_write_checksum: sha1:d3b81298c874a7901d0fd934f1ca4b959576a702
     pristine_git_object: 05f9c000d0738657deb5c5f3bee3445ac5780f92
   internal/sdk/models/shared/gkeplatformmetainfo.go:
     id: e8e0a0401118
@@ -3911,7 +3911,7 @@ trackedFiles:
     last_write_checksum: sha1:84fef173ddc771401f52a4c084d5a3e1b07f776e
   internal/sdk/seqera.go:
     id: b1c23bc5193c
-    last_write_checksum: sha1:d5642398b46a0fd953805293f4e72713a552e0e3
+    last_write_checksum: sha1:3a09040a82da5ad5446ffe297629b3dce887868e
     pristine_git_object: 89364ed6208c4c999b317d23d7d954d63ac46bc5
   internal/sdk/serviceinfo.go:
     id: 085db9a15b34
@@ -4531,7 +4531,7 @@ examples:
   CreateBitbucketCredentials:
     speakeasy-default-create-bitbucket-credentials:
       requestBody:
-        application/json: {"credentials": {"name": "<value>", "provider": "bitbucket", "baseUrl": "https://bitbucket.org/myorg", "keys": {"username": "myuser@example.com", "token": "ATBB..."}}}
+        application/json: {"credentials": {"name": "<value>", "provider": "bitbucket", "baseUrl": "https://bitbucket.org/myorg", "keys": {"username": "myuser@example.com", "password": "BBDC-...", "token": "ATBB..."}}}
       responses:
         "200":
           application/json: {}
@@ -4553,7 +4553,7 @@ examples:
         path:
           credentialsId: "<id>"
       requestBody:
-        application/json: {"credentials": {"name": "<value>", "provider": "bitbucket", "baseUrl": "https://bitbucket.org/myorg", "keys": {"username": "myuser@example.com", "token": "ATBB..."}}}
+        application/json: {"credentials": {"name": "<value>", "provider": "bitbucket", "baseUrl": "https://bitbucket.org/myorg", "keys": {"username": "myuser@example.com", "password": "BBDC-...", "token": "ATBB..."}}}
       responses:
         "400":
           application/json: {"message": "<value>"}

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 3f9b445fa37f16d3aec24b217ee643e3
+  docChecksum: f0115aa3d428640f1521547a715cc5f7
   docVersion: 1.147.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
@@ -553,7 +553,7 @@ trackedFiles:
     last_write_checksum: sha1:412c24d954db792925ec76ad94c227be0a624308
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
-    last_write_checksum: sha1:d020d1a14e329671676b008504023424d5aa1c5c
+    last_write_checksum: sha1:3274fc24e8054c69230765729ad456d66f4fae50
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
@@ -3113,7 +3113,7 @@ trackedFiles:
     pristine_git_object: f2dfcf01b5586b5f4fabf4179fc9f48717d201d9
   internal/sdk/models/shared/giteacredential.go:
     id: dfce6a8fcdf0
-    last_write_checksum: sha1:e62e82ec596c84892d1d46402511c998ca0dde07
+    last_write_checksum: sha1:7282b2a6760534ad4f84413596a79c70a14accfd
     pristine_git_object: 7637ba2ec7d6a8ecf7312350d60e081f096f9a96
   internal/sdk/models/shared/githubactionconfig.go:
     id: f9c267b87cce

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -23524,7 +23524,7 @@ components:
               x-speakeasy-param-computed: false
             password:
               type: string
-              description: Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.
+              description: Gitea account password or personal access token (sensitive).
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: mypassword

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -23041,8 +23041,8 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for on-premises Bitbucket server (optional). Example: https://bitbucket.org/seqeralabs'
-          example: https://bitbucket.org/myorg
+          description: 'Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1'
+          example: https://bitbucket.org/seqeralabs/repo1
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
         keys:
@@ -23061,18 +23061,26 @@ components:
           type: object
           required:
             - username
-            - token
           properties:
             username:
               type: string
-              description: Bitbucket account username (for app passwords) or email (for API tokens). Required.
+              description: Bitbucket account username (for app passwords) or email (for API tokens).
               example: myuser@example.com
               x-speakeasy-param-computed: false
-            token:
+            password:
               type: string
-              description: Bitbucket API token (required, sensitive). App passwords are deprecated.
+              description: Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with `token`.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
+              x-speakeasy-plan-validators: BitbucketPasswordValidator
+              example: BBDC-...
+              writeOnly: true
+            token:
+              type: string
+              description: Bitbucket API token (sensitive). Mutually exclusive with `password`.
+              x-speakeasy-param-sensitive: true
+              x-speakeasy-terraform-write-only: true
+              x-speakeasy-plan-validators: BitbucketTokenValidator
               example: ATBB...
               writeOnly: true
     CreateBitbucketCredentialsRequest:
@@ -23148,7 +23156,7 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for AWS CodeCommit (optional). Example: https://git-codecommit.us-east-1.amazonaws.com'
+          description: 'Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com'
           example: https://git-codecommit.us-east-1.amazonaws.com
           x-speakeasy-param-computed: true
           x-speakeasy-name-override: base_url
@@ -23172,13 +23180,13 @@ components:
           properties:
             username:
               type: string
-              description: AWS Access Key ID for CodeCommit (required)
+              description: AWS IAM access key ID for CodeCommit.
               example: AKIAIOSFODNN7EXAMPLE
               x-speakeasy-param-computed: false
               x-speakeasy-name-override: access_key
             password:
               type: string
-              description: AWS Secret Access Key for CodeCommit (required, sensitive)
+              description: AWS IAM secret access key for CodeCommit (sensitive).
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -23488,7 +23496,7 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for Gitea server (optional). Example: https://gitea.mycompany.com'
+          description: 'Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com'
           example: https://gitea.mycompany.com
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -23511,12 +23519,12 @@ components:
           properties:
             username:
               type: string
-              description: Gitea account username (required)
+              description: Gitea account username.
               example: myuser
               x-speakeasy-param-computed: false
             password:
               type: string
-              description: Gitea account password (required, sensitive)
+              description: Gitea account password (sensitive).
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: mypassword
@@ -23594,8 +23602,8 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for GitHub Enterprise Server (optional). Leave empty for GitHub.com. Example: https://github.mycompany.com'
-          example: https://github.mycompany.com
+          description: 'Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs'
+          example: https://github.com/seqeralabs
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
         keys:
@@ -23618,11 +23626,11 @@ components:
           properties:
             username:
               type: string
-              description: GitHub username associated with the Personal Access Token (required)
+              description: GitHub account username associated with the access token.
               example: octocat
             password:
               type: string
-              description: GitHub Personal Access Token (PAT) for authentication (required, sensitive)
+              description: GitHub Personal Access Token (PAT) — classic or fine-grained — with `repo` scope. Sensitive.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: ghp_1234567890abcdefghijklmnopqrstuvwxyz
@@ -23701,8 +23709,8 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for self-hosted GitLab server (optional). Leave empty for GitLab.com. Example: https://gitlab.mycompany.com'
-          example: https://gitlab.mycompany.com
+          description: 'Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs'
+          example: https://gitlab.com/seqeralabs
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
         keys:
@@ -23725,11 +23733,11 @@ components:
           properties:
             username:
               type: string
-              description: GitLab username associated with the Personal Access Token (required)
+              description: GitLab account username associated with the access token.
               example: gitlab-user
             token:
               type: string
-              description: GitLab Personal Access Token or Project Access Token (required, sensitive)
+              description: GitLab access token (Personal, Group, or Project). Requires `api`, `read_api`, and `read_repository` scopes. Sensitive.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: glpat-xxxxxxxxxxxxxxxxxxxx

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -23041,7 +23041,7 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1'
+          description: 'Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated Bitbucket credential is used. Example: https://bitbucket.org/seqeralabs/repo1'
           example: https://bitbucket.org/seqeralabs/repo1
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -23069,7 +23069,7 @@ components:
               x-speakeasy-param-computed: false
             password:
               type: string
-              description: Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with `token`.
+              description: Bitbucket app password or HTTP password (sensitive). Generate app passwords from Bitbucket account settings. Mutually exclusive with `token`.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               x-speakeasy-plan-validators: BitbucketPasswordValidator
@@ -23156,7 +23156,7 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com'
+          description: 'Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated CodeCommit credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com'
           example: https://git-codecommit.us-east-1.amazonaws.com
           x-speakeasy-param-computed: true
           x-speakeasy-name-override: base_url
@@ -23496,7 +23496,7 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com'
+          description: 'Repository base URL for the self-hosted Gitea instance (required by the credential validator). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. Example: https://gitea.mycompany.com'
           example: https://gitea.mycompany.com
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -23524,7 +23524,7 @@ components:
               x-speakeasy-param-computed: false
             password:
               type: string
-              description: Gitea account password (sensitive).
+              description: Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: mypassword
@@ -23602,7 +23602,7 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs'
+          description: 'Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitHub credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs'
           example: https://github.com/seqeralabs
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -23630,7 +23630,7 @@ components:
               example: octocat
             password:
               type: string
-              description: GitHub Personal Access Token (PAT) — classic or fine-grained — with `repo` scope. Sensitive.
+              description: GitHub Personal Access Token (PAT) — classic or fine-grained. Typically requires `repo` scope; the backend does not enforce specific scopes. Sensitive.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: ghp_1234567890abcdefghijklmnopqrstuvwxyz
@@ -23709,7 +23709,7 @@ components:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs'
+          description: 'Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitLab credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs'
           example: https://gitlab.com/seqeralabs
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -23737,7 +23737,7 @@ components:
               example: gitlab-user
             token:
               type: string
-              description: GitLab access token (Personal, Group, or Project). Requires `api`, `read_api`, and `read_repository` scopes. Sensitive.
+              description: GitLab access token (Personal, Group, or Project). Used by Seqera to authenticate against the GitLab API. Recommended scopes are `api`, `read_api`, and `read_repository`, though the backend does not strictly enforce them. Sensitive.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: glpat-xxxxxxxxxxxxxxxxxxxx

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:3c997a50220899449a79f6f7735ea1be375f4e6b16787a8f14a2590acd3f3908
-        sourceBlobDigest: sha256:55db86ea911c6fa334c892a87bfd1fc55322e607f4fbfa947081aff7d9e20428
+        sourceRevisionDigest: sha256:63a340a605c71b9e7cc23af2345e7a59fa8842c9c47087ed9c14db1c081078a1
+        sourceBlobDigest: sha256:db23314e8d537165f250194c124c535872cc29c6a129a1226e687ab46cbab2cf
         tags:
             - latest
             - 1.147.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:3c997a50220899449a79f6f7735ea1be375f4e6b16787a8f14a2590acd3f3908
-        sourceBlobDigest: sha256:55db86ea911c6fa334c892a87bfd1fc55322e607f4fbfa947081aff7d9e20428
+        sourceRevisionDigest: sha256:63a340a605c71b9e7cc23af2345e7a59fa8842c9c47087ed9c14db1c081078a1
+        sourceBlobDigest: sha256:db23314e8d537165f250194c124c535872cc29c6a129a1226e687ab46cbab2cf
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:82f5d126b64024179d13ed826181b2458e24937b9cd316fbe603ffd8e28af1f2
-        sourceBlobDigest: sha256:758402ce0c87e52ec6a2926716a2c8b77c7e8ada4404a38a2fd0d412c8ce48c9
+        sourceRevisionDigest: sha256:3c997a50220899449a79f6f7735ea1be375f4e6b16787a8f14a2590acd3f3908
+        sourceBlobDigest: sha256:55db86ea911c6fa334c892a87bfd1fc55322e607f4fbfa947081aff7d9e20428
         tags:
             - latest
             - 1.147.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:82f5d126b64024179d13ed826181b2458e24937b9cd316fbe603ffd8e28af1f2
-        sourceBlobDigest: sha256:758402ce0c87e52ec6a2926716a2c8b77c7e8ada4404a38a2fd0d412c8ce48c9
+        sourceRevisionDigest: sha256:3c997a50220899449a79f6f7735ea1be375f4e6b16787a8f14a2590acd3f3908
+        sourceBlobDigest: sha256:55db86ea911c6fa334c892a87bfd1fc55322e607f4fbfa947081aff7d9e20428
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.761.11
+speakeasyVersion: 1.762.0
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:e790b833ab8aa0defb152b8d491dbfe92c9f62041e91026fd7322ea0ed1e153c
-        sourceBlobDigest: sha256:54f3b7833ee129c5b6d833b8e51dfc235dd96dec52e24a73f1f5ac45d1ad3769
+        sourceRevisionDigest: sha256:82f5d126b64024179d13ed826181b2458e24937b9cd316fbe603ffd8e28af1f2
+        sourceBlobDigest: sha256:758402ce0c87e52ec6a2926716a2c8b77c7e8ada4404a38a2fd0d412c8ce48c9
         tags:
             - latest
             - 1.147.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:e790b833ab8aa0defb152b8d491dbfe92c9f62041e91026fd7322ea0ed1e153c
-        sourceBlobDigest: sha256:54f3b7833ee129c5b6d833b8e51dfc235dd96dec52e24a73f1f5ac45d1ad3769
+        sourceRevisionDigest: sha256:82f5d126b64024179d13ed826181b2458e24937b9cd316fbe603ffd8e28af1f2
+        sourceBlobDigest: sha256:758402ce0c87e52ec6a2926716a2c8b77c7e8ada4404a38a2fd0d412c8ce48c9
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/docs/resources/bitbucket_credential.md
+++ b/docs/resources/bitbucket_credential.md
@@ -48,8 +48,8 @@ resource "seqera_bitbucket_credential" "example" {
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `base_url` (String) Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1
-- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with `token`.
+- `base_url` (String) Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated Bitbucket credential is used. Example: https://bitbucket.org/seqeralabs/repo1
+- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Bitbucket app password or HTTP password (sensitive). Generate app passwords from Bitbucket account settings. Mutually exclusive with `token`.
 - `token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Bitbucket API token (sensitive). Mutually exclusive with `password`.
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 

--- a/docs/resources/bitbucket_credential.md
+++ b/docs/resources/bitbucket_credential.md
@@ -32,6 +32,7 @@ resource "seqera_bitbucket_credential" "example" {
 
   username = var.bitbucket_username
   password = var.bitbucket_password
+  base_url = "https://bitbucket.org/seqeralabs"
 }
 ```
 
@@ -40,15 +41,16 @@ resource "seqera_bitbucket_credential" "example" {
 
 ### Required
 
-> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
-
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
-- `token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Bitbucket API token (required, sensitive). App passwords are deprecated.
-- `username` (String) Bitbucket account username (for app passwords) or email (for API tokens). Required.
+- `username` (String) Bitbucket account username (for app passwords) or email (for API tokens).
 
 ### Optional
 
-- `base_url` (String) Repository base URL for on-premises Bitbucket server (optional). Example: https://bitbucket.org/seqeralabs
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
+- `base_url` (String) Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1
+- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with `token`.
+- `token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Bitbucket API token (sensitive). Mutually exclusive with `password`.
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/docs/resources/codecommit_credential.md
+++ b/docs/resources/codecommit_credential.md
@@ -49,7 +49,7 @@ resource "seqera_codecommit_credential" "example" {
 
 ### Optional
 
-- `base_url` (String) Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
+- `base_url` (String) Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated CodeCommit credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/docs/resources/codecommit_credential.md
+++ b/docs/resources/codecommit_credential.md
@@ -17,11 +17,11 @@ AWS Codecommit repositories within the Seqera Platform workflows.
 ## Example Usage
 
 ```terraform
-variable "codecommit_username" {
+variable "codecommit_access_key" {
   type = string
 }
 
-variable "codecommit_password" {
+variable "codecommit_secret_key" {
   type      = string
   sensitive = true
 }
@@ -30,8 +30,9 @@ resource "seqera_codecommit_credential" "example" {
   name         = "codecommit-main"
   workspace_id = seqera_workspace.main.id
 
-  username = var.codecommit_username
-  password = var.codecommit_password
+  access_key = var.codecommit_access_key
+  secret_key = var.codecommit_secret_key
+  base_url   = "https://git-codecommit.eu-west-1.amazonaws.com"
 }
 ```
 
@@ -42,13 +43,13 @@ resource "seqera_codecommit_credential" "example" {
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `access_key` (String) AWS Access Key ID for CodeCommit (required)
+- `access_key` (String) AWS IAM access key ID for CodeCommit.
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
-- `secret_key` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) AWS Secret Access Key for CodeCommit (required, sensitive)
+- `secret_key` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) AWS IAM secret access key for CodeCommit (sensitive).
 
 ### Optional
 
-- `base_url` (String) Repository base URL for AWS CodeCommit (optional). Example: https://git-codecommit.us-east-1.amazonaws.com
+- `base_url` (String) Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/docs/resources/gitea_credential.md
+++ b/docs/resources/gitea_credential.md
@@ -44,7 +44,7 @@ resource "seqera_gitea_credential" "example" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
-- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.
+- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Gitea account password or personal access token (sensitive).
 - `username` (String) Gitea account username.
 
 ### Optional

--- a/docs/resources/gitea_credential.md
+++ b/docs/resources/gitea_credential.md
@@ -44,12 +44,12 @@ resource "seqera_gitea_credential" "example" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
-- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Gitea account password (sensitive).
+- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.
 - `username` (String) Gitea account username.
 
 ### Optional
 
-- `base_url` (String) Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com
+- `base_url` (String) Repository base URL for the self-hosted Gitea instance (required by the credential validator). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. Example: https://gitea.mycompany.com
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/docs/resources/gitea_credential.md
+++ b/docs/resources/gitea_credential.md
@@ -44,12 +44,12 @@ resource "seqera_gitea_credential" "example" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
-- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Gitea account password (required, sensitive)
-- `username` (String) Gitea account username (required)
+- `password` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Gitea account password (sensitive).
+- `username` (String) Gitea account username.
 
 ### Optional
 
-- `base_url` (String) Repository base URL for Gitea server (optional). Example: https://gitea.mycompany.com
+- `base_url` (String) Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/docs/resources/github_credential.md
+++ b/docs/resources/github_credential.md
@@ -32,6 +32,7 @@ resource "seqera_github_credential" "example" {
 
   username     = var.github_username
   access_token = var.github_access_token
+  base_url     = "https://github.com/seqeralabs"
 }
 ```
 
@@ -64,13 +65,13 @@ resource "seqera_github_credential" "enterprise" {
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `access_token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) GitHub Personal Access Token (PAT) for authentication (required, sensitive)
+- `access_token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) GitHub Personal Access Token (PAT) — classic or fine-grained — with `repo` scope. Sensitive.
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
-- `username` (String) GitHub username associated with the Personal Access Token (required)
+- `username` (String) GitHub account username associated with the access token.
 
 ### Optional
 
-- `base_url` (String) Repository base URL for GitHub Enterprise Server (optional). Leave empty for GitHub.com. Example: https://github.mycompany.com
+- `base_url` (String) Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/docs/resources/github_credential.md
+++ b/docs/resources/github_credential.md
@@ -65,13 +65,13 @@ resource "seqera_github_credential" "enterprise" {
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `access_token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) GitHub Personal Access Token (PAT) — classic or fine-grained — with `repo` scope. Sensitive.
+- `access_token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) GitHub Personal Access Token (PAT) — classic or fine-grained. Typically requires `repo` scope; the backend does not enforce specific scopes. Sensitive.
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
 - `username` (String) GitHub account username associated with the access token.
 
 ### Optional
 
-- `base_url` (String) Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
+- `base_url` (String) Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitHub credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/docs/resources/gitlab_credential.md
+++ b/docs/resources/gitlab_credential.md
@@ -66,12 +66,12 @@ resource "seqera_gitlab_credential" "self_hosted" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
-- `token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) GitLab access token (Personal, Group, or Project). Requires `api`, `read_api`, and `read_repository` scopes. Sensitive.
+- `token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) GitLab access token (Personal, Group, or Project). Used by Seqera to authenticate against the GitLab API. Recommended scopes are `api`, `read_api`, and `read_repository`, though the backend does not strictly enforce them. Sensitive.
 - `username` (String) GitLab account username associated with the access token.
 
 ### Optional
 
-- `base_url` (String) Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
+- `base_url` (String) Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitLab credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/docs/resources/gitlab_credential.md
+++ b/docs/resources/gitlab_credential.md
@@ -32,6 +32,7 @@ resource "seqera_gitlab_credential" "example" {
 
   username = var.gitlab_username
   token    = var.gitlab_token
+  base_url = "https://gitlab.com/seqeralabs"
 }
 ```
 
@@ -65,12 +66,12 @@ resource "seqera_gitlab_credential" "self_hosted" {
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
 - `name` (String) Display name for the credential. Must be 2-99 characters using only letters, numbers, underscores, and hyphens. No spaces allowed. Requires replacement if changed.
-- `token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) GitLab Personal Access Token or Project Access Token (required, sensitive)
-- `username` (String) GitLab username associated with the Personal Access Token (required)
+- `token` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) GitLab access token (Personal, Group, or Project). Requires `api`, `read_api`, and `read_repository` scopes. Sensitive.
+- `username` (String) GitLab account username associated with the access token.
 
 ### Optional
 
-- `base_url` (String) Repository base URL for self-hosted GitLab server (optional). Leave empty for GitLab.com. Example: https://gitlab.mycompany.com
+- `base_url` (String) Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Read-Only

--- a/examples/resources/seqera_bitbucket_credential/resource.tf
+++ b/examples/resources/seqera_bitbucket_credential/resource.tf
@@ -13,4 +13,5 @@ resource "seqera_bitbucket_credential" "example" {
 
   username = var.bitbucket_username
   password = var.bitbucket_password
+  base_url = "https://bitbucket.org/seqeralabs"
 }

--- a/examples/resources/seqera_codecommit_credential/resource.tf
+++ b/examples/resources/seqera_codecommit_credential/resource.tf
@@ -1,8 +1,8 @@
-variable "codecommit_username" {
+variable "codecommit_access_key" {
   type = string
 }
 
-variable "codecommit_password" {
+variable "codecommit_secret_key" {
   type      = string
   sensitive = true
 }
@@ -11,6 +11,7 @@ resource "seqera_codecommit_credential" "example" {
   name         = "codecommit-main"
   workspace_id = seqera_workspace.main.id
 
-  username = var.codecommit_username
-  password = var.codecommit_password
+  access_key = var.codecommit_access_key
+  secret_key = var.codecommit_secret_key
+  base_url   = "https://git-codecommit.eu-west-1.amazonaws.com"
 }

--- a/examples/resources/seqera_github_credential/resource.tf
+++ b/examples/resources/seqera_github_credential/resource.tf
@@ -13,4 +13,5 @@ resource "seqera_github_credential" "example" {
 
   username     = var.github_username
   access_token = var.github_access_token
+  base_url     = "https://github.com/seqeralabs"
 }

--- a/examples/resources/seqera_gitlab_credential/resource.tf
+++ b/examples/resources/seqera_gitlab_credential/resource.tf
@@ -13,4 +13,5 @@ resource "seqera_gitlab_credential" "example" {
 
   username = var.gitlab_username
   token    = var.gitlab_token
+  base_url = "https://gitlab.com/seqeralabs"
 }

--- a/internal/provider/bitbucketcredential_resource.go
+++ b/internal/provider/bitbucketcredential_resource.go
@@ -60,7 +60,7 @@ func (r *BitbucketCredentialResource) Schema(ctx context.Context, req resource.S
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{
 				Optional:    true,
-				Description: `Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1`,
+				Description: `Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a ` + "`" + `base_url` + "`" + `, the most recently updated Bitbucket credential is used. Example: https://bitbucket.org/seqeralabs/repo1`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,
@@ -85,7 +85,7 @@ func (r *BitbucketCredentialResource) Schema(ctx context.Context, req resource.S
 				Optional:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with ` + "`" + `token` + "`" + `.`,
+				Description: `Bitbucket app password or HTTP password (sensitive). Generate app passwords from Bitbucket account settings. Mutually exclusive with ` + "`" + `token` + "`" + `.`,
 				Validators: []validator.String{
 					custom_stringvalidators.BitbucketPasswordValidator(),
 				},

--- a/internal/provider/bitbucketcredential_resource.go
+++ b/internal/provider/bitbucketcredential_resource.go
@@ -19,6 +19,7 @@ import (
 	speakeasy_stringplanmodifier "github.com/seqeralabs/terraform-provider-seqera/internal/planmodifiers/stringplanmodifier"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk"
 	stateupgraders "github.com/seqeralabs/terraform-provider-seqera/internal/stateupgraders"
+	custom_stringvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/stringvalidators"
 	"regexp"
 )
 
@@ -41,6 +42,7 @@ type BitbucketCredentialResourceModel struct {
 	BaseURL       types.String `tfsdk:"base_url"`
 	CredentialsID types.String `tfsdk:"credentials_id"`
 	Name          types.String `tfsdk:"name"`
+	Password      types.String `tfsdk:"password"`
 	ProviderType  types.String `tfsdk:"provider_type"`
 	Token         types.String `tfsdk:"token"`
 	Username      types.String `tfsdk:"username"`
@@ -58,7 +60,7 @@ func (r *BitbucketCredentialResource) Schema(ctx context.Context, req resource.S
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{
 				Optional:    true,
-				Description: `Repository base URL for on-premises Bitbucket server (optional). Example: https://bitbucket.org/seqeralabs`,
+				Description: `Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,
@@ -79,20 +81,32 @@ func (r *BitbucketCredentialResource) Schema(ctx context.Context, req resource.S
 					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern "+regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).String()),
 				},
 			},
+			"password": schema.StringAttribute{
+				Optional:    true,
+				Sensitive:   true,
+				WriteOnly:   true,
+				Description: `Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with ` + "`" + `token` + "`" + `.`,
+				Validators: []validator.String{
+					custom_stringvalidators.BitbucketPasswordValidator(),
+				},
+			},
 			"provider_type": schema.StringAttribute{
 				Computed:    true,
 				Default:     stringdefault.StaticString(`bitbucket`),
 				Description: `Cloud provider type (automatically set to "bitbucket"). Default: "bitbucket"`,
 			},
 			"token": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `Bitbucket API token (required, sensitive). App passwords are deprecated.`,
+				Description: `Bitbucket API token (sensitive). Mutually exclusive with ` + "`" + `password` + "`" + `.`,
+				Validators: []validator.String{
+					custom_stringvalidators.BitbucketTokenValidator(),
+				},
 			},
 			"username": schema.StringAttribute{
 				Required:    true,
-				Description: `Bitbucket account username (for app passwords) or email (for API tokens). Required.`,
+				Description: `Bitbucket account username (for app passwords) or email (for API tokens).`,
 			},
 			"workspace_id": schema.Int64Attribute{
 				Optional: true,

--- a/internal/provider/bitbucketcredential_resource_sdk.go
+++ b/internal/provider/bitbucketcredential_resource_sdk.go
@@ -212,11 +212,21 @@ func (r *BitbucketCredentialResourceModel) ToSharedBitbucketCredentialKeys(ctx c
 	var username string
 	username = r.Username.ValueString()
 
-	var token string
-	token = opts.Config.Token.ValueString()
-
+	password := new(string)
+	if !opts.Config.Password.IsUnknown() && !opts.Config.Password.IsNull() {
+		*password = opts.Config.Password.ValueString()
+	} else {
+		password = nil
+	}
+	token := new(string)
+	if !opts.Config.Token.IsUnknown() && !opts.Config.Token.IsNull() {
+		*token = opts.Config.Token.ValueString()
+	} else {
+		token = nil
+	}
 	out := shared.BitbucketCredentialKeys{
 		Username: username,
+		Password: password,
 		Token:    token,
 	}
 

--- a/internal/provider/codecommitcredential_resource.go
+++ b/internal/provider/codecommitcredential_resource.go
@@ -58,12 +58,12 @@ func (r *CodecommitCredentialResource) Schema(ctx context.Context, req resource.
 		Attributes: map[string]schema.Attribute{
 			"access_key": schema.StringAttribute{
 				Required:    true,
-				Description: `AWS Access Key ID for CodeCommit (required)`,
+				Description: `AWS IAM access key ID for CodeCommit.`,
 			},
 			"base_url": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
-				Description: `Repository base URL for AWS CodeCommit (optional). Example: https://git-codecommit.us-east-1.amazonaws.com`,
+				Description: `Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,
@@ -93,7 +93,7 @@ func (r *CodecommitCredentialResource) Schema(ctx context.Context, req resource.
 				Required:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `AWS Secret Access Key for CodeCommit (required, sensitive)`,
+				Description: `AWS IAM secret access key for CodeCommit (sensitive).`,
 			},
 			"workspace_id": schema.Int64Attribute{
 				Optional: true,

--- a/internal/provider/codecommitcredential_resource.go
+++ b/internal/provider/codecommitcredential_resource.go
@@ -63,7 +63,7 @@ func (r *CodecommitCredentialResource) Schema(ctx context.Context, req resource.
 			"base_url": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
-				Description: `Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com`,
+				Description: `Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a ` + "`" + `base_url` + "`" + `, the most recently updated CodeCommit credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/giteacredential_resource.go
+++ b/internal/provider/giteacredential_resource.go
@@ -58,7 +58,7 @@ func (r *GiteaCredentialResource) Schema(ctx context.Context, req resource.Schem
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{
 				Optional:    true,
-				Description: `Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com`,
+				Description: `Repository base URL for the self-hosted Gitea instance (required by the credential validator). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is the longest prefix of the target repository URL; ties are broken by most recently updated. Example: https://gitea.mycompany.com`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,
@@ -83,7 +83,7 @@ func (r *GiteaCredentialResource) Schema(ctx context.Context, req resource.Schem
 				Required:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `Gitea account password (sensitive).`,
+				Description: `Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.`,
 			},
 			"provider_type": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/giteacredential_resource.go
+++ b/internal/provider/giteacredential_resource.go
@@ -58,7 +58,7 @@ func (r *GiteaCredentialResource) Schema(ctx context.Context, req resource.Schem
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{
 				Optional:    true,
-				Description: `Repository base URL for Gitea server (optional). Example: https://gitea.mycompany.com`,
+				Description: `Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,
@@ -83,7 +83,7 @@ func (r *GiteaCredentialResource) Schema(ctx context.Context, req resource.Schem
 				Required:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `Gitea account password (required, sensitive)`,
+				Description: `Gitea account password (sensitive).`,
 			},
 			"provider_type": schema.StringAttribute{
 				Computed:    true,
@@ -92,7 +92,7 @@ func (r *GiteaCredentialResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"username": schema.StringAttribute{
 				Required:    true,
-				Description: `Gitea account username (required)`,
+				Description: `Gitea account username.`,
 			},
 			"workspace_id": schema.Int64Attribute{
 				Optional: true,

--- a/internal/provider/giteacredential_resource.go
+++ b/internal/provider/giteacredential_resource.go
@@ -83,7 +83,7 @@ func (r *GiteaCredentialResource) Schema(ctx context.Context, req resource.Schem
 				Required:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.`,
+				Description: `Gitea account password or personal access token (sensitive).`,
 			},
 			"provider_type": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/githubcredential_resource.go
+++ b/internal/provider/githubcredential_resource.go
@@ -60,11 +60,11 @@ func (r *GithubCredentialResource) Schema(ctx context.Context, req resource.Sche
 				Required:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `GitHub Personal Access Token (PAT) for authentication (required, sensitive)`,
+				Description: `GitHub Personal Access Token (PAT) — classic or fine-grained — with ` + "`" + `repo` + "`" + ` scope. Sensitive.`,
 			},
 			"base_url": schema.StringAttribute{
 				Optional:    true,
-				Description: `Repository base URL for GitHub Enterprise Server (optional). Leave empty for GitHub.com. Example: https://github.mycompany.com`,
+				Description: `Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,
@@ -92,7 +92,7 @@ func (r *GithubCredentialResource) Schema(ctx context.Context, req resource.Sche
 			},
 			"username": schema.StringAttribute{
 				Required:    true,
-				Description: `GitHub username associated with the Personal Access Token (required)`,
+				Description: `GitHub account username associated with the access token.`,
 			},
 			"workspace_id": schema.Int64Attribute{
 				Optional: true,

--- a/internal/provider/githubcredential_resource.go
+++ b/internal/provider/githubcredential_resource.go
@@ -60,11 +60,11 @@ func (r *GithubCredentialResource) Schema(ctx context.Context, req resource.Sche
 				Required:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `GitHub Personal Access Token (PAT) — classic or fine-grained — with ` + "`" + `repo` + "`" + ` scope. Sensitive.`,
+				Description: `GitHub Personal Access Token (PAT) — classic or fine-grained. Typically requires ` + "`" + `repo` + "`" + ` scope; the backend does not enforce specific scopes. Sensitive.`,
 			},
 			"base_url": schema.StringAttribute{
 				Optional:    true,
-				Description: `Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs`,
+				Description: `Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a ` + "`" + `base_url` + "`" + `, the most recently updated GitHub credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,

--- a/internal/provider/gitlabcredential_resource.go
+++ b/internal/provider/gitlabcredential_resource.go
@@ -58,7 +58,7 @@ func (r *GitlabCredentialResource) Schema(ctx context.Context, req resource.Sche
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{
 				Optional:    true,
-				Description: `Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs`,
+				Description: `Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a ` + "`" + `base_url` + "`" + `, the most recently updated GitLab credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,
@@ -88,7 +88,7 @@ func (r *GitlabCredentialResource) Schema(ctx context.Context, req resource.Sche
 				Required:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `GitLab access token (Personal, Group, or Project). Requires ` + "`" + `api` + "`" + `, ` + "`" + `read_api` + "`" + `, and ` + "`" + `read_repository` + "`" + ` scopes. Sensitive.`,
+				Description: `GitLab access token (Personal, Group, or Project). Used by Seqera to authenticate against the GitLab API. Recommended scopes are ` + "`" + `api` + "`" + `, ` + "`" + `read_api` + "`" + `, and ` + "`" + `read_repository` + "`" + `, though the backend does not strictly enforce them. Sensitive.`,
 			},
 			"username": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/gitlabcredential_resource.go
+++ b/internal/provider/gitlabcredential_resource.go
@@ -58,7 +58,7 @@ func (r *GitlabCredentialResource) Schema(ctx context.Context, req resource.Sche
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{
 				Optional:    true,
-				Description: `Repository base URL for self-hosted GitLab server (optional). Leave empty for GitLab.com. Example: https://gitlab.mycompany.com`,
+				Description: `Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose ` + "`" + `base_url` + "`" + ` is most similar to the target repository; if no ` + "`" + `base_url` + "`" + ` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs`,
 			},
 			"credentials_id": schema.StringAttribute{
 				Computed: true,
@@ -88,11 +88,11 @@ func (r *GitlabCredentialResource) Schema(ctx context.Context, req resource.Sche
 				Required:    true,
 				Sensitive:   true,
 				WriteOnly:   true,
-				Description: `GitLab Personal Access Token or Project Access Token (required, sensitive)`,
+				Description: `GitLab access token (Personal, Group, or Project). Requires ` + "`" + `api` + "`" + `, ` + "`" + `read_api` + "`" + `, and ` + "`" + `read_repository` + "`" + ` scopes. Sensitive.`,
 			},
 			"username": schema.StringAttribute{
 				Required:    true,
-				Description: `GitLab username associated with the Personal Access Token (required)`,
+				Description: `GitLab account username associated with the access token.`,
 			},
 			"workspace_id": schema.Int64Attribute{
 				Optional: true,

--- a/internal/sdk/models/shared/bitbucketcredential.go
+++ b/internal/sdk/models/shared/bitbucketcredential.go
@@ -34,10 +34,12 @@ func (e *BitbucketCredentialProviderType) UnmarshalJSON(data []byte) error {
 }
 
 type BitbucketCredentialKeys struct {
-	// Bitbucket account username (for app passwords) or email (for API tokens). Required.
+	// Bitbucket account username (for app passwords) or email (for API tokens).
 	Username string `json:"username"`
-	// Bitbucket API token (required, sensitive). App passwords are deprecated.
-	Token string `json:"token"`
+	// Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with `token`.
+	Password *string `json:"password,omitempty"`
+	// Bitbucket API token (sensitive). Mutually exclusive with `password`.
+	Token *string `json:"token,omitempty"`
 }
 
 func (b *BitbucketCredentialKeys) GetUsername() string {
@@ -47,9 +49,16 @@ func (b *BitbucketCredentialKeys) GetUsername() string {
 	return b.Username
 }
 
-func (b *BitbucketCredentialKeys) GetToken() string {
+func (b *BitbucketCredentialKeys) GetPassword() *string {
 	if b == nil {
-		return ""
+		return nil
+	}
+	return b.Password
+}
+
+func (b *BitbucketCredentialKeys) GetToken() *string {
+	if b == nil {
+		return nil
 	}
 	return b.Token
 }
@@ -69,7 +78,7 @@ type BitbucketCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for on-premises Bitbucket server (optional). Example: https://bitbucket.org/seqeralabs
+	// Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1
 	BaseURL *string                 `json:"baseUrl,omitempty"`
 	Keys    BitbucketCredentialKeys `json:"keys"`
 }
@@ -149,7 +158,7 @@ func (b *BitbucketCredential) GetKeys() BitbucketCredentialKeys {
 }
 
 type BitbucketCredentialKeysOutput struct {
-	// Bitbucket account username (for app passwords) or email (for API tokens). Required.
+	// Bitbucket account username (for app passwords) or email (for API tokens).
 	Username string `json:"username"`
 }
 
@@ -175,7 +184,7 @@ type BitbucketCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for on-premises Bitbucket server (optional). Example: https://bitbucket.org/seqeralabs
+	// Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1
 	BaseURL *string                       `json:"baseUrl,omitempty"`
 	Keys    BitbucketCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/bitbucketcredential.go
+++ b/internal/sdk/models/shared/bitbucketcredential.go
@@ -36,7 +36,7 @@ func (e *BitbucketCredentialProviderType) UnmarshalJSON(data []byte) error {
 type BitbucketCredentialKeys struct {
 	// Bitbucket account username (for app passwords) or email (for API tokens).
 	Username string `json:"username"`
-	// Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with `token`.
+	// Bitbucket app password or HTTP password (sensitive). Generate app passwords from Bitbucket account settings. Mutually exclusive with `token`.
 	Password *string `json:"password,omitempty"`
 	// Bitbucket API token (sensitive). Mutually exclusive with `password`.
 	Token *string `json:"token,omitempty"`
@@ -78,7 +78,7 @@ type BitbucketCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1
+	// Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated Bitbucket credential is used. Example: https://bitbucket.org/seqeralabs/repo1
 	BaseURL *string                 `json:"baseUrl,omitempty"`
 	Keys    BitbucketCredentialKeys `json:"keys"`
 }
@@ -184,7 +184,7 @@ type BitbucketCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1
+	// Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated Bitbucket credential is used. Example: https://bitbucket.org/seqeralabs/repo1
 	BaseURL *string                       `json:"baseUrl,omitempty"`
 	Keys    BitbucketCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/codecommitcredential.go
+++ b/internal/sdk/models/shared/codecommitcredential.go
@@ -69,7 +69,7 @@ type CodecommitCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
+	// Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated CodeCommit credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
 	BaseURL *string                  `json:"baseUrl,omitempty"`
 	Keys    CodecommitCredentialKeys `json:"keys"`
 }
@@ -175,7 +175,7 @@ type CodecommitCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
+	// Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated CodeCommit credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
 	BaseURL *string                        `json:"baseUrl,omitempty"`
 	Keys    CodecommitCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/codecommitcredential.go
+++ b/internal/sdk/models/shared/codecommitcredential.go
@@ -34,9 +34,9 @@ func (e *CodecommitCredentialProviderType) UnmarshalJSON(data []byte) error {
 }
 
 type CodecommitCredentialKeys struct {
-	// AWS Access Key ID for CodeCommit (required)
+	// AWS IAM access key ID for CodeCommit.
 	AccessKey string `json:"username"`
-	// AWS Secret Access Key for CodeCommit (required, sensitive)
+	// AWS IAM secret access key for CodeCommit (sensitive).
 	SecretKey string `json:"password"`
 }
 
@@ -69,7 +69,7 @@ type CodecommitCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for AWS CodeCommit (optional). Example: https://git-codecommit.us-east-1.amazonaws.com
+	// Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
 	BaseURL *string                  `json:"baseUrl,omitempty"`
 	Keys    CodecommitCredentialKeys `json:"keys"`
 }
@@ -149,7 +149,7 @@ func (c *CodecommitCredential) GetKeys() CodecommitCredentialKeys {
 }
 
 type CodecommitCredentialKeysOutput struct {
-	// AWS Access Key ID for CodeCommit (required)
+	// AWS IAM access key ID for CodeCommit.
 	AccessKey string `json:"username"`
 }
 
@@ -175,7 +175,7 @@ type CodecommitCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for AWS CodeCommit (optional). Example: https://git-codecommit.us-east-1.amazonaws.com
+	// Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com
 	BaseURL *string                        `json:"baseUrl,omitempty"`
 	Keys    CodecommitCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/giteacredential.go
+++ b/internal/sdk/models/shared/giteacredential.go
@@ -34,9 +34,9 @@ func (e *GiteaCredentialProviderType) UnmarshalJSON(data []byte) error {
 }
 
 type GiteaCredentialKeys struct {
-	// Gitea account username (required)
+	// Gitea account username.
 	Username string `json:"username"`
-	// Gitea account password (required, sensitive)
+	// Gitea account password (sensitive).
 	Password string `json:"password"`
 }
 
@@ -69,7 +69,7 @@ type GiteaCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for Gitea server (optional). Example: https://gitea.mycompany.com
+	// Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com
 	BaseURL *string             `json:"baseUrl,omitempty"`
 	Keys    GiteaCredentialKeys `json:"keys"`
 }
@@ -149,7 +149,7 @@ func (g *GiteaCredential) GetKeys() GiteaCredentialKeys {
 }
 
 type GiteaCredentialKeysOutput struct {
-	// Gitea account username (required)
+	// Gitea account username.
 	Username string `json:"username"`
 }
 
@@ -175,7 +175,7 @@ type GiteaCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for Gitea server (optional). Example: https://gitea.mycompany.com
+	// Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com
 	BaseURL *string                   `json:"baseUrl,omitempty"`
 	Keys    GiteaCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/giteacredential.go
+++ b/internal/sdk/models/shared/giteacredential.go
@@ -36,7 +36,7 @@ func (e *GiteaCredentialProviderType) UnmarshalJSON(data []byte) error {
 type GiteaCredentialKeys struct {
 	// Gitea account username.
 	Username string `json:"username"`
-	// Gitea account password (sensitive).
+	// Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.
 	Password string `json:"password"`
 }
 
@@ -69,7 +69,7 @@ type GiteaCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com
+	// Repository base URL for the self-hosted Gitea instance (required by the credential validator). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. Example: https://gitea.mycompany.com
 	BaseURL *string             `json:"baseUrl,omitempty"`
 	Keys    GiteaCredentialKeys `json:"keys"`
 }
@@ -175,7 +175,7 @@ type GiteaCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com
+	// Repository base URL for the self-hosted Gitea instance (required by the credential validator). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. Example: https://gitea.mycompany.com
 	BaseURL *string                   `json:"baseUrl,omitempty"`
 	Keys    GiteaCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/giteacredential.go
+++ b/internal/sdk/models/shared/giteacredential.go
@@ -36,7 +36,7 @@ func (e *GiteaCredentialProviderType) UnmarshalJSON(data []byte) error {
 type GiteaCredentialKeys struct {
 	// Gitea account username.
 	Username string `json:"username"`
-	// Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.
+	// Gitea account password or personal access token (sensitive).
 	Password string `json:"password"`
 }
 

--- a/internal/sdk/models/shared/githubcredential.go
+++ b/internal/sdk/models/shared/githubcredential.go
@@ -36,7 +36,7 @@ func (e *GithubCredentialProviderType) UnmarshalJSON(data []byte) error {
 type GithubCredentialKeys struct {
 	// GitHub account username associated with the access token.
 	Username string `json:"username"`
-	// GitHub Personal Access Token (PAT) — classic or fine-grained — with `repo` scope. Sensitive.
+	// GitHub Personal Access Token (PAT) — classic or fine-grained. Typically requires `repo` scope; the backend does not enforce specific scopes. Sensitive.
 	AccessToken string `json:"password"`
 }
 
@@ -69,7 +69,7 @@ type GithubCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
+	// Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitHub credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
 	BaseURL *string              `json:"baseUrl,omitempty"`
 	Keys    GithubCredentialKeys `json:"keys"`
 }
@@ -175,7 +175,7 @@ type GithubCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
+	// Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitHub credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
 	BaseURL *string                    `json:"baseUrl,omitempty"`
 	Keys    GithubCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/githubcredential.go
+++ b/internal/sdk/models/shared/githubcredential.go
@@ -34,9 +34,9 @@ func (e *GithubCredentialProviderType) UnmarshalJSON(data []byte) error {
 }
 
 type GithubCredentialKeys struct {
-	// GitHub username associated with the Personal Access Token (required)
+	// GitHub account username associated with the access token.
 	Username string `json:"username"`
-	// GitHub Personal Access Token (PAT) for authentication (required, sensitive)
+	// GitHub Personal Access Token (PAT) — classic or fine-grained — with `repo` scope. Sensitive.
 	AccessToken string `json:"password"`
 }
 
@@ -69,7 +69,7 @@ type GithubCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for GitHub Enterprise Server (optional). Leave empty for GitHub.com. Example: https://github.mycompany.com
+	// Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
 	BaseURL *string              `json:"baseUrl,omitempty"`
 	Keys    GithubCredentialKeys `json:"keys"`
 }
@@ -149,7 +149,7 @@ func (g *GithubCredential) GetKeys() GithubCredentialKeys {
 }
 
 type GithubCredentialKeysOutput struct {
-	// GitHub username associated with the Personal Access Token (required)
+	// GitHub account username associated with the access token.
 	Username string `json:"username"`
 }
 
@@ -175,7 +175,7 @@ type GithubCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for GitHub Enterprise Server (optional). Leave empty for GitHub.com. Example: https://github.mycompany.com
+	// Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs
 	BaseURL *string                    `json:"baseUrl,omitempty"`
 	Keys    GithubCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/gitlabcredential.go
+++ b/internal/sdk/models/shared/gitlabcredential.go
@@ -36,7 +36,7 @@ func (e *GitlabCredentialProviderType) UnmarshalJSON(data []byte) error {
 type GitlabCredentialKeys struct {
 	// GitLab account username associated with the access token.
 	Username string `json:"username"`
-	// GitLab access token (Personal, Group, or Project). Requires `api`, `read_api`, and `read_repository` scopes. Sensitive.
+	// GitLab access token (Personal, Group, or Project). Used by Seqera to authenticate against the GitLab API. Recommended scopes are `api`, `read_api`, and `read_repository`, though the backend does not strictly enforce them. Sensitive.
 	Token string `json:"token"`
 }
 
@@ -69,7 +69,7 @@ type GitlabCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
+	// Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitLab credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
 	BaseURL *string              `json:"baseUrl,omitempty"`
 	Keys    GitlabCredentialKeys `json:"keys"`
 }
@@ -175,7 +175,7 @@ type GitlabCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
+	// Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitLab credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
 	BaseURL *string                    `json:"baseUrl,omitempty"`
 	Keys    GitlabCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/models/shared/gitlabcredential.go
+++ b/internal/sdk/models/shared/gitlabcredential.go
@@ -34,9 +34,9 @@ func (e *GitlabCredentialProviderType) UnmarshalJSON(data []byte) error {
 }
 
 type GitlabCredentialKeys struct {
-	// GitLab username associated with the Personal Access Token (required)
+	// GitLab account username associated with the access token.
 	Username string `json:"username"`
-	// GitLab Personal Access Token or Project Access Token (required, sensitive)
+	// GitLab access token (Personal, Group, or Project). Requires `api`, `read_api`, and `read_repository` scopes. Sensitive.
 	Token string `json:"token"`
 }
 
@@ -69,7 +69,7 @@ type GitlabCredential struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for self-hosted GitLab server (optional). Leave empty for GitLab.com. Example: https://gitlab.mycompany.com
+	// Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
 	BaseURL *string              `json:"baseUrl,omitempty"`
 	Keys    GitlabCredentialKeys `json:"keys"`
 }
@@ -149,7 +149,7 @@ func (g *GitlabCredential) GetKeys() GitlabCredentialKeys {
 }
 
 type GitlabCredentialKeysOutput struct {
-	// GitLab username associated with the Personal Access Token (required)
+	// GitLab account username associated with the access token.
 	Username string `json:"username"`
 }
 
@@ -175,7 +175,7 @@ type GitlabCredentialOutput struct {
 	DateCreated *time.Time `json:"dateCreated,omitempty"`
 	// Timestamp when the credential was last updated
 	LastUpdated *time.Time `json:"lastUpdated,omitempty"`
-	// Repository base URL for self-hosted GitLab server (optional). Leave empty for GitLab.com. Example: https://gitlab.mycompany.com
+	// Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs
 	BaseURL *string                    `json:"baseUrl,omitempty"`
 	Keys    GitlabCredentialKeysOutput `json:"keys"`
 }

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.147.0 and generator version 2.881.17
+// Generated from OpenAPI doc version 1.147.0 and generator version 2.882.0
 
 import (
 	"context"
@@ -175,7 +175,7 @@ func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
 		SDKVersion: "0.40.0-RC2",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC2 2.881.17 1.147.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC2 2.882.0 1.147.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/internal/validators/stringvalidators/bitbucket_password_validator.go
+++ b/internal/validators/stringvalidators/bitbucket_password_validator.go
@@ -27,8 +27,10 @@ func BitbucketPasswordValidator() validator.String {
 	return StringBitbucketPasswordValidatorValidator{}
 }
 
-// validateBitbucketKeysSibling errors when the current attribute and its sibling
-// are both set. `password` and `token` are mutually exclusive on the API.
+// validateBitbucketKeysSibling errors when both `password` and `token` are set.
+// The Seqera Platform backend technically accepts both (preferring `token`),
+// but having two credentials in one resource is ambiguous user intent — pick
+// one explicitly.
 func validateBitbucketKeysSibling(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse, sibling string) {
 	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() == "" {
 		return
@@ -47,6 +49,6 @@ func validateBitbucketKeysSibling(ctx context.Context, req validator.StringReque
 	resp.Diagnostics.AddAttributeError(
 		req.Path,
 		"Conflicting Bitbucket Credentials",
-		"Only one of `password` or `token` may be set.",
+		"Only one of `password` or `token` may be set. Choose `password` for HTTP/app-password auth, or `token` for API-token auth.",
 	)
 }

--- a/internal/validators/stringvalidators/bitbucket_password_validator.go
+++ b/internal/validators/stringvalidators/bitbucket_password_validator.go
@@ -1,0 +1,52 @@
+package stringvalidators
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ validator.String = StringBitbucketPasswordValidatorValidator{}
+
+type StringBitbucketPasswordValidatorValidator struct{}
+
+func (v StringBitbucketPasswordValidatorValidator) Description(_ context.Context) string {
+	return "validates that `password` and `token` are not both set on a Bitbucket credential"
+}
+
+func (v StringBitbucketPasswordValidatorValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v StringBitbucketPasswordValidatorValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateBitbucketKeysSibling(ctx, req, resp, "token")
+}
+
+func BitbucketPasswordValidator() validator.String {
+	return StringBitbucketPasswordValidatorValidator{}
+}
+
+// validateBitbucketKeysSibling errors when the current attribute and its sibling
+// are both set. `password` and `token` are mutually exclusive on the API.
+func validateBitbucketKeysSibling(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse, sibling string) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueString() == "" {
+		return
+	}
+
+	var siblingValue types.String
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, req.Path.ParentPath().AtName(sibling), &siblingValue)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if siblingValue.IsUnknown() || siblingValue.IsNull() || siblingValue.ValueString() == "" {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Conflicting Bitbucket Credentials",
+		"Only one of `password` or `token` may be set.",
+	)
+}

--- a/internal/validators/stringvalidators/bitbucket_token_validator.go
+++ b/internal/validators/stringvalidators/bitbucket_token_validator.go
@@ -1,0 +1,27 @@
+package stringvalidators
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = StringBitbucketTokenValidatorValidator{}
+
+type StringBitbucketTokenValidatorValidator struct{}
+
+func (v StringBitbucketTokenValidatorValidator) Description(_ context.Context) string {
+	return "validates that `token` and `password` are not both set on a Bitbucket credential"
+}
+
+func (v StringBitbucketTokenValidatorValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v StringBitbucketTokenValidatorValidator) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	validateBitbucketKeysSibling(ctx, req, resp, "password")
+}
+
+func BitbucketTokenValidator() validator.String {
+	return StringBitbucketTokenValidatorValidator{}
+}

--- a/overlays/credentials-bitbucket.yaml
+++ b/overlays/credentials-bitbucket.yaml
@@ -244,7 +244,7 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1'
+          description: 'Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated Bitbucket credential is used. Example: https://bitbucket.org/seqeralabs/repo1'
           example: https://bitbucket.org/seqeralabs/repo1
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -272,7 +272,7 @@ actions:
               x-speakeasy-param-computed: false
             password:
               type: string
-              description: Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with `token`.
+              description: Bitbucket app password or HTTP password (sensitive). Generate app passwords from Bitbucket account settings. Mutually exclusive with `token`.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               x-speakeasy-plan-validators: BitbucketPasswordValidator

--- a/overlays/credentials-bitbucket.yaml
+++ b/overlays/credentials-bitbucket.yaml
@@ -244,8 +244,8 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for on-premises Bitbucket server (optional). Example: https://bitbucket.org/seqeralabs'
-          example: https://bitbucket.org/myorg
+          description: 'Repository base URL (optional, recommended). When multiple Bitbucket credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://bitbucket.org/seqeralabs/repo1'
+          example: https://bitbucket.org/seqeralabs/repo1
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
         keys:
@@ -264,18 +264,25 @@ actions:
           type: object
           required:
           - username
-          - token
           properties:
             username:
               type: string
-              description: Bitbucket account username (for app passwords) or email (for API tokens). Required.
+              description: Bitbucket account username (for app passwords) or email (for API tokens).
               example: myuser@example.com
               x-speakeasy-param-computed: false
-            token:
+            password:
               type: string
-              description: Bitbucket API token (required, sensitive). App passwords are deprecated.
+              description: Bitbucket app password (sensitive). Generate from Bitbucket account settings. Mutually exclusive with `token`.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
+              x-speakeasy-plan-validators: BitbucketPasswordValidator
+              example: BBDC-...
+            token:
+              type: string
+              description: Bitbucket API token (sensitive). Mutually exclusive with `password`.
+              x-speakeasy-param-sensitive: true
+              x-speakeasy-terraform-write-only: true
+              x-speakeasy-plan-validators: BitbucketTokenValidator
               example: ATBB...
     CreateBitbucketCredentialsRequest:
       type: object
@@ -302,7 +309,8 @@ actions:
 - target: $.components.schemas.BitbucketCredential.properties.category
   remove: true
 - target: $.components.schemas.BitbucketCredential.properties.keys.properties.password
-  remove: true
+  update:
+    writeOnly: true
 - target: $.components.schemas.BitbucketCredential.properties.keys.properties.token
   update:
     writeOnly: true

--- a/overlays/credentials-codecommit.yaml
+++ b/overlays/credentials-codecommit.yaml
@@ -242,7 +242,7 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com'
+          description: 'Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated CodeCommit credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com'
           example: https://git-codecommit.us-east-1.amazonaws.com
           x-speakeasy-param-computed: true
           x-speakeasy-name-override: base_url

--- a/overlays/credentials-codecommit.yaml
+++ b/overlays/credentials-codecommit.yaml
@@ -242,7 +242,7 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for AWS CodeCommit (optional). Example: https://git-codecommit.us-east-1.amazonaws.com'
+          description: 'Regional AWS CodeCommit endpoint (optional, recommended). When multiple CodeCommit credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://git-codecommit.eu-west-1.amazonaws.com'
           example: https://git-codecommit.us-east-1.amazonaws.com
           x-speakeasy-param-computed: true
           x-speakeasy-name-override: base_url
@@ -266,13 +266,13 @@ actions:
           properties:
             username:
               type: string
-              description: AWS Access Key ID for CodeCommit (required)
+              description: AWS IAM access key ID for CodeCommit.
               example: AKIAIOSFODNN7EXAMPLE
               x-speakeasy-param-computed: false
               x-speakeasy-name-override: access_key
             password:
               type: string
-              description: AWS Secret Access Key for CodeCommit (required, sensitive)
+              description: AWS IAM secret access key for CodeCommit (sensitive).
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY

--- a/overlays/credentials-gitea.yaml
+++ b/overlays/credentials-gitea.yaml
@@ -244,7 +244,7 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for Gitea server (optional). Example: https://gitea.mycompany.com'
+          description: 'Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com'
           example: https://gitea.mycompany.com
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -267,12 +267,12 @@ actions:
           properties:
             username:
               type: string
-              description: Gitea account username (required)
+              description: Gitea account username.
               example: myuser
               x-speakeasy-param-computed: false
             password:
               type: string
-              description: Gitea account password (required, sensitive)
+              description: Gitea account password (sensitive).
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: mypassword

--- a/overlays/credentials-gitea.yaml
+++ b/overlays/credentials-gitea.yaml
@@ -244,7 +244,7 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for the self-hosted Gitea instance (required). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. Example: https://gitea.mycompany.com'
+          description: 'Repository base URL for the self-hosted Gitea instance (required by the credential validator). When multiple Gitea credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. Example: https://gitea.mycompany.com'
           example: https://gitea.mycompany.com
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -272,7 +272,7 @@ actions:
               x-speakeasy-param-computed: false
             password:
               type: string
-              description: Gitea account password (sensitive).
+              description: Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: mypassword

--- a/overlays/credentials-gitea.yaml
+++ b/overlays/credentials-gitea.yaml
@@ -272,7 +272,7 @@ actions:
               x-speakeasy-param-computed: false
             password:
               type: string
-              description: Gitea account password or personal access token (sensitive). Sent to Gitea as HTTP basic-auth password.
+              description: Gitea account password or personal access token (sensitive).
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: mypassword

--- a/overlays/credentials-github.yaml
+++ b/overlays/credentials-github.yaml
@@ -244,7 +244,7 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs'
+          description: 'Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitHub credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs'
           example: https://github.com/seqeralabs
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -272,7 +272,7 @@ actions:
               example: octocat
             password:
               type: string
-              description: GitHub Personal Access Token (PAT) — classic or fine-grained — with `repo` scope. Sensitive.
+              description: GitHub Personal Access Token (PAT) — classic or fine-grained. Typically requires `repo` scope; the backend does not enforce specific scopes. Sensitive.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: ghp_1234567890abcdefghijklmnopqrstuvwxyz

--- a/overlays/credentials-github.yaml
+++ b/overlays/credentials-github.yaml
@@ -244,9 +244,8 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for GitHub Enterprise Server (optional). Leave empty for GitHub.com. Example:
-            https://github.mycompany.com'
-          example: https://github.mycompany.com
+          description: 'Repository base URL (optional, recommended). When multiple GitHub credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For GitHub Enterprise Server, set this to the server URL. Example: https://github.com/seqeralabs'
+          example: https://github.com/seqeralabs
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
         keys:
@@ -269,11 +268,11 @@ actions:
           properties:
             username:
               type: string
-              description: GitHub username associated with the Personal Access Token (required)
+              description: GitHub account username associated with the access token.
               example: octocat
             password:
               type: string
-              description: GitHub Personal Access Token (PAT) for authentication (required, sensitive)
+              description: GitHub Personal Access Token (PAT) — classic or fine-grained — with `repo` scope. Sensitive.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: ghp_1234567890abcdefghijklmnopqrstuvwxyz

--- a/overlays/credentials-gitlab.yaml
+++ b/overlays/credentials-gitlab.yaml
@@ -244,7 +244,7 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs'
+          description: 'Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is the longest prefix of the target repository URL; ties are broken by most recently updated. If no credential has a `base_url`, the most recently updated GitLab credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs'
           example: https://gitlab.com/seqeralabs
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
@@ -272,7 +272,7 @@ actions:
               example: gitlab-user
             token:
               type: string
-              description: GitLab access token (Personal, Group, or Project). Requires `api`, `read_api`, and `read_repository` scopes. Sensitive.
+              description: GitLab access token (Personal, Group, or Project). Used by Seqera to authenticate against the GitLab API. Recommended scopes are `api`, `read_api`, and `read_repository`, though the backend does not strictly enforce them. Sensitive.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: glpat-xxxxxxxxxxxxxxxxxxxx

--- a/overlays/credentials-gitlab.yaml
+++ b/overlays/credentials-gitlab.yaml
@@ -244,9 +244,8 @@ actions:
           x-speakeasy-terraform-ignore: true
         baseUrl:
           type: string
-          description: 'Repository base URL for self-hosted GitLab server (optional). Leave empty for GitLab.com. Example:
-            https://gitlab.mycompany.com'
-          example: https://gitlab.mycompany.com
+          description: 'Repository base URL (optional, recommended). When multiple GitLab credentials exist in a workspace, Seqera selects the credential whose `base_url` is most similar to the target repository; if no `base_url` is set on any credential, the longest-lived credential is used. For self-hosted GitLab, set this to the server URL. Example: https://gitlab.com/seqeralabs'
+          example: https://gitlab.com/seqeralabs
           x-speakeasy-name-override: base_url
           x-speakeasy-param-computed: false
         keys:
@@ -269,11 +268,11 @@ actions:
           properties:
             username:
               type: string
-              description: GitLab username associated with the Personal Access Token (required)
+              description: GitLab account username associated with the access token.
               example: gitlab-user
             token:
               type: string
-              description: GitLab Personal Access Token or Project Access Token (required, sensitive)
+              description: GitLab access token (Personal, Group, or Project). Requires `api`, `read_api`, and `read_repository` scopes. Sensitive.
               x-speakeasy-param-sensitive: true
               x-speakeasy-terraform-write-only: true
               example: glpat-xxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
## Summary
- Re-expose `password` on `seqera_bitbucket_credential` alongside `token` (both optional, sensitive, write-only) so accounts using a Bitbucket app password can authenticate. The previous overlay removed `password` and forced `token`, which the API rejects for app-password users.
- Add a plan-time validator (`BitbucketPasswordValidator` / `BitbucketTokenValidator`) that errors if both `password` and `token` are set.
- Refresh descriptions and examples for all Git credential resources (GitHub, GitLab, Gitea, Bitbucket, CodeCommit) to match the official docs at https://docs.seqera.io/platform-enterprise/git/overview, including the multi-credential `base_url` filtering behavior.
- Fix the CodeCommit example, which used `username` / `password` instead of `access_key` / `secret_key`.

## Test plan
- [ ] `terraform plan` with both `password` and `token` set surfaces the "Conflicting Bitbucket Credentials" error at plan time
- [ ] `terraform apply` of `seqera_bitbucket_credential` with only `password` (app password) succeeds against an on-prem Bitbucket Server
- [ ] `terraform apply` of `seqera_bitbucket_credential` with only `token` succeeds against Bitbucket Cloud
- [ ] Generated docs render correctly for github / gitlab / gitea / bitbucket / codecommit (`docs/resources/*_credential.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)