### PR TITLE
fix(credentials): JSON import for typed credentials; add seqera_credential migration guide

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 7b13f13a2687e47f8062948f85ca27c6
+  docChecksum: 1845e4aeb0c9e497855394f5b074692e
   docVersion: 1.147.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
@@ -449,7 +449,7 @@ trackedFiles:
     pristine_git_object: 4d4451329e274230a287210d496b8e03aea29724
   internal/provider/awscredential_resource.go:
     id: fd1fb9518f67
-    last_write_checksum: sha1:fe5446450d60dd893e7196da80a4e39ae0cfc1e5
+    last_write_checksum: sha1:2cedfdcc283ddf2713c38ce740d4b260d84d3bc0
     pristine_git_object: 718916f70c62d6cdeb910a896ec32723c62f9346
   internal/provider/awscredential_resource_sdk.go:
     id: 6dd3171fbbcc
@@ -465,7 +465,7 @@ trackedFiles:
     last_write_checksum: sha1:ee96d4bffca3541ba3143c50ddcafdadbd917266
   internal/provider/azurecredential_resource.go:
     id: 4e14a60d78ce
-    last_write_checksum: sha1:0a90e9cf911778833c2f229d111537b5b93473a4
+    last_write_checksum: sha1:b5982013d16928e80e7900cccd06743b3d1bc76c
     pristine_git_object: 0eb0896ee9fe4eed104d1d66e3c5b72221a8e8c1
   internal/provider/azurecredential_resource_sdk.go:
     id: 1cff49867392
@@ -473,7 +473,7 @@ trackedFiles:
     pristine_git_object: 62f301e24df9501920ae8a9afe8ae7927b82a862
   internal/provider/bitbucketcredential_resource.go:
     id: 99461a76ba60
-    last_write_checksum: sha1:f7b48773b2360857da9162729d341a1e19ccb203
+    last_write_checksum: sha1:10de5c4b1bf180cc731b220f8fe756579375d744
     pristine_git_object: ef48989850ba46b7641a28a14055504c1737a53c
   internal/provider/bitbucketcredential_resource_sdk.go:
     id: ea250abc2a72
@@ -481,7 +481,7 @@ trackedFiles:
     pristine_git_object: 8a0bebdcdd3d64be9a83a6a75aa5bc0422f8f3ff
   internal/provider/codecommitcredential_resource.go:
     id: 22c2e9aa4b13
-    last_write_checksum: sha1:732a23d3c4d892f68816a12f4265422816a9e058
+    last_write_checksum: sha1:7fc6ac51acc944a430104e20cc37e5da22546912
     pristine_git_object: 58dcb06c3f42ed4aa8f5bf250a2b70ed4ad235ed
   internal/provider/codecommitcredential_resource_sdk.go:
     id: dcc60e154878
@@ -497,7 +497,7 @@ trackedFiles:
     pristine_git_object: 2e933070714e8aa8d9ab83f2e1b81abd6f262ade
   internal/provider/containerregistrycredential_resource.go:
     id: f0a18857f2ea
-    last_write_checksum: sha1:fb67156930a77bc69f3b2f21c17804d47d5801e6
+    last_write_checksum: sha1:0fc918f0e84a51b2c6729920c8ce536a257c882b
     pristine_git_object: e6a9866eacb679ff8d1567624763412dcb61f0d1
   internal/provider/containerregistrycredential_resource_sdk.go:
     id: 84a1496699d8
@@ -553,7 +553,7 @@ trackedFiles:
     last_write_checksum: sha1:412c24d954db792925ec76ad94c227be0a624308
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
-    last_write_checksum: sha1:4f00b5be119b8b29e65c3deea4be3e66720aefb7
+    last_write_checksum: sha1:e172fdce80711e50a3ded865ccbc75b603ce02fd
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
@@ -561,7 +561,7 @@ trackedFiles:
     pristine_git_object: 71e29ff10c22205eab4418ac0b8a92152cc5b23d
   internal/provider/githubcredential_resource.go:
     id: e1f090a0cb9e
-    last_write_checksum: sha1:2a32227fd96a32d24d3e0326dc35b559e4b71a4b
+    last_write_checksum: sha1:3aafce0235d9c05d3438774c52a7a033ca3798e5
     pristine_git_object: c6a4da7de3d8a1ca06c268021bcb56ba09f3c9f1
   internal/provider/githubcredential_resource_sdk.go:
     id: bc2bee614a62
@@ -569,7 +569,7 @@ trackedFiles:
     pristine_git_object: 01c4b02c388b5caf56516bd71e9a2176973234b2
   internal/provider/gitlabcredential_resource.go:
     id: fcb86103d097
-    last_write_checksum: sha1:40d1e93c54e43a07c2a96af6199a753f434fc949
+    last_write_checksum: sha1:b066d81cd7d1389b7f1537572d27fddfdb252be3
     pristine_git_object: 5b27290c979fb073cf156f1babc37c36cde9ab8e
   internal/provider/gitlabcredential_resource_sdk.go:
     id: a6c217015659
@@ -577,7 +577,7 @@ trackedFiles:
     pristine_git_object: 0f3d5604b62f838d2b0b79919f08bc65e5c9cf5b
   internal/provider/googlecredential_resource.go:
     id: 8822521a4af3
-    last_write_checksum: sha1:d63f75ff53f6cb5327152f7e9258c198874bdcc6
+    last_write_checksum: sha1:4556538adc4bff783ddb46c696c7fba299cbb48d
     pristine_git_object: 026226dc9ef3d464025bca768181bcaa0a4e6f7f
   internal/provider/googlecredential_resource_sdk.go:
     id: b4c881561996
@@ -585,7 +585,7 @@ trackedFiles:
     pristine_git_object: a25a2b110b86b9bffc9496f89bf92a4e5e452bce
   internal/provider/kubernetescredential_resource.go:
     id: 9cca06635b9e
-    last_write_checksum: sha1:35c5eb558ccd525e9cfcd36919df4e685576987e
+    last_write_checksum: sha1:29e76c00bd3f4c37a8999393dc879d9e2fbdcbea
     pristine_git_object: 1be6769e629c348b8cf88a2f4898baf75b3da740
   internal/provider/kubernetescredential_resource_sdk.go:
     id: ea2832ecd302
@@ -701,7 +701,7 @@ trackedFiles:
     pristine_git_object: c588f768bd7b39be33962188f97d81e1c4c25f4b
   internal/provider/sshcredential_resource.go:
     id: 7eb281c9649c
-    last_write_checksum: sha1:099241b3dfb112d9ff9be92f40880518c1fd4550
+    last_write_checksum: sha1:f13b19585a0e97dd70b11b08b4b823296b16a673
     pristine_git_object: 47f7c6e152f7cecdcbd982d27de12746f870a355
   internal/provider/sshcredential_resource_sdk.go:
     id: 3c25312d23ab
@@ -729,7 +729,7 @@ trackedFiles:
     last_write_checksum: sha1:09b4887dfd5f9916f8a729c10ba042065dec71b0
   internal/provider/toweragentcredential_resource.go:
     id: 9596670e4f16
-    last_write_checksum: sha1:0eeeb8d6202f882dbd9bd92ef842c65912d2e56e
+    last_write_checksum: sha1:8fbe8791467c53afeea2d0472d220759ef1d5bbd
     pristine_git_object: d91d65ea5bffdb82659601bb5f8c37780e55e998
   internal/provider/toweragentcredential_resource_sdk.go:
     id: 139ea0cf9bf1

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: f0115aa3d428640f1521547a715cc5f7
+  docChecksum: 168eda034a69ae92d335b575f20afa92
   docVersion: 1.147.0
   speakeasyVersion: 1.762.0
   generationVersion: 2.882.0
@@ -473,15 +473,15 @@ trackedFiles:
     pristine_git_object: 62f301e24df9501920ae8a9afe8ae7927b82a862
   internal/provider/bitbucketcredential_resource.go:
     id: 99461a76ba60
-    last_write_checksum: sha1:e0429d833c03de274091ee5b19de3038d564b592
+    last_write_checksum: sha1:2d3763dd12783af41e7ce369880f7ed9246e7a57
     pristine_git_object: ef48989850ba46b7641a28a14055504c1737a53c
   internal/provider/bitbucketcredential_resource_sdk.go:
     id: ea250abc2a72
-    last_write_checksum: sha1:155f0083160e07ce4ad7dad16aa9cc63e1570d5e
+    last_write_checksum: sha1:fd9d03c1e344a4909fd9f95d604a32ec0e43355c
     pristine_git_object: 8a0bebdcdd3d64be9a83a6a75aa5bc0422f8f3ff
   internal/provider/codecommitcredential_resource.go:
     id: 22c2e9aa4b13
-    last_write_checksum: sha1:e91652ea75fd58954aab173c976e5f309d24b5ff
+    last_write_checksum: sha1:906d4e276b75bff8a65cd9d6a7e1ff6bd3fd01bf
     pristine_git_object: 58dcb06c3f42ed4aa8f5bf250a2b70ed4ad235ed
   internal/provider/codecommitcredential_resource_sdk.go:
     id: dcc60e154878
@@ -553,7 +553,7 @@ trackedFiles:
     last_write_checksum: sha1:412c24d954db792925ec76ad94c227be0a624308
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
-    last_write_checksum: sha1:3274fc24e8054c69230765729ad456d66f4fae50
+    last_write_checksum: sha1:c5bd62a86b6bacb9d62f0817517d1b096c8cffce
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
@@ -561,7 +561,7 @@ trackedFiles:
     pristine_git_object: 71e29ff10c22205eab4418ac0b8a92152cc5b23d
   internal/provider/githubcredential_resource.go:
     id: e1f090a0cb9e
-    last_write_checksum: sha1:51e774b13b7ae0ea1c96ff69ce07f5964ea5171a
+    last_write_checksum: sha1:7c8f62abe4873493ab556540c99aef8d8946708f
     pristine_git_object: c6a4da7de3d8a1ca06c268021bcb56ba09f3c9f1
   internal/provider/githubcredential_resource_sdk.go:
     id: bc2bee614a62
@@ -569,7 +569,7 @@ trackedFiles:
     pristine_git_object: 01c4b02c388b5caf56516bd71e9a2176973234b2
   internal/provider/gitlabcredential_resource.go:
     id: fcb86103d097
-    last_write_checksum: sha1:ded1df7d5778dd4b89755c235b25fdd9e4b0d80f
+    last_write_checksum: sha1:6730820e5ac93a2a020115616d1788e14ba7883a
     pristine_git_object: 5b27290c979fb073cf156f1babc37c36cde9ab8e
   internal/provider/gitlabcredential_resource_sdk.go:
     id: a6c217015659

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,10 +1,10 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 01318fe35f2b468ba80afe08088bd970
+  docChecksum: 7b13f13a2687e47f8062948f85ca27c6
   docVersion: 1.147.0
-  speakeasyVersion: 1.761.11
-  generationVersion: 2.881.17
+  speakeasyVersion: 1.762.0
+  generationVersion: 2.882.0
   releaseVersion: 0.40.0-RC2
   configChecksum: c77908dbe8aa95c668e0cdc1862e3c7f
 persistentEdits:
@@ -75,11 +75,11 @@ trackedFiles:
     pristine_git_object: f6cd02d2c1b98058a0e1babcbad048a6bc0d27ba
   examples/resources/seqera_aws_credential/import-by-string-id.tf:
     id: ad3bcd233d82
-    last_write_checksum: sha1:4bebbaac8013eac2ac1046dc59e96bf106665d98
+    last_write_checksum: sha1:222929c7f7081990d4ff77390a826bf3960077fd
     pristine_git_object: e16169437f762b94a32848a4537f73ce82ca9c32
   examples/resources/seqera_aws_credential/import.sh:
     id: e4972b257c31
-    last_write_checksum: sha1:f36391a662426b2e6d08bc7e5f3dd64ae20677ed
+    last_write_checksum: sha1:1c5ec602f1a51cb9e817739eb655ef892b5a2527
     pristine_git_object: 03c742164c58fdcc51c61e231038cdb09107cde5
   examples/resources/seqera_azure_batch_ce/import-by-string-id.tf:
     last_write_checksum: sha1:3d328f6ac3f83ecea81b5d3f0235d1ff1857c066
@@ -95,27 +95,27 @@ trackedFiles:
     last_write_checksum: sha1:4dbd94a68cff29bfb7484168440b5dea5cde1a68
   examples/resources/seqera_azure_credential/import-by-string-id.tf:
     id: 53558040e9ca
-    last_write_checksum: sha1:8ca89aca29c3414862350b08d72f1080fd097f8d
+    last_write_checksum: sha1:6518c53d5fed7582509fb8ebd5d70d7033dd23b1
     pristine_git_object: c4978b9c587644f1cc7f3d2e30cd179d3f7dc769
   examples/resources/seqera_azure_credential/import.sh:
     id: cbeb123214c6
-    last_write_checksum: sha1:3515f5ac66322ff7a6c3e85751d3d5994e884760
+    last_write_checksum: sha1:9add37980734e6a40da57eeb3b70b25609a973c7
     pristine_git_object: dde5987defc526aa2feb51d9c682dc4192e5e5e3
   examples/resources/seqera_bitbucket_credential/import-by-string-id.tf:
     id: d6912a2080f1
-    last_write_checksum: sha1:a4003fb24d91b177b3bf9531d65253b40e73ac44
+    last_write_checksum: sha1:07858bc491fd0debfea62111db86145c95b39553
     pristine_git_object: 8f22b34d9671444770b69dff6f48f06fad4acda6
   examples/resources/seqera_bitbucket_credential/import.sh:
     id: 92da17a4b326
-    last_write_checksum: sha1:a3851499a9fb7184f17c203b043ae1f3fc38a9c7
+    last_write_checksum: sha1:0895a8675710a78abf110e7a782c757baca9f503
     pristine_git_object: 0a818666db7794b7a6e5f79bf4b26a5c0af8eb6b
   examples/resources/seqera_codecommit_credential/import-by-string-id.tf:
     id: b4d4404234f9
