### PR TITLE
fix: mark pipeline as mandatory in LaunchRequest

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 95950901c27916c27ccbefea584885f7
+  docChecksum: f782de63dde628920353d931fef0bfb0
   docVersion: 1.153.0
   speakeasyVersion: 1.763.1
   generationVersion: 2.884.4
@@ -425,11 +425,11 @@ trackedFiles:
     pristine_git_object: 0ea64fbeb1fd7709d7241a8e06d34bfe9d0323d3
   internal/provider/action_resource.go:
     id: f7c19bf35b58
-    last_write_checksum: sha1:cb0081b6b231270e315b8042b311241b091c12bb
+    last_write_checksum: sha1:cebe299123271acd137216814e07e1fd6c6ebb4e
     pristine_git_object: fc35041e2f1cf6db01d04e9e9e861df96d042782
   internal/provider/action_resource_sdk.go:
     id: 28576317893d
-    last_write_checksum: sha1:b377ce3e6495b9ab2bc6058208550471134d2d04
+    last_write_checksum: sha1:576714be3001bfae2d49a5ecb5bc6a85986641d5
     pristine_git_object: b987eb32b2d86ebe52fb9875e9e4b6eb9f30af6e
   internal/provider/awsbatchce_resource.go:
     id: aeeab49ad69b
@@ -632,10 +632,10 @@ trackedFiles:
     last_write_checksum: sha1:2d307f6ad9029a4dd900dac1e440f4c3c4891e4b
     pristine_git_object: fe81d09c0d5656f2f24a007997800ddfa455d8b7
   internal/provider/pipeline_resource.go:
-    last_write_checksum: sha1:6953fc27494d42331d0d152ee49ee1bc64047b35
+    last_write_checksum: sha1:f34071ee6dd3fbcb5d819f3f845e52986820c028
   internal/provider/pipeline_resource_sdk.go:
     id: c3bca9acd758
-    last_write_checksum: sha1:18a97f4dda70c6d689e219fe8d55e26248e97ef2
+    last_write_checksum: sha1:30a2128391bc026cf81b407d2533f0155988c927
     pristine_git_object: eb186d4cf2287bf1eec7eb07d9b9c7e0386b7b26
   internal/provider/pipelinesecret_resource.go:
     id: 5319f8284106
@@ -1015,11 +1015,11 @@ trackedFiles:
     pristine_git_object: 9cc78dd1f7684941df14144df744dad2b23885f9
   internal/provider/workflows_resource.go:
     id: efcad015245a
-    last_write_checksum: sha1:1f0b1d90f261d6d28001bdb853d58a24ef9c0b05
+    last_write_checksum: sha1:8d94cf5afb25e5389f9541af83ca618cabc4a260
     pristine_git_object: 2ec8cdfba570a37c74c14055a3d9ffa12fe8881c
   internal/provider/workflows_resource_sdk.go:
     id: ee2d992725aa
-    last_write_checksum: sha1:ffbb717dc27eea86fd26c68df683031525074432
+    last_write_checksum: sha1:0ae2d06bab1aedbad8e9fd41e6078eb7efc9599e
     pristine_git_object: 32dd5a54a21939c3cfa3c2ada55b841cb54032f9
   internal/provider/workspace_resource.go:
     id: 4255ab3c913f
@@ -3889,7 +3889,7 @@ trackedFiles:
     pristine_git_object: 3bc4009b3e5d627558d496fdfa955c0de921bde3
   internal/sdk/models/shared/workflowlaunchrequest.go:
     id: 2b0df021cbad
-    last_write_checksum: sha1:89437f333f65a2c25d9ee4c75d55ec823c343dfc
+    last_write_checksum: sha1:3e66ab461a2ef386cc97fd76a893f9ac515fd18f
     pristine_git_object: 610d44495458858e298def213b53372951961f8e
   internal/sdk/models/shared/workflowlaunchresponse.go:
     id: 58befbe96295

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -22260,7 +22260,7 @@ components:
           items:
             type: string
           example: ["WORKSPACE_TOKEN", "SHARED_CREDENTIALS"]
-      required: [workDir]
+      required: [pipeline, workDir]
       x-speakeasy-entity: Workflows
     WorkflowLaunchResponse:
       type: object

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.763.1
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:f07081d36127190c68f312b03dc9202d8b956da235c9bb0adbc83a1647b130aa
-        sourceBlobDigest: sha256:275b14e69dff0ea9e148360942f0a2e586d37547f7acf10d7c8e73c71f7527c6
+        sourceRevisionDigest: sha256:7e1b7cc8b5051fcbadcc1845fb0d164d1f18237011af7c9e6a26418f911df438
+        sourceBlobDigest: sha256:004d3d2313b36ec6b2a678c2cd144402dbcd2e62db976566cacb75cea2f74e8d
         tags:
             - latest
             - 1.153.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:f07081d36127190c68f312b03dc9202d8b956da235c9bb0adbc83a1647b130aa
