### PR TITLE
fix: mark workspace id as readonly

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -301,7 +301,7 @@ trackedFiles:
     pristine_git_object: fd5a27e12a4fe32fb7817dd93d51447a7d67f58d
   examples/resources/seqera_workspace/resource.tf:
     id: 0861dd715211
-    last_write_checksum: sha1:6aea6fceaab2cb3beda2a79ce58aeadf8d67116d
+    last_write_checksum: sha1:3f3a3ec874fa3912c2f1f9077e710deb6db914ad
     pristine_git_object: 6cdb08cff8d5e98c92183f577fc8fbe059d61ff7
   go.mod:
     id: c47645c391ad
@@ -1023,7 +1023,7 @@ trackedFiles:
     pristine_git_object: 32dd5a54a21939c3cfa3c2ada55b841cb54032f9
   internal/provider/workspace_resource.go:
     id: 4255ab3c913f
-    last_write_checksum: sha1:4bf6ad93820be0b88c973503918a062924020608
+    last_write_checksum: sha1:1eab3b4395cbc6ae2907a9bbb47fe6d9152cfddc
     pristine_git_object: 3a254498bdb26fe0a1be5e3afd3452978bba12da
   internal/provider/workspace_resource_sdk.go:
     id: 6b7b5772bf74

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -22583,7 +22583,7 @@ components:
           type: integer
           format: int64
           nullable: true
-          x-speakeasy-param-optional: true
+          x-speakeasy-param-readonly: true
         lastUpdated:
           type: string
           format: date-time

--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -41,7 +41,6 @@ Organizations consist of members, while workspaces consist of participants.
 resource "seqera_workspace" "my_workspace" {
   description = "Workspace for genomics research projects and computational biology workflows"
   full_name   = "Genomics Research Workspace"
-  id          = 1
   name        = "genomics-research"
   org_id      = 7
   visibility  = "SHARED"
@@ -61,11 +60,11 @@ resource "seqera_workspace" "my_workspace" {
 ### Optional
 
 - `description` (String) Workspace description
-- `id` (Number) Workspace numeric identifier
 
 ### Read-Only
 
 - `date_created` (String)
+- `id` (Number) Workspace numeric identifier
 - `last_updated` (String)
 
 ## Import

--- a/examples/resources/seqera_workspace/resource.tf
+++ b/examples/resources/seqera_workspace/resource.tf
@@ -1,7 +1,6 @@
 resource "seqera_workspace" "my_workspace" {
   description = "Workspace for genomics research projects and computational biology workflows"
   full_name   = "Genomics Research Workspace"
-  id          = 1
   name        = "genomics-research"
   org_id      = 7
   visibility  = "SHARED"

--- a/internal/provider/workspace_resource.go
+++ b/internal/provider/workspace_resource.go
@@ -76,7 +76,6 @@ func (r *WorkspaceResource) Schema(ctx context.Context, req resource.SchemaReque
 			},
 			"id": schema.Int64Attribute{
 				Computed:    true,
-				Optional:    true,
 				Description: `Workspace numeric identifier`,
 			},
 			"last_updated": schema.StringAttribute{

--- a/overlays/workspaces.yaml
+++ b/overlays/workspaces.yaml
@@ -7,7 +7,7 @@ actions:
   # Workspace schema annotations
   - target: $["components"]["schemas"]["Workspace"]["properties"]["id"]
     update:
-      x-speakeasy-param-optional: true
+      x-speakeasy-param-readonly: true
   - target: $["components"]["schemas"]["Workspace"]["properties"]["name"]
     update:
       x-speakeasy-param-readonly: false


### PR DESCRIPTION
Users should not be able to supply the unique identifier for the workspace, field will be computed by the backend.