-    last_write_checksum: sha1:7723c39c4056c1b57038fc7eda51b4021abca526
+    last_write_checksum: sha1:1fedad2aadfca835893b7241eb2258aef1a30e3f
     pristine_git_object: a99b6b27131c80328d6e99c591c63d2ecf48751e
   examples/resources/seqera_codecommit_credential/import.sh:
     id: 302e793461f9
-    last_write_checksum: sha1:deeb74224cf3a170a110339352f5ffb0a6f4d7c6
+    last_write_checksum: sha1:e04c2ce8629dc0ff557fa62f161441d4f2712c47
     pristine_git_object: a20cb26841a6a1f855795e173aaae9a94d5881f5
   examples/resources/seqera_compute_env/import-by-string-id.tf:
     id: 13f60e2cb9b2
@@ -131,11 +131,11 @@ trackedFiles:
     pristine_git_object: eb351742350d6f70ed41a265a3c499868043286d
   examples/resources/seqera_container_registry_credential/import-by-string-id.tf:
     id: 64a1256ab555
-    last_write_checksum: sha1:6be3814fcf4504de41057f127542bec064f4044a
+    last_write_checksum: sha1:cf3edcff4d032e34c80f8e456705b20764332129
     pristine_git_object: 9f685febf2d507eaa7cc47d1cdf5fa5417066c7f
   examples/resources/seqera_container_registry_credential/import.sh:
     id: 05a9bb448c36
-    last_write_checksum: sha1:d6c22e59827e6c1ec4aab2b9710b85441fe79517
+    last_write_checksum: sha1:d1f5c76a28b2235d01ac3a27d1ec92a3d1f01e84
     pristine_git_object: e89ac47520d8662ce098f1458f3809cc53862df7
   examples/resources/seqera_credential/import-by-string-id.tf:
     id: 6933128d0881
@@ -175,37 +175,37 @@ trackedFiles:
     last_write_checksum: sha1:0b229f2296557fbc841ddb2793983b7d34867d6a
   examples/resources/seqera_gitea_credential/import-by-string-id.tf:
     id: 26efec7dcd49
-    last_write_checksum: sha1:d5aaa3356e82d8f5d720553524a74047bde6e3b2
+    last_write_checksum: sha1:db7ccd94a6c83c3281d85cdc49926361f361fa28
     pristine_git_object: e35422623aa52520f9bb8945cc1de0a2bf09ee69
   examples/resources/seqera_gitea_credential/import.sh:
     id: 8c0e614b09f4
-    last_write_checksum: sha1:6ccd09b7665b83b0fa70d79d1dc776fc8d3cbf18
+    last_write_checksum: sha1:4681c9452c3a5db6a2ac5eadc7f9d01cf48ef42e
     pristine_git_object: f6811dac82b57092419a4dd94f44e967bf3eaa58
   examples/resources/seqera_github_credential/import-by-string-id.tf:
     id: cec576dc44c5
-    last_write_checksum: sha1:020fcce409582941da2e8884b4c4483bda05c405
+    last_write_checksum: sha1:b4cc4d7bbb39c46c5a97f5ddf5260b14fb2914c4
     pristine_git_object: 79b716aafeefc919c9612ce1ac3a1973e4bb6197
   examples/resources/seqera_github_credential/import.sh:
     id: 3949d9b6b6e9
-    last_write_checksum: sha1:40ab7747a4afbc42cb4222ee339f60e2f12b2ff5
+    last_write_checksum: sha1:1da59e162dc4ac17dc9c9f534ec52f948acadeb7
     pristine_git_object: 2ab60310623b532cc4ec625014598077eb38dc3c
   examples/resources/seqera_gitlab_credential/import-by-string-id.tf:
     id: 202d97610124
-    last_write_checksum: sha1:97ad8f683c38e4de3f8577f90f355601bc14fb17
+    last_write_checksum: sha1:4cb01d790bf77c2b8fa2a0eb2399c2f6e0803fe1
     pristine_git_object: 86f02d4f51f77744cfb27d7753c7ee3e8ce8ae23
   examples/resources/seqera_gitlab_credential/import.sh:
     id: 1f454dbdee03
-    last_write_checksum: sha1:1dd66315d501dd2762569a3cb198cbe0991424de
+    last_write_checksum: sha1:3801aaab404867fd521d968481c07b412b06c0b0
     pristine_git_object: b4d7dfacb838d9a2fcd47d30f9214606a274aa55
   examples/resources/seqera_google_credential/import-by-string-id.tf:
-    last_write_checksum: sha1:0d4abe0935e36ce0613f01dbee8a933f45838522
+    last_write_checksum: sha1:73d1fb5353192a6885e6e7124cea8ca1568ed7e0
   examples/resources/seqera_kubernetes_credential/import-by-string-id.tf:
     id: 351dcc957fb0
-    last_write_checksum: sha1:0d6c88f4893c8ce6a4c5ed9551cc1c164a5ff4b9
+    last_write_checksum: sha1:2f2517e0681e6ffe51a03b739d25623c5003b2b9
     pristine_git_object: bbf6c0f6e305976ab6b0180b67addf134a9a4de8
   examples/resources/seqera_kubernetes_credential/import.sh:
     id: f8fe469e9196
-    last_write_checksum: sha1:f47415abb290619e743d453ddfa4bfaaf683afd1
+    last_write_checksum: sha1:8485d845061616209a6fc31cd0d88767d0d795ab
     pristine_git_object: 3f3f73233c1026ed25f8fd50fd8fcdd71c107aa5
   examples/resources/seqera_managed_compute_ce/import-by-string-id.tf:
     id: 2a079c451bbd
@@ -245,11 +245,11 @@ trackedFiles:
     pristine_git_object: 4d69188d92974da17d3f96e317dcd1fea7e8c561
   examples/resources/seqera_ssh_credential/import-by-string-id.tf:
     id: 5366e17fedde
-    last_write_checksum: sha1:1b6f6e8212667aa673d845a52d955696e51e8854
+    last_write_checksum: sha1:717930037e6623c72161d5a98da980d84c4d6e60
     pristine_git_object: ee758781cdb46ddb1cab63a1de1d3af84e3784e1
   examples/resources/seqera_ssh_credential/import.sh:
     id: e07c6c42952d
-    last_write_checksum: sha1:fe6b0be7c2894df9fbaf0eb24a758e57ef43c203
+    last_write_checksum: sha1:945668b9be569d0ae9babdb7a90d0831defc54ce
     pristine_git_object: b8773e8e728549da151c6a6ffb7109a4a030834c
   examples/resources/seqera_studios/import-by-string-id.tf:
     id: f5422afa526c
@@ -273,11 +273,11 @@ trackedFiles:
     pristine_git_object: 1d1e81b647e97a166456b7cbae35c9ac05dc477f
   examples/resources/seqera_tower_agent_credential/import-by-string-id.tf:
     id: 559a9a121b1f
-    last_write_checksum: sha1:5282ed1dfbc7721b0ee2de210d3b74e100d5504e
+    last_write_checksum: sha1:c30c932768a6e9c2b3bbb9fd20c2d9cabfab0367
     pristine_git_object: f8bc298d062a4c72a18e3e6576207709e4403f0b
   examples/resources/seqera_tower_agent_credential/import.sh:
     id: 4808258b4c68
-    last_write_checksum: sha1:328c0184e5c52503f9bc97660d2b96f93bdc85b2
+    last_write_checksum: sha1:39745d89aff10b62bc9a57f1513793af6557afb6
     pristine_git_object: 7bd992c9eb2db0a3eee79a9049c5a738058ee00c
   examples/resources/seqera_workflows/import-by-string-id.tf:
     id: 22bc4d0b4ded
@@ -449,11 +449,11 @@ trackedFiles:
     pristine_git_object: 4d4451329e274230a287210d496b8e03aea29724
   internal/provider/awscredential_resource.go:
     id: fd1fb9518f67
-    last_write_checksum: sha1:763635b7ae4c85b9958ec821c0cfe60b0e329836
+    last_write_checksum: sha1:fe5446450d60dd893e7196da80a4e39ae0cfc1e5
     pristine_git_object: 718916f70c62d6cdeb910a896ec32723c62f9346
   internal/provider/awscredential_resource_sdk.go:
     id: 6dd3171fbbcc
-    last_write_checksum: sha1:bf4dcb70e6072016cc6fb69e63532f19a62021b1
+    last_write_checksum: sha1:aa18daa26d7f5c16a05b4d2575693999a52cd9dd
     pristine_git_object: fb79abddd43fc8a362ddaff379637c1def78665a
   internal/provider/azurebatchce_resource.go:
     last_write_checksum: sha1:6eca17d40ca96d5e939e3e5515a78b97bcd1d7a1
@@ -465,27 +465,27 @@ trackedFiles:
     last_write_checksum: sha1:ee96d4bffca3541ba3143c50ddcafdadbd917266
   internal/provider/azurecredential_resource.go:
     id: 4e14a60d78ce
-    last_write_checksum: sha1:3b839c12645a6b32d1c8e9c318a2bb39601c998c
+    last_write_checksum: sha1:0a90e9cf911778833c2f229d111537b5b93473a4
     pristine_git_object: 0eb0896ee9fe4eed104d1d66e3c5b72221a8e8c1
   internal/provider/azurecredential_resource_sdk.go:
     id: 1cff49867392
-    last_write_checksum: sha1:fa2b35c862d1a6578b8ec34c4fd973df939225e9
+    last_write_checksum: sha1:2fbc2a13612a9a7210bd36cdac311b9624928e5b
     pristine_git_object: 62f301e24df9501920ae8a9afe8ae7927b82a862
   internal/provider/bitbucketcredential_resource.go:
     id: 99461a76ba60
-    last_write_checksum: sha1:1d5dae518b5de9ed6a3b9ace4a4b1c3df7301962
+    last_write_checksum: sha1:f7b48773b2360857da9162729d341a1e19ccb203
     pristine_git_object: ef48989850ba46b7641a28a14055504c1737a53c
   internal/provider/bitbucketcredential_resource_sdk.go:
     id: ea250abc2a72
-    last_write_checksum: sha1:4d21f18905224f7273dd1087df0656331ac860f0
+    last_write_checksum: sha1:caf91eb3ac51b7013c587460cecf9a27f8c23aa7
     pristine_git_object: 8a0bebdcdd3d64be9a83a6a75aa5bc0422f8f3ff
   internal/provider/codecommitcredential_resource.go:
     id: 22c2e9aa4b13
-    last_write_checksum: sha1:e919dfed021e52087fc3b4df37aff92ec2a175de
+    last_write_checksum: sha1:732a23d3c4d892f68816a12f4265422816a9e058
     pristine_git_object: 58dcb06c3f42ed4aa8f5bf250a2b70ed4ad235ed
   internal/provider/codecommitcredential_resource_sdk.go:
     id: dcc60e154878
-    last_write_checksum: sha1:b743163163be0b20408da545d66fd4f20d673574
+    last_write_checksum: sha1:3ed5f8a29d0090becba2275f92d1357ec47f5984
     pristine_git_object: 0c1b43d5db49b023cf3c7408c198a4d66c795d8a
   internal/provider/computeenv_resource.go:
     id: f4162f219efd
@@ -497,11 +497,11 @@ trackedFiles:
     pristine_git_object: 2e933070714e8aa8d9ab83f2e1b81abd6f262ade
   internal/provider/containerregistrycredential_resource.go:
     id: f0a18857f2ea
-    last_write_checksum: sha1:f63c4cd4a5b6929ac9686b027d20b00c687cca79
+    last_write_checksum: sha1:fb67156930a77bc69f3b2f21c17804d47d5801e6
     pristine_git_object: e6a9866eacb679ff8d1567624763412dcb61f0d1
   internal/provider/containerregistrycredential_resource_sdk.go:
     id: 84a1496699d8
-    last_write_checksum: sha1:9ab9eeb3ec1e325b252e847b27c46df6da6427bc
+    last_write_checksum: sha1:227e832c747c18e5c41d8d298136c4f25b9fd3c8
     pristine_git_object: 9cb9ad7d844c9ac4c05ed05c9fbc4351231a9c4e
   internal/provider/credential_resource.go:
     id: b17d06f08976
@@ -553,43 +553,43 @@ trackedFiles:
     last_write_checksum: sha1:412c24d954db792925ec76ad94c227be0a624308
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
-    last_write_checksum: sha1:6ae8d03e115448f05d1455a0ee2f1f6811ab29f9
+    last_write_checksum: sha1:4f00b5be119b8b29e65c3deea4be3e66720aefb7
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
-    last_write_checksum: sha1:f264faf69a3f2a879accef8e4ff75e168584ea8a
+    last_write_checksum: sha1:d7f08344fcbafda9ce2f235490e11a301d6c5cc8
     pristine_git_object: 71e29ff10c22205eab4418ac0b8a92152cc5b23d
   internal/provider/githubcredential_resource.go:
     id: e1f090a0cb9e
-    last_write_checksum: sha1:188312fea5a86ad334c087ac2392ba63d38f2c2a
+    last_write_checksum: sha1:2a32227fd96a32d24d3e0326dc35b559e4b71a4b
     pristine_git_object: c6a4da7de3d8a1ca06c268021bcb56ba09f3c9f1
   internal/provider/githubcredential_resource_sdk.go:
     id: bc2bee614a62
-    last_write_checksum: sha1:41095593d126638b483f09fadccf11a5e4598e42
+    last_write_checksum: sha1:cf4184ac3ea17bb97f07b0dd9b4569f4c3ec8c5d
     pristine_git_object: 01c4b02c388b5caf56516bd71e9a2176973234b2
   internal/provider/gitlabcredential_resource.go:
     id: fcb86103d097
-    last_write_checksum: sha1:62ad11d73226d6163a03a9bb3262194871bb3453
+    last_write_checksum: sha1:40d1e93c54e43a07c2a96af6199a753f434fc949
     pristine_git_object: 5b27290c979fb073cf156f1babc37c36cde9ab8e
   internal/provider/gitlabcredential_resource_sdk.go:
     id: a6c217015659