-        sourceBlobDigest: sha256:275b14e69dff0ea9e148360942f0a2e586d37547f7acf10d7c8e73c71f7527c6
+        sourceRevisionDigest: sha256:7e1b7cc8b5051fcbadcc1845fb0d164d1f18237011af7c9e6a26418f911df438
+        sourceBlobDigest: sha256:004d3d2313b36ec6b2a678c2cd144402dbcd2e62db976566cacb75cea2f74e8d
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -146,6 +146,10 @@ resource "seqera_action" "tower_advanced" {
 <a id="nestedatt--launch"></a>
 ### Nested Schema for `launch`
 
+Required:
+
+- `pipeline` (String)
+
 Optional:
 
 - `compute_env_id` (String)
@@ -157,7 +161,6 @@ Optional:
 - `label_ids` (List of Number)
 - `main_script` (String) Main script path
 - `params_text` (String) Pipeline parameters text
-- `pipeline` (String)
 - `pipeline_schema_id` (Number)
 - `post_run_script` (String) Script to run after pipeline execution
 - `pre_run_script` (String) Script to run before pipeline execution

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -103,6 +103,10 @@ resource "seqera_pipeline" "shared" {
 <a id="nestedatt--launch"></a>
 ### Nested Schema for `launch`
 
+Required:
+
+- `pipeline` (String)
+
 Optional:
 
 - `compute_env_id` (String)
@@ -114,7 +118,6 @@ Optional:
 - `label_ids` (List of Number)
 - `main_script` (String) Main script path
 - `params_text` (String) Pipeline parameters text
-- `pipeline` (String)
 - `pipeline_schema_id` (Number)
 - `post_run_script` (String) Script to run after pipeline execution
 - `pre_run_script` (String) Script to run before pipeline execution

--- a/docs/resources/workflows.md
+++ b/docs/resources/workflows.md
@@ -67,6 +67,7 @@ resource "seqera_workflows" "my_workflows" {
 
 ### Required
 
+- `pipeline` (String) Requires replacement if changed.
 - `workspace_id` (Number) Workspace numeric identifier. Requires replacement if changed.
 
 ### Optional
@@ -81,7 +82,6 @@ resource "seqera_workflows" "my_workflows" {
 - `label_ids` (List of Number) Requires replacement if changed.
 - `main_script` (String) Main script path. Requires replacement if changed.
 - `params_text` (String) Pipeline parameters text. Requires replacement if changed.
-- `pipeline` (String) Requires replacement if changed.
 - `pipeline_schema_id` (Number) Requires replacement if changed.
 - `post_run_script` (String) Script to run after pipeline execution. Requires replacement if changed.
 - `pre_run_script` (String) Script to run before pipeline execution. Requires replacement if changed.

--- a/internal/provider/action_resource.go
+++ b/internal/provider/action_resource.go
@@ -2414,8 +2414,7 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Description: `Pipeline parameters text`,
 					},
 					"pipeline": schema.StringAttribute{
-						Computed: true,
-						Optional: true,
+						Required: true,
 					},
 					"pipeline_schema_id": schema.Int64Attribute{
 						Computed: true,

--- a/internal/provider/action_resource_sdk.go
+++ b/internal/provider/action_resource_sdk.go
@@ -1082,12 +1082,9 @@ func (r *ActionResourceModel) ToSharedCreateActionRequest(ctx context.Context) (
 	} else {
 		paramsText = nil
 	}
-	pipeline := new(string)
-	if !r.Launch.Pipeline.IsUnknown() && !r.Launch.Pipeline.IsNull() {
-		*pipeline = r.Launch.Pipeline.ValueString()
-	} else {
-		pipeline = nil
-	}
+	var pipeline string
+	pipeline = r.Launch.Pipeline.ValueString()
+
 	pipelineSchemaID := new(int64)
 	if !r.Launch.PipelineSchemaID.IsUnknown() && !r.Launch.PipelineSchemaID.IsNull() {
 		*pipelineSchemaID = r.Launch.PipelineSchemaID.ValueInt64()
@@ -1325,12 +1322,9 @@ func (r *ActionResourceModel) ToSharedUpdateActionRequest(ctx context.Context) (
 	} else {
 		paramsText = nil
 	}
-	pipeline := new(string)
-	if !r.Launch.Pipeline.IsUnknown() && !r.Launch.Pipeline.IsNull() {
-		*pipeline = r.Launch.Pipeline.ValueString()
-	} else {
-		pipeline = nil
-	}
+	var pipeline string
+	pipeline = r.Launch.Pipeline.ValueString()
+
 	pipelineSchemaID := new(int64)
 	if !r.Launch.PipelineSchemaID.IsUnknown() && !r.Launch.PipelineSchemaID.IsNull() {
 		*pipelineSchemaID = r.Launch.PipelineSchemaID.ValueInt64()

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -2304,8 +2304,7 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 						Description: `Pipeline parameters text`,
 					},
 					"pipeline": schema.StringAttribute{
-						Computed: true,
-						Optional: true,
+						Required: true,
 					},
 					"pipeline_schema_id": schema.Int64Attribute{
 						Computed: true,

--- a/internal/provider/pipeline_resource_sdk.go
+++ b/internal/provider/pipeline_resource_sdk.go
@@ -1050,12 +1050,9 @@ func (r *PipelineResourceModel) ToSharedCreatePipelineRequest(ctx context.Contex
 	} else {
 		paramsText = nil
 	}
-	pipeline := new(string)
-	if !r.Launch.Pipeline.IsUnknown() && !r.Launch.Pipeline.IsNull() {
-		*pipeline = r.Launch.Pipeline.ValueString()
-	} else {
-		pipeline = nil
-	}
+	var pipeline string
+	pipeline = r.Launch.Pipeline.ValueString()
+
 	pipelineSchemaID := new(int64)
 	if !r.Launch.PipelineSchemaID.IsUnknown() && !r.Launch.PipelineSchemaID.IsNull() {
 		*pipelineSchemaID = r.Launch.PipelineSchemaID.ValueInt64()
@@ -1252,12 +1249,9 @@ func (r *PipelineResourceModel) ToSharedUpdatePipelineRequest(ctx context.Contex
 	} else {
 		paramsText = nil
 	}
-	pipeline := new(string)
-	if !r.Launch.Pipeline.IsUnknown() && !r.Launch.Pipeline.IsNull() {
-		*pipeline = r.Launch.Pipeline.ValueString()
-	} else {
-		pipeline = nil
-	}
+	var pipeline string
+	pipeline = r.Launch.Pipeline.ValueString()
+
 	pipelineSchemaID := new(int64)
 	if !r.Launch.PipelineSchemaID.IsUnknown() && !r.Launch.PipelineSchemaID.IsNull() {
 		*pipelineSchemaID = r.Launch.PipelineSchemaID.ValueInt64()

--- a/internal/provider/workflows_resource.go
+++ b/internal/provider/workflows_resource.go
@@ -153,7 +153,7 @@ func (r *WorkflowsResource) Schema(ctx context.Context, req resource.SchemaReque
 				Description: `Pipeline parameters text. Requires replacement if changed.`,
 			},
 			"pipeline": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},

--- a/internal/provider/workflows_resource_sdk.go
+++ b/internal/provider/workflows_resource_sdk.go
@@ -261,12 +261,9 @@ func (r *WorkflowsResourceModel) ToSharedWorkflowLaunchRequest(ctx context.Conte
 	} else {
 		paramsText = nil
 	}
-	pipeline := new(string)
-	if !r.Pipeline.IsUnknown() && !r.Pipeline.IsNull() {
-		*pipeline = r.Pipeline.ValueString()
-	} else {
-		pipeline = nil
-	}
+	var pipeline string
+	pipeline = r.Pipeline.ValueString()
+
 	pipelineSchemaID := new(int64)
 	if !r.PipelineSchemaID.IsUnknown() && !r.PipelineSchemaID.IsNull() {
 		*pipelineSchemaID = r.PipelineSchemaID.ValueInt64()

--- a/internal/sdk/models/shared/workflowlaunchrequest.go
+++ b/internal/sdk/models/shared/workflowlaunchrequest.go
@@ -18,7 +18,7 @@ type WorkflowLaunchRequest struct {
 	MainScript *string `json:"mainScript,omitempty"`
 	// Pipeline parameters text
 	ParamsText       *string `json:"paramsText,omitempty"`
-	Pipeline         *string `json:"pipeline,omitempty"`
+	Pipeline         string  `json:"pipeline"`
 	PipelineSchemaID *int64  `json:"pipelineSchemaId,omitempty"`
 	// Script to run after pipeline execution
 	PostRunScript *string `json:"postRunScript,omitempty"`
@@ -104,9 +104,9 @@ func (w *WorkflowLaunchRequest) GetParamsText() *string {
 	return w.ParamsText
 }
 
-func (w *WorkflowLaunchRequest) GetPipeline() *string {
+func (w *WorkflowLaunchRequest) GetPipeline() string {
 	if w == nil {
-		return nil
+		return ""
 	}
 	return w.Pipeline
 }

--- a/overlays/pipelines.yaml
+++ b/overlays/pipelines.yaml
@@ -184,7 +184,7 @@ actions:
   # This allows pipelines to be created without specifying compute env and work dir
   - target: $.components.schemas.WorkflowLaunchRequest
     update:
-      required: []
+      required: [pipeline]
 
   # Make workDir optional in WorkflowLaunchRequest
   - target: $.components.schemas.WorkflowLaunchRequest.properties.workDir


### PR DESCRIPTION
pipeline fields is currently marked as optional in the nested WorkflowLaunchRequest object. This object is shared among different resources: pipelines, workflows and actions. It is required for each of them, when missing each resource has a different failure modes.

If missing for pipelines and workflows, the backend responds with 400 and an appropriate error message. If missing for actions, the backend returns 400 with an unexpected error message.