-    last_write_checksum: sha1:9e990d31a78b9bc17e4af32d1bcba20a7551759e
+    last_write_checksum: sha1:1e6f845ca8b1da612d6ed49da220965d5a0d2bf4
     pristine_git_object: 0f3d5604b62f838d2b0b79919f08bc65e5c9cf5b
   internal/provider/googlecredential_resource.go:
     id: 8822521a4af3
-    last_write_checksum: sha1:a4fbf9619ce7fd9ec8a82d0c60cd2f0acc905667
+    last_write_checksum: sha1:d63f75ff53f6cb5327152f7e9258c198874bdcc6
     pristine_git_object: 026226dc9ef3d464025bca768181bcaa0a4e6f7f
   internal/provider/googlecredential_resource_sdk.go:
     id: b4c881561996
-    last_write_checksum: sha1:92b207ac477c5e3ad00ab51099150bf23b31ae09
+    last_write_checksum: sha1:3292ff1babe20dba42e687db007a5a759ee52c63
     pristine_git_object: a25a2b110b86b9bffc9496f89bf92a4e5e452bce
   internal/provider/kubernetescredential_resource.go:
     id: 9cca06635b9e
-    last_write_checksum: sha1:76355cc6348e388b9888c2b7d3de670d3a60ab46
+    last_write_checksum: sha1:35c5eb558ccd525e9cfcd36919df4e685576987e
     pristine_git_object: 1be6769e629c348b8cf88a2f4898baf75b3da740
   internal/provider/kubernetescredential_resource_sdk.go:
     id: ea2832ecd302
-    last_write_checksum: sha1:da948e6f8a4edaaecb53ef9236a7481e141d0e23
+    last_write_checksum: sha1:790937521e1a46d6732be21ab9e478bc69280c5f
     pristine_git_object: 2814ac2db68121be9482eefc7c946a8df0202a38
   internal/provider/labels_resource.go:
     id: 738bccd5f1b7
@@ -701,11 +701,11 @@ trackedFiles:
     pristine_git_object: c588f768bd7b39be33962188f97d81e1c4c25f4b
   internal/provider/sshcredential_resource.go:
     id: 7eb281c9649c
-    last_write_checksum: sha1:caf43a4a0c373914c8f121d7db005d570dd63993
+    last_write_checksum: sha1:099241b3dfb112d9ff9be92f40880518c1fd4550
     pristine_git_object: 47f7c6e152f7cecdcbd982d27de12746f870a355
   internal/provider/sshcredential_resource_sdk.go:
     id: 3c25312d23ab
-    last_write_checksum: sha1:05d7bed319f8eb09b33e9170f28f56bf2d1120dc
+    last_write_checksum: sha1:278f06add26e80720b36fc9185786fde77563dc3
     pristine_git_object: a633929e19d2c86fc43fdc96a586954c0992048c
   internal/provider/studios_resource.go:
     id: d5d4f38592d9
@@ -729,11 +729,11 @@ trackedFiles:
     last_write_checksum: sha1:09b4887dfd5f9916f8a729c10ba042065dec71b0
   internal/provider/toweragentcredential_resource.go:
     id: 9596670e4f16
-    last_write_checksum: sha1:c076be59a053311486265677b90d3c5ad5e59c7a
+    last_write_checksum: sha1:0eeeb8d6202f882dbd9bd92ef842c65912d2e56e
     pristine_git_object: d91d65ea5bffdb82659601bb5f8c37780e55e998
   internal/provider/toweragentcredential_resource_sdk.go:
     id: 139ea0cf9bf1
-    last_write_checksum: sha1:b1b3124544fc95709304e6ef36ab85f6d5576aee
+    last_write_checksum: sha1:6e21e2db1cca7ba39acbf1b840f9aef14169b19c
     pristine_git_object: 8717142892f205e2ca6d831bbe400d59dd11f556
   internal/provider/typeconvert/date.go:
     id: dfe2bc95ad1b
@@ -1529,7 +1529,7 @@ trackedFiles:
     pristine_git_object: 8800203d7cdbb9fb3564fa6a3afecdd8e7c57795
   internal/sdk/models/operations/describeawscredentials.go:
     id: b6c81dbe2d53
-    last_write_checksum: sha1:5a9ff0b40582bf74dfd62176330452130fc742f8
+    last_write_checksum: sha1:c0f480a92e581b7e82a8bc287541dcbc4208c4a6
     pristine_git_object: f875abef9cc844ab77a400da7fbd60143556368e
   internal/sdk/models/operations/describeazurebatchce.go:
     last_write_checksum: sha1:75a8d5438d0cd571f1c11a2745039993edd2c3ef
@@ -1537,15 +1537,15 @@ trackedFiles:
     last_write_checksum: sha1:62d82ac90fbb55b677f0371834d216dbf3926c3c
   internal/sdk/models/operations/describeazurecredentials.go:
     id: 24476858a911
-    last_write_checksum: sha1:c5499b91da4ef2742c4bde6255ec048ceb2e3e0a
+    last_write_checksum: sha1:ba58cbfbc82a33c85e6dcb04e04de2fcd6a314a7
     pristine_git_object: 29385ab2a7f9b2617446b7e640ac9351c466ee33
   internal/sdk/models/operations/describebitbucketcredentials.go:
     id: b6ca37cb8056
-    last_write_checksum: sha1:7d2414c6ea4f1fcba1f1cc1d09efb43db222f39a
+    last_write_checksum: sha1:f86c5e1619290a1b8075de91f6aafced35c5b96a
     pristine_git_object: 5bda8d5504eda6ef49612fe4053c48aaccae4a74
   internal/sdk/models/operations/describecodecommitcredentials.go:
     id: b31aa295e1a7
-    last_write_checksum: sha1:0b7eb5c74925834dffc40a19402bc8a061e3736a
+    last_write_checksum: sha1:a50d4db47d3659f549cdc5057f422623a138ed84
     pristine_git_object: 28c1cc130948bc5beacb09cd1c4c14ba5dbcbd7b
   internal/sdk/models/operations/describecomputeenv.go:
     id: aac3d7006c79
@@ -1553,7 +1553,7 @@ trackedFiles:
     pristine_git_object: 398dcc69ce552ac86530380bbdef6527eed55d68
   internal/sdk/models/operations/describecontainerregistrycredentials.go:
     id: 96e8211a8e67
-    last_write_checksum: sha1:cf742841eb00ab4e38e3c4f3a186ecde3e388476
+    last_write_checksum: sha1:f43af19af2d746d2e207addc26dc849fedd40f87
     pristine_git_object: 1b0090c8b4f5b40d4324d470aad00e411d7c8b56
   internal/sdk/models/operations/describecredentials.go:
     id: 48bfbf511a8b
@@ -1581,23 +1581,23 @@ trackedFiles:
     last_write_checksum: sha1:175e01f42fab0dcac607a33564af486355cf6722
   internal/sdk/models/operations/describegiteacredentials.go:
     id: 37766e51b23b
-    last_write_checksum: sha1:cdb7e5c01e631eb090f5b335528a694cab87e55d
+    last_write_checksum: sha1:b25a1cf11e00202dff364881770e54922b7466df
     pristine_git_object: eed1e5430625595f6216e7f8ffc2e5f55516fc6f
   internal/sdk/models/operations/describegithubcredentials.go:
     id: e3220a54e087
-    last_write_checksum: sha1:1d672111b988d0d47f0c3584dce0030017b1c0bc
+    last_write_checksum: sha1:026d32046738383ed337fe521a5bc94d8524dec2
     pristine_git_object: 29c030008f8baef0f3f6944172a56a0bf596278e
   internal/sdk/models/operations/describegitlabcredentials.go:
     id: ddc3638df429
-    last_write_checksum: sha1:1757e813f4afd2a179f76629dc865e06345338d5
+    last_write_checksum: sha1:79e8a5fb33586c0aba43084519f00a7432d4c75d
     pristine_git_object: 8c65a74b0190d5fd7778dd7623836de5a5bb9548
   internal/sdk/models/operations/describegooglecredentials.go:
     id: 6431e37b27c2
-    last_write_checksum: sha1:ca41847f83f87ad7414fd6a61e03c417dfdfd9fd
+    last_write_checksum: sha1:4ec220d70dfdfe92cd5b31be11c7b163890e379d
     pristine_git_object: 3143077b2ea8b6537ab6631d5d7614edea9e5ac6
   internal/sdk/models/operations/describekubernetescredentials.go:
     id: d12bcff46246
-    last_write_checksum: sha1:84b67a7092b32d8adb31b266371dba375d35b1db
+    last_write_checksum: sha1:43a30c171f17b1cb22f3ec0cb7e49da02058fb73
     pristine_git_object: 6a588a9be6c399e95ce0f1a82210610fbe2a374a
   internal/sdk/models/operations/describelaunch.go:
     id: c45eb8993de2
@@ -1651,13 +1651,13 @@ trackedFiles:
     last_write_checksum: sha1:449a66d454b7b3d22f48d59d3beaaf2a5e2ae534
   internal/sdk/models/operations/describesshcredentials.go:
     id: a85ddc2ebbb2
-    last_write_checksum: sha1:ad8cc2869fb51557e2b6b19bbdf92b01f7b9d3d1
+    last_write_checksum: sha1:4b48c159209cda718c28b0ad1525775b0c6257de
     pristine_git_object: 269951ab0f95723155436b936287eb6e117bd89b
   internal/sdk/models/operations/describesshkey.go:
     last_write_checksum: sha1:0dc11d3435677a4c9def6e24d3d160fefd538eb1
   internal/sdk/models/operations/describetoweragentcredentials.go:
     id: 3230404bb7bc
-    last_write_checksum: sha1:e0e162fb6780fd29a3399506eba3a41063a2768e
+    last_write_checksum: sha1:4d185bb39beba42ee2e5c47653b0df52d0be112f
     pristine_git_object: 3152138c00fbc854b6d110e69820240e8614f8d6
   internal/sdk/models/operations/describeuser.go:
     id: d70d71349869
@@ -3911,7 +3911,7 @@ trackedFiles:
     last_write_checksum: sha1:84fef173ddc771401f52a4c084d5a3e1b07f776e
   internal/sdk/seqera.go:
     id: b1c23bc5193c
-    last_write_checksum: sha1:d5642398b46a0fd953805293f4e72713a552e0e3
+    last_write_checksum: sha1:3a09040a82da5ad5446ffe297629b3dce887868e
     pristine_git_object: 89364ed6208c4c999b317d23d7d954d63ac46bc5
   internal/sdk/serviceinfo.go:
     id: 085db9a15b34
@@ -4464,6 +4464,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 359184
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "aws", "keys": {"accessKey": "AKIAIOSFODNN7EXAMPLE"}}}
@@ -4503,6 +4505,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 248753
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "azure", "keys": {"discriminator": "azure", "batchName": "myazurebatch", "storageName": "myazurestorage"}}}
@@ -4542,6 +4546,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 197308
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "bitbucket", "baseUrl": "https://bitbucket.org/myorg", "keys": {"username": "myuser@example.com"}}}
@@ -4579,6 +4585,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 340322
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "codecommit", "baseUrl": "https://git-codecommit.us-east-1.amazonaws.com", "keys": {"username": "AKIAIOSFODNN7EXAMPLE"}}}
@@ -4616,6 +4624,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 626039
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "container-reg", "keys": {"userName": "myuser", "registry": "docker.io"}}}
@@ -4653,6 +4663,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 829482
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "google", "keys": {"workloadIdentityProvider": "projects/123456789012/locations/global/workloadIdentityPools/seqera-pool/providers/seqera-provider", "serviceAccountEmail": "seqera-runner@my-project.iam.gserviceaccount.com", "keyType": "google"}}}
@@ -4692,6 +4704,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 854272
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "gitea", "baseUrl": "https://gitea.mycompany.com", "keys": {"username": "myuser"}}}
@@ -4729,6 +4743,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 154616
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "github", "baseUrl": "https://github.mycompany.com", "keys": {"username": "octocat"}}}
@@ -4766,6 +4782,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 841024
       responses:
         "200":
           application/json: {"credentials": {"name": "<value>", "provider": "gitlab", "baseUrl": "https://gitlab.mycompany.com", "keys": {"username": "gitlab-user"}}}
@@ -4803,6 +4821,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 826684
       responses:
         "200":
           application/json: {}
@@ -4840,6 +4860,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 363750
       responses:
         "200":
           application/json: {}
@@ -4877,6 +4899,8 @@ examples:
       parameters:
         path:
           credentialsId: "<id>"
+        query:
+          workspaceId: 673032
       responses:
         "200":
           application/json: {}

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -10939,6 +10939,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -11125,6 +11126,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -11306,6 +11308,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -11483,6 +11486,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -11658,6 +11662,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -11835,6 +11840,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -12016,6 +12022,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -12191,6 +12198,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -12366,6 +12374,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -12541,6 +12550,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -12716,6 +12726,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64
@@ -12893,6 +12904,7 @@ paths:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -22774,6 +22774,8 @@ components:
           x-speakeasy-entity: AWSCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-entity-description: |
+            **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
+
             Manage AWS credentials in Seqera platform using this resource.
 
             AWS credentials store authentication information for accessing AWS services
@@ -22899,6 +22901,8 @@ components:
           x-speakeasy-entity: AzureCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-entity-description: |
+            **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
+
             Manage Azure credentials in Seqera platform using this resource.
 
             Azure credentials support three authentication modes: shared key
@@ -23062,7 +23066,7 @@ components:
           x-speakeasy-entity: BitbucketCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-terraform-resource-name: bitbucket_credential
-          x-speakeasy-entity-description: 'Manage Bitbucket credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Bitbucket credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Bitbucket credentials store authentication information for accessing Bitbucket
@@ -23169,7 +23173,7 @@ components:
           x-speakeasy-entity: CodecommitCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-terraform-resource-name: codecommit_credential
-          x-speakeasy-entity-description: 'Manage Codecommit credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Codecommit credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Codecommit credentials store AWS authentication information for accessing
@@ -23271,7 +23275,7 @@ components:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: ContainerRegistryCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage container registry credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage container registry credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Container registry credentials store authentication information for accessing
@@ -23378,6 +23382,8 @@ components:
           x-speakeasy-entity: GoogleCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-entity-description: |
+            **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
+
             Manage Google credentials in Seqera platform using this resource.
 
             Google credentials authenticate to Google Cloud either with a service account
@@ -23508,7 +23514,7 @@ components:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: GiteaCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage Gitea credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Gitea credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Gitea credentials store authentication information for accessing Gitea
@@ -23615,7 +23621,7 @@ components:
           x-speakeasy-entity: GithubCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-terraform-resource-name: github_credential
-          x-speakeasy-entity-description: 'Manage GitHub credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage GitHub credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             GitHub credentials store authentication information for accessing GitHub
@@ -23722,7 +23728,7 @@ components:
           x-speakeasy-entity: GitlabCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-terraform-resource-name: gitlab_credential
-          x-speakeasy-entity-description: 'Manage GitLab credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage GitLab credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             GitLab credentials store authentication information for accessing GitLab
@@ -23821,7 +23827,7 @@ components:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: KubernetesCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage Kubernetes credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Kubernetes credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Kubernetes credentials enable secure connections to Kubernetes clusters for workflow
@@ -23931,7 +23937,7 @@ components:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: SSHCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage SSH credentials in Seqera platform using this resource. SSH credentials store SSH private keys for secure access to remote compute environments and resources within the Seqera Platform workflows. '
+          x-speakeasy-entity-description: 'Manage SSH credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource. SSH credentials store SSH private keys for secure access to remote compute environments and resources within the Seqera Platform workflows. '
           type: object
           required:
             - privateKey
@@ -24031,7 +24037,7 @@ components:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: TowerAgentCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage Tower Agent credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Tower Agent credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Tower Agent credentials store connection IDs for Tower Agent instances that

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.761.11
+speakeasyVersion: 1.762.0
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:e790b833ab8aa0defb152b8d491dbfe92c9f62041e91026fd7322ea0ed1e153c
-        sourceBlobDigest: sha256:54f3b7833ee129c5b6d833b8e51dfc235dd96dec52e24a73f1f5ac45d1ad3769
+        sourceRevisionDigest: sha256:b706505b24e8191b7a1850a886cef15bee704ede2a4f8627bcae3c897913f607
+        sourceBlobDigest: sha256:6c61807718df377677989f068a51160de8d815323cea550df5cbe95c645160c0
         tags:
             - latest
             - 1.147.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:e790b833ab8aa0defb152b8d491dbfe92c9f62041e91026fd7322ea0ed1e153c
-        sourceBlobDigest: sha256:54f3b7833ee129c5b6d833b8e51dfc235dd96dec52e24a73f1f5ac45d1ad3769
+        sourceRevisionDigest: sha256:b706505b24e8191b7a1850a886cef15bee704ede2a4f8627bcae3c897913f607
+        sourceBlobDigest: sha256:6c61807718df377677989f068a51160de8d815323cea550df5cbe95c645160c0
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:63a340a605c71b9e7cc23af2345e7a59fa8842c9c47087ed9c14db1c081078a1
-        sourceBlobDigest: sha256:db23314e8d537165f250194c124c535872cc29c6a129a1226e687ab46cbab2cf
+        sourceRevisionDigest: sha256:9dbcb07a4027190d602e07e4772aeb53444ae457655520279730879fc966585a
+        sourceBlobDigest: sha256:3c494242c4cc83f782a22f9541bfdd65fa7ddc1a96fa83528d881c177cb0bf4b
         tags:
             - latest
             - 1.147.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:63a340a605c71b9e7cc23af2345e7a59fa8842c9c47087ed9c14db1c081078a1
-        sourceBlobDigest: sha256:db23314e8d537165f250194c124c535872cc29c6a129a1226e687ab46cbab2cf
+        sourceRevisionDigest: sha256:9dbcb07a4027190d602e07e4772aeb53444ae457655520279730879fc966585a
+        sourceBlobDigest: sha256:3c494242c4cc83f782a22f9541bfdd65fa7ddc1a96fa83528d881c177cb0bf4b
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.762.0
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:b706505b24e8191b7a1850a886cef15bee704ede2a4f8627bcae3c897913f607
-        sourceBlobDigest: sha256:6c61807718df377677989f068a51160de8d815323cea550df5cbe95c645160c0
+        sourceRevisionDigest: sha256:81ef35531b9d6ee6b4bdac26101301904d6a52796097d20f948342308d44a586
+        sourceBlobDigest: sha256:f6bf76b85b590b378c1fe7f2640c52ebecd76ca5fde685d722d3a288410e843b
         tags:
             - latest
             - 1.147.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:b706505b24e8191b7a1850a886cef15bee704ede2a4f8627bcae3c897913f607
-        sourceBlobDigest: sha256:6c61807718df377677989f068a51160de8d815323cea550df5cbe95c645160c0
+        sourceRevisionDigest: sha256:81ef35531b9d6ee6b4bdac26101301904d6a52796097d20f948342308d44a586
+        sourceBlobDigest: sha256:f6bf76b85b590b378c1fe7f2640c52ebecd76ca5fde685d722d3a288410e843b
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 > [!CAUTION]
 > **Deprecated Resources** - Resources marked as deprecated should be avoided in new configurations, as they will be removed for the stable release. Please migrate to their recommended replacements if available.
 
+> [!IMPORTANT]
+> **Scope of testing** — This provider is tested and validated for use within a Seqera **organization workspace**. Use against a personal (user-context) workspace is not part of our test matrix and may not work consistently across all resources — typed credential resources in particular are workspace-scoped only. If you need to manage user-context credentials, use the generic `seqera_credential` resource and please report any issues via [GitHub](https://github.com/seqeralabs/terraform-provider-seqera/issues).
+
 
 Terraform Provider for the Seqera Platform API.
 

--- a/docs/guides/migrating-from-seqera-credential.md
+++ b/docs/guides/migrating-from-seqera-credential.md
@@ -1,0 +1,253 @@
+---
+page_title: "Migrating from seqera_credential to typed credential resources"
+subcategory: "Upgrade Guides"
+description: |-
+  Step-by-step guide for migrating existing seqera_credential resources to the per-provider typed credentials (seqera_aws_credential, seqera_bitbucket_credential, seqera_github_credential, etc.) without destroying the underlying Seqera Platform credential.
+---
+
+# Migrating from `seqera_credential` to typed credential resources
+
+The provider exposes both a generic `seqera_credential` resource (one resource type, a `keys` block per provider) and per-provider typed resources (`seqera_aws_credential`, `seqera_github_credential`, `seqera_bitbucket_credential`, …). The typed resources have provider-specific schemas, plan-time validators, and clearer documentation. New configurations should use them.
+
+This guide walks through migrating an existing `seqera_credential` to the matching typed resource without destroying the underlying credential on Seqera Platform.
+
+## Why migrate
+
+- Provider-specific plan-time validation (e.g. mutually-exclusive auth fields, required-pair checks).
+- Clearer field names — flat top-level attributes instead of a nested `keys.<provider>` block.
+- Per-provider documentation pages with field-level guidance.
+- Generic `seqera_credential` will eventually be deprecated in favour of the typed resources.
+
+## Approach
+
+Migration uses Terraform's import/removal flow rather than `moved {}` blocks. `moved {}` only works between resources of the same type (or when the destination resource declares an explicit `MoveState` for the source type, which the credential resources do not). What you can do today:
+
+1. **Terraform 1.7+ — single-plan migration** using `import {}` and `removed {}` blocks. Recommended.
+2. **Terraform 1.5–1.6** — `terraform state rm` followed by `terraform import` (or an `import {}` block). Same end state, two commands.
+
+The underlying Seqera Platform credential is never touched — only Terraform state is rewritten.
+
+## What you need
+
+- The credential's `credentials_id` (from `terraform state show seqera_credential.<name>`, the `credentials_id` attribute).
+- The `workspace_id` it lives in (also visible in state, or in your existing config).
+- The credential's secret values (token/password/key data). These are write-only — the provider never reads them back from the API, so the typed resource will need them re-supplied in config (typically via the same `var.…` you already use).
+
+## Provider mapping
+
+The `keys.<provider>` sub-block in `seqera_credential` maps to a typed resource as follows:
+
+| `seqera_credential.keys` block | Typed resource | Notable field renames |
+| --- | --- | --- |
+| `aws` | `seqera_aws_credential` | `access_key`, `secret_key`, `assume_role_arn` |
+| `azure` / `azure_cloud` / `azure_entra` | `seqera_azure_credential` | `batch_name`, `storage_name`, `batch_key`, `storage_key`, `tenant_id`, `client_id`, `client_secret` |
+| `bitbucket` | `seqera_bitbucket_credential` | `username`, `password`, `token` |
+| `codecommit` | `seqera_codecommit_credential` | `username` → `access_key`, `password` → `secret_key` |
+| `container_reg` | `seqera_container_registry_credential` | `username`, `password`, `registry` |
+| `gitea` | `seqera_gitea_credential` | `username`, `password` |
+| `github` | `seqera_github_credential` | `password` → `access_token` |
+| `gitlab` | `seqera_gitlab_credential` | `username`, `token` |
+| `google` | `seqera_google_credential` | `data` (service account JSON) |
+| `k8s` | `seqera_kubernetes_credential` | `data` (kubeconfig) |
+| `ssh` | `seqera_ssh_credential` | `private_key`, `passphrase` |
+| `tw_agent` | `seqera_tower_agent_credential` | `connection_id`, `work_dir` |
+
+In all cases the top-level fields (`name`, `workspace_id`, `base_url`, `provider_type`) keep their names.
+
+## Worked example: Bitbucket
+
+### Before
+
+```terraform
+resource "seqera_credential" "bitbucket" {
+  name         = "bitbucket-main"
+  workspace_id = seqera_workspace.main.id
+  base_url     = "https://bitbucket.org/seqeralabs"
+
+  keys = {
+    bitbucket = {
+      username = var.bitbucket_username
+      password = var.bitbucket_password
+    }
+  }
+}
+```
+
+### Step 1 — capture the IDs
+
+```shell
+terraform state show seqera_credential.bitbucket | grep -E 'credentials_id|workspace_id'
+```
+
+Note the values; you'll need them in step 2.
+
+### Step 2 — rewrite the resource and add migration blocks (Terraform 1.7+)
+
+```terraform
+resource "seqera_bitbucket_credential" "bitbucket" {
+  name         = "bitbucket-main"
+  workspace_id = seqera_workspace.main.id
+  base_url     = "https://bitbucket.org/seqeralabs"
+
+  username = var.bitbucket_username
+  password = var.bitbucket_password
+}
+
+import {
+  to = seqera_bitbucket_credential.bitbucket
+  id = jsonencode({
+    credentials_id = "abc123XYZ"   # from step 1
+    workspace_id   = 1234567890    # from step 1
+  })
+}
+
+removed {
+  from = seqera_credential.bitbucket
+  lifecycle {
+    destroy = false   # important — keeps the Platform credential alive
+  }
+}
+```
+
+### Step 3 — apply
+
+```shell
+terraform plan
+terraform apply
+```
+
+Terraform imports the credential under the new resource address and drops the old one from state without calling Delete. Confirm with:
+
+```shell
+terraform state list | grep credential
+```
+
+You should see `seqera_bitbucket_credential.bitbucket` and no `seqera_credential.bitbucket`.
+
+### Step 4 — clean up
+
+Once the plan is clean (no diff), remove the `import {}` and `removed {}` blocks. They are one-shot — leaving them in is harmless but adds noise.
+
+## Older Terraform (1.5–1.6)
+
+Same end state, two steps:
+
+```shell
+# 1. Drop the old resource from state without touching the Platform credential
+terraform state rm seqera_credential.bitbucket
+
+# 2. Import under the new typed resource address
+terraform import 'seqera_bitbucket_credential.bitbucket' \
+  '{"credentials_id": "abc123XYZ", "workspace_id": 1234567890}'
+```
+
+Then run `terraform plan` and confirm no diff. The typed `resource "seqera_bitbucket_credential" "bitbucket" { … }` block must already be in your config before the import.
+
+## Worked example: GitHub
+
+### Before
+
+```terraform
+resource "seqera_credential" "github" {
+  name         = "github-main"
+  workspace_id = seqera_workspace.main.id
+  base_url     = "https://github.com/seqeralabs"
+
+  keys = {
+    github = {
+      username = var.github_username
+      password = var.github_token   # PAT goes in `password`
+    }
+  }
+}
+```
+
+### After
+
+```terraform
+resource "seqera_github_credential" "github" {
+  name         = "github-main"
+  workspace_id = seqera_workspace.main.id
+  base_url     = "https://github.com/seqeralabs"
+
+  username     = var.github_username
+  access_token = var.github_token   # renamed from `password`
+}
+
+import {
+  to = seqera_github_credential.github
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
+}
+
+removed {
+  from = seqera_credential.github
+  lifecycle { destroy = false }
+}
+```
+
+The only field-level change: the PAT moves from `keys.github.password` to a top-level `access_token`.
+
+## Worked example: AWS
+
+### Before
+
+```terraform
+resource "seqera_credential" "aws" {
+  name         = "aws-main"
+  workspace_id = seqera_workspace.main.id
+
+  keys = {
+    aws = {
+      accessKey     = var.aws_access_key
+      secretKey     = var.aws_secret_key
+      assumeRoleArn = "arn:aws:iam::123456789012:role/SeqeraRole"
+    }
+  }
+}
+```
+
+### After
+
+```terraform
+resource "seqera_aws_credential" "aws" {
+  name         = "aws-main"
+  workspace_id = seqera_workspace.main.id
+
+  access_key      = var.aws_access_key
+  secret_key      = var.aws_secret_key
+  assume_role_arn = "arn:aws:iam::123456789012:role/SeqeraRole"
+}
+
+import {
+  to = seqera_aws_credential.aws
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
+}
+
+removed {
+  from = seqera_credential.aws
+  lifecycle { destroy = false }
+}
+```
+
+Field renames: `accessKey` → `access_key`, `secretKey` → `secret_key`, `assumeRoleArn` → `assume_role_arn`.
+
+## Verifying the migration
+
+After apply:
+
+- `terraform plan` should report **no changes**.
+- The Seqera Platform UI should show the same credential record (same ID, same name, same workspace).
+- Any compute environments / pipelines / actions referencing the credential by ID continue to work without re-creation, because the underlying Platform record is unchanged.
+
+## Common pitfalls
+
+- **Forgot `lifecycle { destroy = false }` in the `removed {}` block.** Without it, Terraform will Delete the credential — which destroys the Platform record, including any compute environment associations. Always include it.
+- **`workspace_id` is `0` in the import ID.** The `0` placeholder in the snippets is just illustrative — replace it with the real numeric workspace ID. A `0` value will fail the import.
+- **Secret values out of sync after import.** Write-only fields (`password`, `token`, `access_token`, `secret_key`, etc.) are never read back from the API. After import, the config's value is what gets sent on the next Update; if the value differs from what's in the platform you'll silently rotate the secret on the next apply. Re-supply the same secret you used originally.
+- **Leftover `import {}` / `removed {}` blocks.** They're one-shot. Once apply is clean, remove them — otherwise every plan re-evaluates them (no-op but noisy).

--- a/docs/guides/migrating-from-seqera-credential.md
+++ b/docs/guides/migrating-from-seqera-credential.md
@@ -11,6 +11,8 @@ The provider exposes both a generic `seqera_credential` resource (one resource t
 
 This guide walks through migrating an existing `seqera_credential` to the matching typed resource without destroying the underlying credential on Seqera Platform.
 
+~> **Workspace-scoped only.** The typed credential resources are tested and validated for use within a Seqera organization workspace. User-context (personal) credentials are not supported on the typed resources — keep using `seqera_credential` for those.
+
 ## Why migrate
 
 - Provider-specific plan-time validation (e.g. mutually-exclusive auth fields, required-pair checks).

--- a/docs/resources/aws_credential.md
+++ b/docs/resources/aws_credential.md
@@ -2,12 +2,15 @@
 page_title: "seqera_aws_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
+  Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Manage AWS credentials in Seqera platform using this resource.
   AWS credentials store authentication information for accessing AWS services
   within the Seqera Platform workflows.
 ---
 
 # seqera_aws_credential (Resource)
+
+**Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Manage AWS credentials in Seqera platform using this resource.
 

--- a/docs/resources/aws_credential.md
+++ b/docs/resources/aws_credential.md
@@ -152,12 +152,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_aws_credential.my_seqera_aws_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_aws_credential.my_seqera_aws_credential "..."
+terraform import seqera_aws_credential.my_seqera_aws_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/azure_credential.md
+++ b/docs/resources/azure_credential.md
@@ -2,6 +2,7 @@
 page_title: "seqera_azure_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
+  Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Manage Azure credentials in Seqera platform using this resource.
   Azure credentials support three authentication modes: shared key
   (batch_key and storage_key, discriminator 'azure'), Entra service
@@ -11,6 +12,8 @@ description: |-
 ---
 
 # seqera_azure_credential (Resource)
+
+**Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Manage Azure credentials in Seqera platform using this resource.
 

--- a/docs/resources/azure_credential.md
+++ b/docs/resources/azure_credential.md
@@ -81,12 +81,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_azure_credential.my_seqera_azure_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_azure_credential.my_seqera_azure_credential "..."
+terraform import seqera_azure_credential.my_seqera_azure_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/bitbucket_credential.md
+++ b/docs/resources/bitbucket_credential.md
@@ -2,14 +2,14 @@
 page_title: "seqera_bitbucket_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage Bitbucket credentials in Seqera platform using this resource.
+  Manage Bitbucket credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Bitbucket credentials store authentication information for accessing Bitbucket
   repositories within the Seqera Platform workflows.
 ---
 
 # seqera_bitbucket_credential (Resource)
 
-Manage Bitbucket credentials in Seqera platform using this resource.
+Manage Bitbucket credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Bitbucket credentials store authentication information for accessing Bitbucket
 repositories within the Seqera Platform workflows.

--- a/docs/resources/bitbucket_credential.md
+++ b/docs/resources/bitbucket_credential.md
@@ -65,12 +65,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_bitbucket_credential.my_seqera_bitbucket_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_bitbucket_credential.my_seqera_bitbucket_credential "..."
+terraform import seqera_bitbucket_credential.my_seqera_bitbucket_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/codecommit_credential.md
+++ b/docs/resources/codecommit_credential.md
@@ -2,14 +2,14 @@
 page_title: "seqera_codecommit_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage Codecommit credentials in Seqera platform using this resource.
+  Manage Codecommit credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Codecommit credentials store AWS authentication information for accessing
   AWS Codecommit repositories within the Seqera Platform workflows.
 ---
 
 # seqera_codecommit_credential (Resource)
 
-Manage Codecommit credentials in Seqera platform using this resource.
+Manage Codecommit credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Codecommit credentials store AWS authentication information for accessing
 AWS Codecommit repositories within the Seqera Platform workflows.

--- a/docs/resources/codecommit_credential.md
+++ b/docs/resources/codecommit_credential.md
@@ -65,12 +65,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_codecommit_credential.my_seqera_codecommit_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_codecommit_credential.my_seqera_codecommit_credential "..."
+terraform import seqera_codecommit_credential.my_seqera_codecommit_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/container_registry_credential.md
+++ b/docs/resources/container_registry_credential.md
@@ -2,14 +2,14 @@
 page_title: "seqera_container_registry_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage container registry credentials in Seqera platform using this resource.
+  Manage container registry credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Container registry credentials store authentication information for accessing
   container registries (Docker Hub, ECR, GCR, ACR, etc.) within the Seqera Platform workflows.
 ---
 
 # seqera_container_registry_credential (Resource)
 
-Manage container registry credentials in Seqera platform using this resource.
+Manage container registry credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Container registry credentials store authentication information for accessing
 container registries (Docker Hub, ECR, GCR, ACR, etc.) within the Seqera Platform workflows.

--- a/docs/resources/container_registry_credential.md
+++ b/docs/resources/container_registry_credential.md
@@ -88,12 +88,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_container_registry_credential.my_seqera_container_registry_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_container_registry_credential.my_seqera_container_registry_credential "..."
+terraform import seqera_container_registry_credential.my_seqera_container_registry_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/gitea_credential.md
+++ b/docs/resources/gitea_credential.md
@@ -66,12 +66,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_gitea_credential.my_seqera_gitea_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_gitea_credential.my_seqera_gitea_credential "..."
+terraform import seqera_gitea_credential.my_seqera_gitea_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/gitea_credential.md
+++ b/docs/resources/gitea_credential.md
@@ -2,14 +2,14 @@
 page_title: "seqera_gitea_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage Gitea credentials in Seqera platform using this resource.
+  Manage Gitea credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Gitea credentials store authentication information for accessing Gitea
   repositories within the Seqera Platform workflows.
 ---
 
 # seqera_gitea_credential (Resource)
 
-Manage Gitea credentials in Seqera platform using this resource.
+Manage Gitea credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Gitea credentials store authentication information for accessing Gitea
 repositories within the Seqera Platform workflows.

--- a/docs/resources/github_credential.md
+++ b/docs/resources/github_credential.md
@@ -2,14 +2,14 @@
 page_title: "seqera_github_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage GitHub credentials in Seqera platform using this resource.
+  Manage GitHub credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   GitHub credentials store authentication information for accessing GitHub
   repositories within the Seqera Platform workflows.
 ---
 
 # seqera_github_credential (Resource)
 
-Manage GitHub credentials in Seqera platform using this resource.
+Manage GitHub credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 GitHub credentials store authentication information for accessing GitHub
 repositories within the Seqera Platform workflows.

--- a/docs/resources/github_credential.md
+++ b/docs/resources/github_credential.md
@@ -87,12 +87,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_github_credential.my_seqera_github_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_github_credential.my_seqera_github_credential "..."
+terraform import seqera_github_credential.my_seqera_github_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/gitlab_credential.md
+++ b/docs/resources/gitlab_credential.md
@@ -87,12 +87,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_gitlab_credential.my_seqera_gitlab_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_gitlab_credential.my_seqera_gitlab_credential "..."
+terraform import seqera_gitlab_credential.my_seqera_gitlab_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/gitlab_credential.md
+++ b/docs/resources/gitlab_credential.md
@@ -2,14 +2,14 @@
 page_title: "seqera_gitlab_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage GitLab credentials in Seqera platform using this resource.
+  Manage GitLab credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   GitLab credentials store authentication information for accessing GitLab
   repositories within the Seqera Platform workflows.
 ---
 
 # seqera_gitlab_credential (Resource)
 
-Manage GitLab credentials in Seqera platform using this resource.
+Manage GitLab credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 GitLab credentials store authentication information for accessing GitLab
 repositories within the Seqera Platform workflows.

--- a/docs/resources/google_credential.md
+++ b/docs/resources/google_credential.md
@@ -2,6 +2,7 @@
 page_title: "seqera_google_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
+  Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Manage Google credentials in Seqera platform using this resource.
   Google credentials authenticate to Google Cloud either with a service account
   key (data) or via Workload Identity Federation (workload_identity_provider
@@ -10,6 +11,8 @@ description: |-
 ---
 
 # seqera_google_credential (Resource)
+
+**Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Manage Google credentials in Seqera platform using this resource.
 

--- a/docs/resources/google_credential.md
+++ b/docs/resources/google_credential.md
@@ -77,7 +77,10 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_google_credential.my_seqera_google_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 

--- a/docs/resources/kubernetes_credential.md
+++ b/docs/resources/kubernetes_credential.md
@@ -66,12 +66,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_kubernetes_credential.my_seqera_kubernetes_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_kubernetes_credential.my_seqera_kubernetes_credential "..."
+terraform import seqera_kubernetes_credential.my_seqera_kubernetes_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/kubernetes_credential.md
+++ b/docs/resources/kubernetes_credential.md
@@ -2,14 +2,14 @@
 page_title: "seqera_kubernetes_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage Kubernetes credentials in Seqera platform using this resource.
+  Manage Kubernetes credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Kubernetes credentials enable secure connections to Kubernetes clusters for workflow
   execution. Supports two authentication methods: Service Account Token and X.509 Client Certificates.
 ---
 
 # seqera_kubernetes_credential (Resource)
 
-Manage Kubernetes credentials in Seqera platform using this resource.
+Manage Kubernetes credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Kubernetes credentials enable secure connections to Kubernetes clusters for workflow
 execution. Supports two authentication methods: Service Account Token and X.509 Client Certificates.

--- a/docs/resources/ssh_credential.md
+++ b/docs/resources/ssh_credential.md
@@ -63,12 +63,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_ssh_credential.my_seqera_ssh_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_ssh_credential.my_seqera_ssh_credential "..."
+terraform import seqera_ssh_credential.my_seqera_ssh_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/ssh_credential.md
+++ b/docs/resources/ssh_credential.md
@@ -2,12 +2,12 @@
 page_title: "seqera_ssh_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage SSH credentials in Seqera platform using this resource. SSH credentials store SSH private keys for secure access to remote compute environments and resources within the Seqera Platform workflows.
+  Manage SSH credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource. SSH credentials store SSH private keys for secure access to remote compute environments and resources within the Seqera Platform workflows.
 ---
 
 # seqera_ssh_credential (Resource)
 
-Manage SSH credentials in Seqera platform using this resource. SSH credentials store SSH private keys for secure access to remote compute environments and resources within the Seqera Platform workflows.
+Manage SSH credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource. SSH credentials store SSH private keys for secure access to remote compute environments and resources within the Seqera Platform workflows.
 
 ## Example Usage
 

--- a/docs/resources/tower_agent_credential.md
+++ b/docs/resources/tower_agent_credential.md
@@ -85,12 +85,15 @@ In Terraform v1.5.0 and later, the [`import` block](https://developer.hashicorp.
 ```terraform
 import {
   to = seqera_tower_agent_credential.my_seqera_tower_agent_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }
 ```
 
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-terraform import seqera_tower_agent_credential.my_seqera_tower_agent_credential "..."
+terraform import seqera_tower_agent_credential.my_seqera_tower_agent_credential '{"credentials_id": "...", "workspace_id": 0}'
 ```

--- a/docs/resources/tower_agent_credential.md
+++ b/docs/resources/tower_agent_credential.md
@@ -2,7 +2,7 @@
 page_title: "seqera_tower_agent_credential Resource - terraform-provider-seqera"
 subcategory: "Credentials"
 description: |-
-  Manage Tower Agent credentials in Seqera platform using this resource.
+  Manage Tower Agent credentials in Seqera platform using this resource. Note: This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic seqera_credential resource.
   Tower Agent credentials store connection IDs for Tower Agent instances that
   enable secure communication between the Seqera Platform and compute environments.
   IMPORTANT: The Tower Agent must be running and online before creating the credential.
@@ -12,7 +12,7 @@ description: |-
 
 # seqera_tower_agent_credential (Resource)
 
-Manage Tower Agent credentials in Seqera platform using this resource.
+Manage Tower Agent credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 Tower Agent credentials store connection IDs for Tower Agent instances that
 enable secure communication between the Seqera Platform and compute environments.

--- a/examples/resources/seqera_aws_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_aws_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_aws_credential.my_seqera_aws_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_aws_credential/import.sh
+++ b/examples/resources/seqera_aws_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_aws_credential.my_seqera_aws_credential "..."
+terraform import seqera_aws_credential.my_seqera_aws_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_azure_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_azure_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_azure_credential.my_seqera_azure_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_azure_credential/import.sh
+++ b/examples/resources/seqera_azure_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_azure_credential.my_seqera_azure_credential "..."
+terraform import seqera_azure_credential.my_seqera_azure_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_bitbucket_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_bitbucket_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_bitbucket_credential.my_seqera_bitbucket_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_bitbucket_credential/import.sh
+++ b/examples/resources/seqera_bitbucket_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_bitbucket_credential.my_seqera_bitbucket_credential "..."
+terraform import seqera_bitbucket_credential.my_seqera_bitbucket_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_codecommit_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_codecommit_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_codecommit_credential.my_seqera_codecommit_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_codecommit_credential/import.sh
+++ b/examples/resources/seqera_codecommit_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_codecommit_credential.my_seqera_codecommit_credential "..."
+terraform import seqera_codecommit_credential.my_seqera_codecommit_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_container_registry_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_container_registry_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_container_registry_credential.my_seqera_container_registry_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_container_registry_credential/import.sh
+++ b/examples/resources/seqera_container_registry_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_container_registry_credential.my_seqera_container_registry_credential "..."
+terraform import seqera_container_registry_credential.my_seqera_container_registry_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_gitea_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_gitea_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_gitea_credential.my_seqera_gitea_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_gitea_credential/import.sh
+++ b/examples/resources/seqera_gitea_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_gitea_credential.my_seqera_gitea_credential "..."
+terraform import seqera_gitea_credential.my_seqera_gitea_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_github_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_github_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_github_credential.my_seqera_github_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_github_credential/import.sh
+++ b/examples/resources/seqera_github_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_github_credential.my_seqera_github_credential "..."
+terraform import seqera_github_credential.my_seqera_github_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_gitlab_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_gitlab_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_gitlab_credential.my_seqera_gitlab_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_gitlab_credential/import.sh
+++ b/examples/resources/seqera_gitlab_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_gitlab_credential.my_seqera_gitlab_credential "..."
+terraform import seqera_gitlab_credential.my_seqera_gitlab_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_google_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_google_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_google_credential.my_seqera_google_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_kubernetes_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_kubernetes_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_kubernetes_credential.my_seqera_kubernetes_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_kubernetes_credential/import.sh
+++ b/examples/resources/seqera_kubernetes_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_kubernetes_credential.my_seqera_kubernetes_credential "..."
+terraform import seqera_kubernetes_credential.my_seqera_kubernetes_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_ssh_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_ssh_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_ssh_credential.my_seqera_ssh_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_ssh_credential/import.sh
+++ b/examples/resources/seqera_ssh_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_ssh_credential.my_seqera_ssh_credential "..."
+terraform import seqera_ssh_credential.my_seqera_ssh_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/examples/resources/seqera_tower_agent_credential/import-by-string-id.tf
+++ b/examples/resources/seqera_tower_agent_credential/import-by-string-id.tf
@@ -1,4 +1,7 @@
 import {
   to = seqera_tower_agent_credential.my_seqera_tower_agent_credential
-  id = "..."
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
 }

--- a/examples/resources/seqera_tower_agent_credential/import.sh
+++ b/examples/resources/seqera_tower_agent_credential/import.sh
@@ -1,1 +1,1 @@
-terraform import seqera_tower_agent_credential.my_seqera_tower_agent_credential "..."
+terraform import seqera_tower_agent_credential.my_seqera_tower_agent_credential '{"credentials_id": "...", "workspace_id": 0}'

--- a/internal/provider/awscredential_resource.go
+++ b/internal/provider/awscredential_resource.go
@@ -59,7 +59,7 @@ func (r *AWSCredentialResource) Metadata(ctx context.Context, req resource.Metad
 
 func (r *AWSCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage AWS credentials in Seqera platform using this resource.\n\nAWS credentials store authentication information for accessing AWS services\nwithin the Seqera Platform workflows.\n",
+		MarkdownDescription: "**Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nManage AWS credentials in Seqera platform using this resource.\n\nAWS credentials store authentication information for accessing AWS services\nwithin the Seqera Platform workflows.\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"access_key": schema.StringAttribute{

--- a/internal/provider/awscredential_resource.go
+++ b/internal/provider/awscredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -452,7 +454,24 @@ func (r *AWSCredentialResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 func (r *AWSCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *AWSCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/awscredential_resource_sdk.go
+++ b/internal/provider/awscredential_resource_sdk.go
@@ -134,12 +134,9 @@ func (r *AWSCredentialResourceModel) ToOperationsDescribeAWSCredentialsRequest(c
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeAWSCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/azurecredential_resource.go
+++ b/internal/provider/azurecredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -418,7 +420,24 @@ func (r *AzureCredentialResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func (r *AzureCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *AzureCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/azurecredential_resource.go
+++ b/internal/provider/azurecredential_resource.go
@@ -60,7 +60,7 @@ func (r *AzureCredentialResource) Metadata(ctx context.Context, req resource.Met
 
 func (r *AzureCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage Azure credentials in Seqera platform using this resource.\n\nAzure credentials support three authentication modes: shared key\n(batch_key and storage_key, discriminator 'azure'), Entra service\nprincipal (tenant_id, client_id, client_secret, discriminator\n'azure-entra'), and Cloud service principal (same fields as Entra,\ndiscriminator 'azure-cloud').\n",
+		MarkdownDescription: "**Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nManage Azure credentials in Seqera platform using this resource.\n\nAzure credentials support three authentication modes: shared key\n(batch_key and storage_key, discriminator 'azure'), Entra service\nprincipal (tenant_id, client_id, client_secret, discriminator\n'azure-entra'), and Cloud service principal (same fields as Entra,\ndiscriminator 'azure-cloud').\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"batch_key": schema.StringAttribute{

--- a/internal/provider/azurecredential_resource_sdk.go
+++ b/internal/provider/azurecredential_resource_sdk.go
@@ -122,12 +122,9 @@ func (r *AzureCredentialResourceModel) ToOperationsDescribeAzureCredentialsReque
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeAzureCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/bitbucketcredential_resource.go
+++ b/internal/provider/bitbucketcredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -378,7 +380,24 @@ func (r *BitbucketCredentialResource) Delete(ctx context.Context, req resource.D
 }
 
 func (r *BitbucketCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *BitbucketCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/bitbucketcredential_resource.go
+++ b/internal/provider/bitbucketcredential_resource.go
@@ -55,7 +55,7 @@ func (r *BitbucketCredentialResource) Metadata(ctx context.Context, req resource
 
 func (r *BitbucketCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage Bitbucket credentials in Seqera platform using this resource.\n\nBitbucket credentials store authentication information for accessing Bitbucket\nrepositories within the Seqera Platform workflows.\n",
+		MarkdownDescription: "Manage Bitbucket credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nBitbucket credentials store authentication information for accessing Bitbucket\nrepositories within the Seqera Platform workflows.\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{

--- a/internal/provider/bitbucketcredential_resource_sdk.go
+++ b/internal/provider/bitbucketcredential_resource_sdk.go
@@ -122,12 +122,9 @@ func (r *BitbucketCredentialResourceModel) ToOperationsDescribeBitbucketCredenti
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeBitbucketCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/codecommitcredential_resource.go
+++ b/internal/provider/codecommitcredential_resource.go
@@ -55,7 +55,7 @@ func (r *CodecommitCredentialResource) Metadata(ctx context.Context, req resourc
 
 func (r *CodecommitCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage Codecommit credentials in Seqera platform using this resource.\n\nCodecommit credentials store AWS authentication information for accessing\nAWS Codecommit repositories within the Seqera Platform workflows.\n",
+		MarkdownDescription: "Manage Codecommit credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nCodecommit credentials store AWS authentication information for accessing\nAWS Codecommit repositories within the Seqera Platform workflows.\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"access_key": schema.StringAttribute{

--- a/internal/provider/codecommitcredential_resource.go
+++ b/internal/provider/codecommitcredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -416,7 +418,24 @@ func (r *CodecommitCredentialResource) Delete(ctx context.Context, req resource.
 }
 
 func (r *CodecommitCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *CodecommitCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/codecommitcredential_resource_sdk.go
+++ b/internal/provider/codecommitcredential_resource_sdk.go
@@ -122,12 +122,9 @@ func (r *CodecommitCredentialResourceModel) ToOperationsDescribeCodecommitCreden
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeCodecommitCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/containerregistrycredential_resource.go
+++ b/internal/provider/containerregistrycredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -378,7 +380,24 @@ func (r *ContainerRegistryCredentialResource) Delete(ctx context.Context, req re
 }
 
 func (r *ContainerRegistryCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *ContainerRegistryCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/containerregistrycredential_resource.go
+++ b/internal/provider/containerregistrycredential_resource.go
@@ -55,7 +55,7 @@ func (r *ContainerRegistryCredentialResource) Metadata(ctx context.Context, req 
 
 func (r *ContainerRegistryCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage container registry credentials in Seqera platform using this resource.\n\nContainer registry credentials store authentication information for accessing\ncontainer registries (Docker Hub, ECR, GCR, ACR, etc.) within the Seqera Platform workflows.\n",
+		MarkdownDescription: "Manage container registry credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nContainer registry credentials store authentication information for accessing\ncontainer registries (Docker Hub, ECR, GCR, ACR, etc.) within the Seqera Platform workflows.\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"credentials_id": schema.StringAttribute{

--- a/internal/provider/containerregistrycredential_resource_sdk.go
+++ b/internal/provider/containerregistrycredential_resource_sdk.go
@@ -122,12 +122,9 @@ func (r *ContainerRegistryCredentialResourceModel) ToOperationsDescribeContainer
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeContainerRegistryCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/giteacredential_resource.go
+++ b/internal/provider/giteacredential_resource.go
@@ -55,7 +55,7 @@ func (r *GiteaCredentialResource) Metadata(ctx context.Context, req resource.Met
 
 func (r *GiteaCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage Gitea credentials in Seqera platform using this resource.\n\nGitea credentials store authentication information for accessing Gitea\nrepositories within the Seqera Platform workflows.\n",
+		MarkdownDescription: "Manage Gitea credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nGitea credentials store authentication information for accessing Gitea\nrepositories within the Seqera Platform workflows.\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{

--- a/internal/provider/giteacredential_resource.go
+++ b/internal/provider/giteacredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -378,7 +380,24 @@ func (r *GiteaCredentialResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func (r *GiteaCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *GiteaCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/giteacredential_resource_sdk.go
+++ b/internal/provider/giteacredential_resource_sdk.go
@@ -122,12 +122,9 @@ func (r *GiteaCredentialResourceModel) ToOperationsDescribeGiteaCredentialsReque
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeGiteaCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/githubcredential_resource.go
+++ b/internal/provider/githubcredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -378,7 +380,24 @@ func (r *GithubCredentialResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *GithubCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *GithubCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/githubcredential_resource.go
+++ b/internal/provider/githubcredential_resource.go
@@ -55,7 +55,7 @@ func (r *GithubCredentialResource) Metadata(ctx context.Context, req resource.Me
 
 func (r *GithubCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage GitHub credentials in Seqera platform using this resource.\n\nGitHub credentials store authentication information for accessing GitHub\nrepositories within the Seqera Platform workflows.\n",
+		MarkdownDescription: "Manage GitHub credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nGitHub credentials store authentication information for accessing GitHub\nrepositories within the Seqera Platform workflows.\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"access_token": schema.StringAttribute{

--- a/internal/provider/githubcredential_resource_sdk.go
+++ b/internal/provider/githubcredential_resource_sdk.go
@@ -122,12 +122,9 @@ func (r *GithubCredentialResourceModel) ToOperationsDescribeGithubCredentialsReq
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeGithubCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/gitlabcredential_resource.go
+++ b/internal/provider/gitlabcredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -378,7 +380,24 @@ func (r *GitlabCredentialResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *GitlabCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *GitlabCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/gitlabcredential_resource.go
+++ b/internal/provider/gitlabcredential_resource.go
@@ -55,7 +55,7 @@ func (r *GitlabCredentialResource) Metadata(ctx context.Context, req resource.Me
 
 func (r *GitlabCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage GitLab credentials in Seqera platform using this resource.\n\nGitLab credentials store authentication information for accessing GitLab\nrepositories within the Seqera Platform workflows.\n",
+		MarkdownDescription: "Manage GitLab credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nGitLab credentials store authentication information for accessing GitLab\nrepositories within the Seqera Platform workflows.\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"base_url": schema.StringAttribute{

--- a/internal/provider/gitlabcredential_resource_sdk.go
+++ b/internal/provider/gitlabcredential_resource_sdk.go
@@ -122,12 +122,9 @@ func (r *GitlabCredentialResourceModel) ToOperationsDescribeGitlabCredentialsReq
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeGitlabCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/googlecredential_resource.go
+++ b/internal/provider/googlecredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -435,7 +437,24 @@ func (r *GoogleCredentialResource) Delete(ctx context.Context, req resource.Dele
 }
 
 func (r *GoogleCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *GoogleCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/googlecredential_resource.go
+++ b/internal/provider/googlecredential_resource.go
@@ -57,7 +57,7 @@ func (r *GoogleCredentialResource) Metadata(ctx context.Context, req resource.Me
 
 func (r *GoogleCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage Google credentials in Seqera platform using this resource.\n\nGoogle credentials authenticate to Google Cloud either with a service account\nkey (`data`) or via Workload Identity Federation (`workload_identity_provider`\nand `service_account_email`). WIF is the recommended path — no long-lived key\nis stored in the platform.\n",
+		MarkdownDescription: "**Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nManage Google credentials in Seqera platform using this resource.\n\nGoogle credentials authenticate to Google Cloud either with a service account\nkey (`data`) or via Workload Identity Federation (`workload_identity_provider`\nand `service_account_email`). WIF is the recommended path — no long-lived key\nis stored in the platform.\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"credentials_id": schema.StringAttribute{

--- a/internal/provider/googlecredential_resource_sdk.go
+++ b/internal/provider/googlecredential_resource_sdk.go
@@ -123,12 +123,9 @@ func (r *GoogleCredentialResourceModel) ToOperationsDescribeGoogleCredentialsReq
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeGoogleCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/kubernetescredential_resource.go
+++ b/internal/provider/kubernetescredential_resource.go
@@ -55,7 +55,7 @@ func (r *KubernetesCredentialResource) Metadata(ctx context.Context, req resourc
 
 func (r *KubernetesCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage Kubernetes credentials in Seqera platform using this resource.\n\nKubernetes credentials enable secure connections to Kubernetes clusters for workflow\nexecution. Supports two authentication methods: Service Account Token and X.509 Client Certificates.",
+		MarkdownDescription: "Manage Kubernetes credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nKubernetes credentials enable secure connections to Kubernetes clusters for workflow\nexecution. Supports two authentication methods: Service Account Token and X.509 Client Certificates.",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"client_certificate": schema.StringAttribute{

--- a/internal/provider/kubernetescredential_resource.go
+++ b/internal/provider/kubernetescredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -382,7 +384,24 @@ func (r *KubernetesCredentialResource) Delete(ctx context.Context, req resource.
 }
 
 func (r *KubernetesCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *KubernetesCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/kubernetescredential_resource_sdk.go
+++ b/internal/provider/kubernetescredential_resource_sdk.go
@@ -107,12 +107,9 @@ func (r *KubernetesCredentialResourceModel) ToOperationsDescribeKubernetesCreden
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeKubernetesCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/sshcredential_resource.go
+++ b/internal/provider/sshcredential_resource.go
@@ -54,7 +54,7 @@ func (r *SSHCredentialResource) Metadata(ctx context.Context, req resource.Metad
 
 func (r *SSHCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage SSH credentials in Seqera platform using this resource. SSH credentials store SSH private keys for secure access to remote compute environments and resources within the Seqera Platform workflows. ",
+		MarkdownDescription: "Manage SSH credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource. SSH credentials store SSH private keys for secure access to remote compute environments and resources within the Seqera Platform workflows. ",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"credentials_id": schema.StringAttribute{

--- a/internal/provider/sshcredential_resource.go
+++ b/internal/provider/sshcredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -375,7 +377,24 @@ func (r *SSHCredentialResource) Delete(ctx context.Context, req resource.DeleteR
 }
 
 func (r *SSHCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *SSHCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/sshcredential_resource_sdk.go
+++ b/internal/provider/sshcredential_resource_sdk.go
@@ -107,12 +107,9 @@ func (r *SSHCredentialResourceModel) ToOperationsDescribeSSHCredentialsRequest(c
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeSSHCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/provider/toweragentcredential_resource.go
+++ b/internal/provider/toweragentcredential_resource.go
@@ -55,7 +55,7 @@ func (r *TowerAgentCredentialResource) Metadata(ctx context.Context, req resourc
 
 func (r *TowerAgentCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage Tower Agent credentials in Seqera platform using this resource.\n\nTower Agent credentials store connection IDs for Tower Agent instances that\nenable secure communication between the Seqera Platform and compute environments.\n\n**IMPORTANT**: The Tower Agent must be running and online before creating the credential.\nStart the agent with your connection ID first, then create the credential resource.\nIf the agent is not online, you will receive an error: \"The agent is not online - You need to run the agent before proceeding\".\n",
+		MarkdownDescription: "Manage Tower Agent credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.\n\nTower Agent credentials store connection IDs for Tower Agent instances that\nenable secure communication between the Seqera Platform and compute environments.\n\n**IMPORTANT**: The Tower Agent must be running and online before creating the credential.\nStart the agent with your connection ID first, then create the credential resource.\nIf the agent is not online, you will receive an error: \"The agent is not online - You need to run the agent before proceeding\".\n",
 		Version:             1,
 		Attributes: map[string]schema.Attribute{
 			"connection_id": schema.StringAttribute{

--- a/internal/provider/toweragentcredential_resource.go
+++ b/internal/provider/toweragentcredential_resource.go
@@ -3,7 +3,9 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -377,7 +379,24 @@ func (r *TowerAgentCredentialResource) Delete(ctx context.Context, req resource.
 }
 
 func (r *TowerAgentCredentialResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), req.ID)...)
+	dec := json.NewDecoder(bytes.NewReader([]byte(req.ID)))
+	dec.DisallowUnknownFields()
+	var data struct {
+		CredentialsID string `json:"credentials_id"`
+		WorkspaceID   int64  `json:"workspace_id"`
+	}
+
+	if err := dec.Decode(&data); err != nil {
+		resp.Diagnostics.AddError("Invalid ID", `The import ID is not valid. It is expected to be a JSON object string with the format: '{"credentials_id": "...", "workspace_id": 0}': `+err.Error())
+		return
+	}
+
+	if len(data.CredentialsID) == 0 {
+		resp.Diagnostics.AddError("Missing required field", `The field credentials_id is required but was not found in the json encoded ID.`)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_id"), data.CredentialsID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("workspace_id"), data.WorkspaceID)...)
 }
 
 func (r *TowerAgentCredentialResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/toweragentcredential_resource_sdk.go
+++ b/internal/provider/toweragentcredential_resource_sdk.go
@@ -115,12 +115,9 @@ func (r *TowerAgentCredentialResourceModel) ToOperationsDescribeTowerAgentCreden
 	var credentialsID string
 	credentialsID = r.CredentialsID.ValueString()
 
-	workspaceID := new(int64)
-	if !r.WorkspaceID.IsUnknown() && !r.WorkspaceID.IsNull() {
-		*workspaceID = r.WorkspaceID.ValueInt64()
-	} else {
-		workspaceID = nil
-	}
+	var workspaceID int64
+	workspaceID = r.WorkspaceID.ValueInt64()
+
 	out := operations.DescribeTowerAgentCredentialsRequest{
 		CredentialsID: credentialsID,
 		WorkspaceID:   workspaceID,

--- a/internal/sdk/models/operations/describeawscredentials.go
+++ b/internal/sdk/models/operations/describeawscredentials.go
@@ -11,7 +11,7 @@ type DescribeAWSCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeAWSCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeAWSCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeAWSCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeAWSCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describeazurecredentials.go
+++ b/internal/sdk/models/operations/describeazurecredentials.go
@@ -11,7 +11,7 @@ type DescribeAzureCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeAzureCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeAzureCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeAzureCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeAzureCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describebitbucketcredentials.go
+++ b/internal/sdk/models/operations/describebitbucketcredentials.go
@@ -11,7 +11,7 @@ type DescribeBitbucketCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeBitbucketCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeBitbucketCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeBitbucketCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeBitbucketCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describecodecommitcredentials.go
+++ b/internal/sdk/models/operations/describecodecommitcredentials.go
@@ -11,7 +11,7 @@ type DescribeCodecommitCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeCodecommitCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeCodecommitCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeCodecommitCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeCodecommitCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describecontainerregistrycredentials.go
+++ b/internal/sdk/models/operations/describecontainerregistrycredentials.go
@@ -11,7 +11,7 @@ type DescribeContainerRegistryCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeContainerRegistryCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeContainerRegistryCredentialsRequest) GetCredentialsID() string 
 	return d.CredentialsID
 }
 
-func (d *DescribeContainerRegistryCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeContainerRegistryCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describegiteacredentials.go
+++ b/internal/sdk/models/operations/describegiteacredentials.go
@@ -11,7 +11,7 @@ type DescribeGiteaCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeGiteaCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeGiteaCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeGiteaCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeGiteaCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describegithubcredentials.go
+++ b/internal/sdk/models/operations/describegithubcredentials.go
@@ -11,7 +11,7 @@ type DescribeGithubCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeGithubCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeGithubCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeGithubCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeGithubCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describegitlabcredentials.go
+++ b/internal/sdk/models/operations/describegitlabcredentials.go
@@ -11,7 +11,7 @@ type DescribeGitlabCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeGitlabCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeGitlabCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeGitlabCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeGitlabCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describegooglecredentials.go
+++ b/internal/sdk/models/operations/describegooglecredentials.go
@@ -11,7 +11,7 @@ type DescribeGoogleCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeGoogleCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeGoogleCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeGoogleCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeGoogleCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describekubernetescredentials.go
+++ b/internal/sdk/models/operations/describekubernetescredentials.go
@@ -11,7 +11,7 @@ type DescribeKubernetesCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeKubernetesCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeKubernetesCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeKubernetesCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeKubernetesCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describesshcredentials.go
+++ b/internal/sdk/models/operations/describesshcredentials.go
@@ -11,7 +11,7 @@ type DescribeSSHCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeSSHCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeSSHCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeSSHCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeSSHCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/models/operations/describetoweragentcredentials.go
+++ b/internal/sdk/models/operations/describetoweragentcredentials.go
@@ -11,7 +11,7 @@ type DescribeTowerAgentCredentialsRequest struct {
 	// Credentials string identifier
 	CredentialsID string `pathParam:"style=simple,explode=false,name=credentialsId"`
 	// Workspace numeric identifier
-	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	WorkspaceID int64 `queryParam:"style=form,explode=true,name=workspaceId"`
 }
 
 func (d *DescribeTowerAgentCredentialsRequest) GetCredentialsID() string {
@@ -21,9 +21,9 @@ func (d *DescribeTowerAgentCredentialsRequest) GetCredentialsID() string {
 	return d.CredentialsID
 }
 
-func (d *DescribeTowerAgentCredentialsRequest) GetWorkspaceID() *int64 {
+func (d *DescribeTowerAgentCredentialsRequest) GetWorkspaceID() int64 {
 	if d == nil {
-		return nil
+		return 0
 	}
 	return d.WorkspaceID
 }

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.147.0 and generator version 2.881.17
+// Generated from OpenAPI doc version 1.147.0 and generator version 2.882.0
 
 import (
 	"context"
@@ -175,7 +175,7 @@ func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
 		SDKVersion: "0.40.0-RC2",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC2 2.881.17 1.147.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC2 2.882.0 1.147.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/overlays/credentials-aws.yaml
+++ b/overlays/credentials-aws.yaml
@@ -267,6 +267,8 @@ actions:
           x-speakeasy-entity: AWSCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-entity-description: |
+            **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
+
             Manage AWS credentials in Seqera platform using this resource.
 
             AWS credentials store authentication information for accessing AWS services

--- a/overlays/credentials-aws.yaml
+++ b/overlays/credentials-aws.yaml
@@ -83,6 +83,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-azure.yaml
+++ b/overlays/credentials-azure.yaml
@@ -259,6 +259,8 @@ actions:
           x-speakeasy-entity: AzureCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-entity-description: |
+            **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
+
             Manage Azure credentials in Seqera platform using this resource.
 
             Azure credentials support three authentication modes: shared key

--- a/overlays/credentials-azure.yaml
+++ b/overlays/credentials-azure.yaml
@@ -80,6 +80,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-bitbucket.yaml
+++ b/overlays/credentials-bitbucket.yaml
@@ -254,7 +254,7 @@ actions:
           x-speakeasy-entity: BitbucketCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-terraform-resource-name: bitbucket_credential
-          x-speakeasy-entity-description: 'Manage Bitbucket credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Bitbucket credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Bitbucket credentials store authentication information for accessing Bitbucket

--- a/overlays/credentials-bitbucket.yaml
+++ b/overlays/credentials-bitbucket.yaml
@@ -80,6 +80,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-codecommit.yaml
+++ b/overlays/credentials-codecommit.yaml
@@ -78,6 +78,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-codecommit.yaml
+++ b/overlays/credentials-codecommit.yaml
@@ -252,7 +252,7 @@ actions:
           x-speakeasy-entity: CodecommitCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-terraform-resource-name: codecommit_credential
-          x-speakeasy-entity-description: 'Manage Codecommit credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Codecommit credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Codecommit credentials store AWS authentication information for accessing

--- a/overlays/credentials-container-registry.yaml
+++ b/overlays/credentials-container-registry.yaml
@@ -247,7 +247,7 @@ actions:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: ContainerRegistryCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage container registry credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage container registry credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Container registry credentials store authentication information for accessing

--- a/overlays/credentials-container-registry.yaml
+++ b/overlays/credentials-container-registry.yaml
@@ -80,6 +80,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-gcp.yaml
+++ b/overlays/credentials-gcp.yaml
@@ -253,6 +253,8 @@ actions:
           x-speakeasy-entity: GoogleCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-entity-description: |
+            **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
+
             Manage Google credentials in Seqera platform using this resource.
 
             Google credentials authenticate to Google Cloud either with a service account

--- a/overlays/credentials-gcp.yaml
+++ b/overlays/credentials-gcp.yaml
@@ -78,6 +78,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-gitea.yaml
+++ b/overlays/credentials-gitea.yaml
@@ -80,6 +80,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-gitea.yaml
+++ b/overlays/credentials-gitea.yaml
@@ -253,7 +253,7 @@ actions:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: GiteaCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage Gitea credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Gitea credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Gitea credentials store authentication information for accessing Gitea

--- a/overlays/credentials-github.yaml
+++ b/overlays/credentials-github.yaml
@@ -80,6 +80,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-github.yaml
+++ b/overlays/credentials-github.yaml
@@ -255,7 +255,7 @@ actions:
           x-speakeasy-entity: GithubCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-terraform-resource-name: github_credential
-          x-speakeasy-entity-description: 'Manage GitHub credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage GitHub credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             GitHub credentials store authentication information for accessing GitHub

--- a/overlays/credentials-gitlab.yaml
+++ b/overlays/credentials-gitlab.yaml
@@ -80,6 +80,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-gitlab.yaml
+++ b/overlays/credentials-gitlab.yaml
@@ -255,7 +255,7 @@ actions:
           x-speakeasy-entity: GitlabCredential
           x-speakeasy-entity-version: 1
           x-speakeasy-terraform-resource-name: gitlab_credential
-          x-speakeasy-entity-description: 'Manage GitLab credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage GitLab credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             GitLab credentials store authentication information for accessing GitLab

--- a/overlays/credentials-kubernetes.yaml
+++ b/overlays/credentials-kubernetes.yaml
@@ -247,7 +247,7 @@ actions:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: KubernetesCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage Kubernetes credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage Kubernetes credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
             Kubernetes credentials enable secure connections to Kubernetes clusters for workflow

--- a/overlays/credentials-kubernetes.yaml
+++ b/overlays/credentials-kubernetes.yaml
@@ -80,6 +80,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-ssh.yaml
+++ b/overlays/credentials-ssh.yaml
@@ -76,6 +76,7 @@ actions:
         - name: workspaceId
           in: query
           description: Workspace numeric identifier
+          required: true
           schema:
             type: integer
             format: int64

--- a/overlays/credentials-ssh.yaml
+++ b/overlays/credentials-ssh.yaml
@@ -239,7 +239,7 @@ actions:
           x-speakeasy-param-readonly: true
           x-speakeasy-entity: SSHCredential
           x-speakeasy-entity-version: 1
-          x-speakeasy-entity-description: 'Manage SSH credentials in Seqera platform using this resource.
+          x-speakeasy-entity-description: 'Manage SSH credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
             SSH credentials store SSH private keys for secure access to remote
             compute environments and resources within the Seqera Platform workflows.
             '

--- a/overlays/credentials-tower-agent.yaml
+++ b/overlays/credentials-tower-agent.yaml
@@ -79,6 +79,7 @@ actions:
             - name: workspaceId
               in: query
               description: Workspace numeric identifier
+              required: true
               schema:
                 type: integer
                 format: int64

--- a/overlays/credentials-tower-agent.yaml
+++ b/overlays/credentials-tower-agent.yaml
@@ -244,7 +244,7 @@ actions:
             x-speakeasy-entity: TowerAgentCredential
             x-speakeasy-entity-version: 1
             x-speakeasy-entity-description:
-              'Manage Tower Agent credentials in Seqera platform using this resource.
+              'Manage Tower Agent credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.
 
 
               Tower Agent credentials store connection IDs for Tower Agent instances that

--- a/templates/guides/migrating-from-seqera-credential.md
+++ b/templates/guides/migrating-from-seqera-credential.md
@@ -1,0 +1,253 @@
+---
+page_title: "Migrating from seqera_credential to typed credential resources"
+subcategory: "Upgrade Guides"
+description: |-
+  Step-by-step guide for migrating existing seqera_credential resources to the per-provider typed credentials (seqera_aws_credential, seqera_bitbucket_credential, seqera_github_credential, etc.) without destroying the underlying Seqera Platform credential.
+---
+
+# Migrating from `seqera_credential` to typed credential resources
+
+The provider exposes both a generic `seqera_credential` resource (one resource type, a `keys` block per provider) and per-provider typed resources (`seqera_aws_credential`, `seqera_github_credential`, `seqera_bitbucket_credential`, …). The typed resources have provider-specific schemas, plan-time validators, and clearer documentation. New configurations should use them.
+
+This guide walks through migrating an existing `seqera_credential` to the matching typed resource without destroying the underlying credential on Seqera Platform.
+
+## Why migrate
+
+- Provider-specific plan-time validation (e.g. mutually-exclusive auth fields, required-pair checks).
+- Clearer field names — flat top-level attributes instead of a nested `keys.<provider>` block.
+- Per-provider documentation pages with field-level guidance.
+- Generic `seqera_credential` will eventually be deprecated in favour of the typed resources.
+
+## Approach
+
+Migration uses Terraform's import/removal flow rather than `moved {}` blocks. `moved {}` only works between resources of the same type (or when the destination resource declares an explicit `MoveState` for the source type, which the credential resources do not). What you can do today:
+
+1. **Terraform 1.7+ — single-plan migration** using `import {}` and `removed {}` blocks. Recommended.
+2. **Terraform 1.5–1.6** — `terraform state rm` followed by `terraform import` (or an `import {}` block). Same end state, two commands.
+
+The underlying Seqera Platform credential is never touched — only Terraform state is rewritten.
+
+## What you need
+
+- The credential's `credentials_id` (from `terraform state show seqera_credential.<name>`, the `credentials_id` attribute).
+- The `workspace_id` it lives in (also visible in state, or in your existing config).
+- The credential's secret values (token/password/key data). These are write-only — the provider never reads them back from the API, so the typed resource will need them re-supplied in config (typically via the same `var.…` you already use).
+
+## Provider mapping
+
+The `keys.<provider>` sub-block in `seqera_credential` maps to a typed resource as follows:
+
+| `seqera_credential.keys` block | Typed resource | Notable field renames |
+| --- | --- | --- |
+| `aws` | `seqera_aws_credential` | `access_key`, `secret_key`, `assume_role_arn` |
+| `azure` / `azure_cloud` / `azure_entra` | `seqera_azure_credential` | `batch_name`, `storage_name`, `batch_key`, `storage_key`, `tenant_id`, `client_id`, `client_secret` |
+| `bitbucket` | `seqera_bitbucket_credential` | `username`, `password`, `token` |
+| `codecommit` | `seqera_codecommit_credential` | `username` → `access_key`, `password` → `secret_key` |
+| `container_reg` | `seqera_container_registry_credential` | `username`, `password`, `registry` |
+| `gitea` | `seqera_gitea_credential` | `username`, `password` |
+| `github` | `seqera_github_credential` | `password` → `access_token` |
+| `gitlab` | `seqera_gitlab_credential` | `username`, `token` |
+| `google` | `seqera_google_credential` | `data` (service account JSON) |
+| `k8s` | `seqera_kubernetes_credential` | `data` (kubeconfig) |
+| `ssh` | `seqera_ssh_credential` | `private_key`, `passphrase` |
+| `tw_agent` | `seqera_tower_agent_credential` | `connection_id`, `work_dir` |
+
+In all cases the top-level fields (`name`, `workspace_id`, `base_url`, `provider_type`) keep their names.
+
+## Worked example: Bitbucket
+
+### Before
+
+```terraform
+resource "seqera_credential" "bitbucket" {
+  name         = "bitbucket-main"
+  workspace_id = seqera_workspace.main.id
+  base_url     = "https://bitbucket.org/seqeralabs"
+
+  keys = {
+    bitbucket = {
+      username = var.bitbucket_username
+      password = var.bitbucket_password
+    }
+  }
+}
+```
+
+### Step 1 — capture the IDs
+
+```shell
+terraform state show seqera_credential.bitbucket | grep -E 'credentials_id|workspace_id'
+```
+
+Note the values; you'll need them in step 2.
+
+### Step 2 — rewrite the resource and add migration blocks (Terraform 1.7+)
+
+```terraform
+resource "seqera_bitbucket_credential" "bitbucket" {
+  name         = "bitbucket-main"
+  workspace_id = seqera_workspace.main.id
+  base_url     = "https://bitbucket.org/seqeralabs"
+
+  username = var.bitbucket_username
+  password = var.bitbucket_password
+}
+
+import {
+  to = seqera_bitbucket_credential.bitbucket
+  id = jsonencode({
+    credentials_id = "abc123XYZ"   # from step 1
+    workspace_id   = 1234567890    # from step 1
+  })
+}
+
+removed {
+  from = seqera_credential.bitbucket
+  lifecycle {
+    destroy = false   # important — keeps the Platform credential alive
+  }
+}
+```
+
+### Step 3 — apply
+
+```shell
+terraform plan
+terraform apply
+```
+
+Terraform imports the credential under the new resource address and drops the old one from state without calling Delete. Confirm with:
+
+```shell
+terraform state list | grep credential
+```
+
+You should see `seqera_bitbucket_credential.bitbucket` and no `seqera_credential.bitbucket`.
+
+### Step 4 — clean up
+
+Once the plan is clean (no diff), remove the `import {}` and `removed {}` blocks. They are one-shot — leaving them in is harmless but adds noise.
+
+## Older Terraform (1.5–1.6)
+
+Same end state, two steps:
+
+```shell
+# 1. Drop the old resource from state without touching the Platform credential
+terraform state rm seqera_credential.bitbucket
+
+# 2. Import under the new typed resource address
+terraform import 'seqera_bitbucket_credential.bitbucket' \
+  '{"credentials_id": "abc123XYZ", "workspace_id": 1234567890}'
+```
+
+Then run `terraform plan` and confirm no diff. The typed `resource "seqera_bitbucket_credential" "bitbucket" { … }` block must already be in your config before the import.
+
+## Worked example: GitHub
+
+### Before
+
+```terraform
+resource "seqera_credential" "github" {
+  name         = "github-main"
+  workspace_id = seqera_workspace.main.id
+  base_url     = "https://github.com/seqeralabs"
+
+  keys = {
+    github = {
+      username = var.github_username
+      password = var.github_token   # PAT goes in `password`
+    }
+  }
+}
+```
+
+### After
+
+```terraform
+resource "seqera_github_credential" "github" {
+  name         = "github-main"
+  workspace_id = seqera_workspace.main.id
+  base_url     = "https://github.com/seqeralabs"
+
+  username     = var.github_username
+  access_token = var.github_token   # renamed from `password`
+}
+
+import {
+  to = seqera_github_credential.github
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
+}
+
+removed {
+  from = seqera_credential.github
+  lifecycle { destroy = false }
+}
+```
+
+The only field-level change: the PAT moves from `keys.github.password` to a top-level `access_token`.
+
+## Worked example: AWS
+
+### Before
+
+```terraform
+resource "seqera_credential" "aws" {
+  name         = "aws-main"
+  workspace_id = seqera_workspace.main.id
+
+  keys = {
+    aws = {
+      accessKey     = var.aws_access_key
+      secretKey     = var.aws_secret_key
+      assumeRoleArn = "arn:aws:iam::123456789012:role/SeqeraRole"
+    }
+  }
+}
+```
+
+### After
+
+```terraform
+resource "seqera_aws_credential" "aws" {
+  name         = "aws-main"
+  workspace_id = seqera_workspace.main.id
+
+  access_key      = var.aws_access_key
+  secret_key      = var.aws_secret_key
+  assume_role_arn = "arn:aws:iam::123456789012:role/SeqeraRole"
+}
+
+import {
+  to = seqera_aws_credential.aws
+  id = jsonencode({
+    credentials_id = "..."
+    workspace_id   = 0
+  })
+}
+
+removed {
+  from = seqera_credential.aws
+  lifecycle { destroy = false }
+}
+```
+
+Field renames: `accessKey` → `access_key`, `secretKey` → `secret_key`, `assumeRoleArn` → `assume_role_arn`.
+
+## Verifying the migration
+
+After apply:
+
+- `terraform plan` should report **no changes**.
+- The Seqera Platform UI should show the same credential record (same ID, same name, same workspace).
+- Any compute environments / pipelines / actions referencing the credential by ID continue to work without re-creation, because the underlying Platform record is unchanged.
+
+## Common pitfalls
+
+- **Forgot `lifecycle { destroy = false }` in the `removed {}` block.** Without it, Terraform will Delete the credential — which destroys the Platform record, including any compute environment associations. Always include it.
+- **`workspace_id` is `0` in the import ID.** The `0` placeholder in the snippets is just illustrative — replace it with the real numeric workspace ID. A `0` value will fail the import.
+- **Secret values out of sync after import.** Write-only fields (`password`, `token`, `access_token`, `secret_key`, etc.) are never read back from the API. After import, the config's value is what gets sent on the next Update; if the value differs from what's in the platform you'll silently rotate the secret on the next apply. Re-supply the same secret you used originally.
+- **Leftover `import {}` / `removed {}` blocks.** They're one-shot. Once apply is clean, remove them — otherwise every plan re-evaluates them (no-op but noisy).

--- a/templates/guides/migrating-from-seqera-credential.md
+++ b/templates/guides/migrating-from-seqera-credential.md
@@ -11,6 +11,8 @@ The provider exposes both a generic `seqera_credential` resource (one resource t
 
 This guide walks through migrating an existing `seqera_credential` to the matching typed resource without destroying the underlying credential on Seqera Platform.
 
+~> **Workspace-scoped only.** The typed credential resources are tested and validated for use within a Seqera organization workspace. User-context (personal) credentials are not supported on the typed resources — keep using `seqera_credential` for those.
+
 ## Why migrate
 
 - Provider-specific plan-time validation (e.g. mutually-exclusive auth fields, required-pair checks).


### PR DESCRIPTION
## Summary
- Mark `workspaceId` as required on the GET operation in all 12 typed credential overlays. Speakeasy now generates a JSON-encoded `ImportState` (`{"credentials_id": "...", "workspace_id": 0}`) instead of a single string. This is a bug fix on its own — the previous single-string import set only `credentials_id`, so the next refresh failed for workspace-scoped credentials (i.e. virtually all of them).
- Add docs guide `migrating-from-seqera-credential.md` describing how to migrate an existing `seqera_credential` to the typed resource using `import {}` + `removed { lifecycle { destroy = false } }` blocks (Terraform 1.7+) or `terraform state rm` + `terraform import` (1.5–1.6). Includes a provider mapping table and worked examples for Bitbucket, GitHub, and AWS.
- Updates `import.sh` and `import-by-string-id.tf` examples for all typed credential resources to reflect the new JSON import format.

`moved {}` blocks across resource types would require a `MoveState` implementation on each typed credential, which is a much bigger change; punted to a future PR if desired.

## Test plan
- [ ] `terraform plan` against an existing `seqera_credential` followed by an `import {}` + `removed {}` migration to the typed resource — apply succeeds, no diff afterward, Platform credential UI shows the same record.
- [ ] `terraform import 'seqera_aws_credential.example' '{"credentials_id": "...", "workspace_id": 12345}'` succeeds and the next refresh returns the credential intact.
- [ ] Generated docs render the new guide at `docs/guides/migrating-from-seqera-credential.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)