### PR TITLE
fix: ignore fusion and wave enabled for cloud CEs

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: f782de63dde628920353d931fef0bfb0
+  docChecksum: 46b2348612c72913a48dbf93308a895e
   docVersion: 1.153.0
   speakeasyVersion: 1.763.1
   generationVersion: 2.884.4
@@ -425,11 +425,11 @@ trackedFiles:
     pristine_git_object: 0ea64fbeb1fd7709d7241a8e06d34bfe9d0323d3
   internal/provider/action_resource.go:
     id: f7c19bf35b58
-    last_write_checksum: sha1:cebe299123271acd137216814e07e1fd6c6ebb4e
+    last_write_checksum: sha1:29001b95985ab203b3165617016dd07daef05034
     pristine_git_object: fc35041e2f1cf6db01d04e9e9e861df96d042782
   internal/provider/action_resource_sdk.go:
     id: 28576317893d
-    last_write_checksum: sha1:576714be3001bfae2d49a5ecb5bc6a85986641d5
+    last_write_checksum: sha1:bceab68cc8fc3d4b8ae04ca88b2167881dbccb5d
     pristine_git_object: b987eb32b2d86ebe52fb9875e9e4b6eb9f30af6e
   internal/provider/awsbatchce_resource.go:
     id: aeeab49ad69b
@@ -440,9 +440,9 @@ trackedFiles:
     last_write_checksum: sha1:24662f3ae4add03a0261eefe1348aca7e2b63421
     pristine_git_object: 91db6c7b9d563b0b0fa5e57c712ed1952c1d54d2
   internal/provider/awscloudce_resource.go:
-    last_write_checksum: sha1:ba3c11909e4e382ba5b469123ce8a420c8efcdaf
+    last_write_checksum: sha1:03adf4d22091ffa199a337244ad36a8e8e9905f7
   internal/provider/awscloudce_resource_sdk.go:
-    last_write_checksum: sha1:beaada36fc0c5595503332c4653a9510c31c5419
+    last_write_checksum: sha1:670c5788a7235ce26d0212dff732ced782d42a66
   internal/provider/awscomputeenv_resource.go:
     id: 788844f2d22e
     last_write_checksum: sha1:9d12cfcecfb390bf5135eeb27f0838cf4af63d92
@@ -464,9 +464,9 @@ trackedFiles:
   internal/provider/azurebatchce_resource_sdk.go:
     last_write_checksum: sha1:149ff0c5af2eb00c69f5885db1f3803181c34ec8
   internal/provider/azurecloudce_resource.go:
-    last_write_checksum: sha1:b0540ca20010b701e3a584e5cd16526936824f72
+    last_write_checksum: sha1:08e51735c41d7f732c4ee6a69a276602f521b36c
   internal/provider/azurecloudce_resource_sdk.go:
-    last_write_checksum: sha1:3243d0d417373469a13ed31c48b53a4f6c783b15
+    last_write_checksum: sha1:bd04316eae695ad1caa2059f05c10c3dc8bf6c39
   internal/provider/azurecloudcredential_resource.go:
     last_write_checksum: sha1:18ad4cb4c6c5566376cd9c01e2fb8f2b45e9e2bd
   internal/provider/azurecloudcredential_resource_sdk.go:
@@ -501,11 +501,11 @@ trackedFiles:
     pristine_git_object: 0c1b43d5db49b023cf3c7408c198a4d66c795d8a
   internal/provider/computeenv_resource.go:
     id: f4162f219efd
-    last_write_checksum: sha1:a839adaec8091e8d51a6fc7233011ad745ba7934
+    last_write_checksum: sha1:57f067587590c5c1b898c100bbca2adbbf2b5b9f
     pristine_git_object: d5550a0a3bc980d281c55531d71458e7e4968b48
   internal/provider/computeenv_resource_sdk.go:
     id: 1e29eea44332
-    last_write_checksum: sha1:cd71102ec41c1c1fb103d70122f4b4fc5dad41d2
+    last_write_checksum: sha1:5d79a0cbe35631af52ffd3ad4da63dbe0a98d9e1
     pristine_git_object: 2e933070714e8aa8d9ab83f2e1b81abd6f262ade
   internal/provider/containerregistrycredential_resource.go:
     id: f0a18857f2ea
@@ -564,9 +564,9 @@ trackedFiles:
   internal/provider/gcpbatchce_resource_sdk.go:
     last_write_checksum: sha1:0a2d6bb7b81f8053dfc9aab6a27b27848c64075e
   internal/provider/gcpcloudce_resource.go:
-    last_write_checksum: sha1:e21d557bc6f9844810ef4c8a9b8190b52a5dacc6
+    last_write_checksum: sha1:29b34eb39339f6d500e35ec9c20f89cdb6580665
   internal/provider/gcpcloudce_resource_sdk.go:
-    last_write_checksum: sha1:f7ed41a731ecf577cf40bac4aedfcdb7edf4b26b
+    last_write_checksum: sha1:0c4f03cd5a79cceb0ffb487e743e63488ba61ad1
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
     last_write_checksum: sha1:2e739ea241a59f21cbebac2c7b74235e68dcd92f
@@ -632,10 +632,10 @@ trackedFiles:
     last_write_checksum: sha1:2d307f6ad9029a4dd900dac1e440f4c3c4891e4b
     pristine_git_object: fe81d09c0d5656f2f24a007997800ddfa455d8b7
   internal/provider/pipeline_resource.go:
-    last_write_checksum: sha1:f34071ee6dd3fbcb5d819f3f845e52986820c028
+    last_write_checksum: sha1:072135eb80839997b86a2ff3720f06507e34abd2
   internal/provider/pipeline_resource_sdk.go:
     id: c3bca9acd758
-    last_write_checksum: sha1:30a2128391bc026cf81b407d2533f0155988c927
+    last_write_checksum: sha1:72d66982bbd71fb5e43a21431a190a275e5e40fa
     pristine_git_object: eb186d4cf2287bf1eec7eb07d9b9c7e0386b7b26
   internal/provider/pipelinesecret_resource.go:
     id: 5319f8284106
@@ -790,10 +790,10 @@ trackedFiles:
     last_write_checksum: sha1:db767b32bfc2fb4189addc2e19f8f72cd0911823
     pristine_git_object: 7db3202471193f93826bdf67c90bd74b9dab4c88
   internal/provider/types/aws_cloud_config.go:
-    last_write_checksum: sha1:c09bc74345ea65d0e7b193b7d653fb668d6dc45c
+    last_write_checksum: sha1:2e5b6470024757b7ccff0882b57ee4d5a9fc5e10
   internal/provider/types/aws_cloud_configuration.go:
     id: db2f67953459
-    last_write_checksum: sha1:d9f5769c6cf55c4034e4be6cf7f476c151c64822
+    last_write_checksum: sha1:1e1d73343d108dae3d056651be00660c29e3f178
     pristine_git_object: 62842b6d7f36077a795bcfce869fcaff8d351e2d
   internal/provider/types/aws_code_commit_credentials.go:
     id: 78d63242bf3a
@@ -812,14 +812,14 @@ trackedFiles:
   internal/provider/types/az_batch_pool_config.go:
     last_write_checksum: sha1:59ae1cf1de55768255d7c0b7f15c8b3b1abddebc
   internal/provider/types/az_cloud_config.go:
-    last_write_checksum: sha1:6fe1053df9d9c0978cf9aeb00c8c64827e07df7b
+    last_write_checksum: sha1:50a6f99e1fe960d077ed0eebffaa5bf3d7597c1c
   internal/provider/types/azure_batch_configuration.go:
     id: c880ec503280
     last_write_checksum: sha1:b0782c5246ede6bf1781ff620c200c67bf7badab
     pristine_git_object: cb480f8f017e553bf3999b583fe1ba3dc0e2ca4b
   internal/provider/types/azure_cloud_configuration.go:
     id: 82511ba85861
-    last_write_checksum: sha1:5f4adf1e660815e2441cc083f467852f434b4316
+    last_write_checksum: sha1:87b0a76a64bb938034d60ed672185c2be7799321
     pristine_git_object: 8f6837bd0be5614d5c706b97dbfc0bf5f8ec80ac
   internal/provider/types/azure_cloud_credentials.go:
     id: af7c8a543af9
@@ -916,10 +916,10 @@ trackedFiles:
     last_write_checksum: sha1:424253fca68124a48d60eb944d8acac635303f13
     pristine_git_object: 3b1d18b5efc8fd5120b4d3f2f7a9a56feafa342c
   internal/provider/types/google_cloud_config.go:
-    last_write_checksum: sha1:5d8f52392872df4650d08c638f314c9c687e28da
+    last_write_checksum: sha1:9c0bf7121f7c5699a63c0644927e9f4fcfdfb617
   internal/provider/types/google_cloud_configuration.go:
     id: 4eb43152509e
-    last_write_checksum: sha1:8c1c427287420255fa88deeacbc7a7765504d564
+    last_write_checksum: sha1:500773395b84b5e44b7ec5079f8c545f438ff16a
     pristine_git_object: 60248593c3c3ece07a86cbc3e309b545cd5672db
   internal/provider/types/google_credentials.go:
     id: 8ea55670d7b3
@@ -2378,7 +2378,7 @@ trackedFiles:
   internal/sdk/models/shared/awscloudcecomputeconfiginput.go:
     last_write_checksum: sha1:da2a59c738ccc8ca4bcbc61f527eef5f1a8745ed
   internal/sdk/models/shared/awscloudconfig.go:
-    last_write_checksum: sha1:44dddc2a3a66f31ff19d49abfa96193140b1e475
+    last_write_checksum: sha1:780b9f975d426c16728552f6f48453fef0819193
   internal/sdk/models/shared/awscloudplatformmetainfo.go:
     id: 28be3c81b43e
     last_write_checksum: sha1:30fea4bc09a5b062b7440c106478a265b7502272
@@ -2406,7 +2406,7 @@ trackedFiles:
   internal/sdk/models/shared/azbatchpoolconfig.go:
     last_write_checksum: sha1:ef193d583de59c4fc6792341365d8a9a48341ee3
   internal/sdk/models/shared/azcloudconfig.go:
-    last_write_checksum: sha1:ed64b2d1fec69b8641fa5e716cf853f161147395
+    last_write_checksum: sha1:ceb669a5d57f1c05986190cd321318b76622f486
   internal/sdk/models/shared/azurebatchcecomputeconfiginput.go:
     last_write_checksum: sha1:2dff8b40592cd6a35c0e94c70c0dae2bedbfce80
   internal/sdk/models/shared/azurecloudcecomputeconfiginput.go:
@@ -2448,7 +2448,7 @@ trackedFiles:
     last_write_checksum: sha1:5e43c5c9fa8b8619eb944637514b97fb358f44ff
     pristine_git_object: 168da50a9909ad4639d68c4ef0cb63bf647d949b
   internal/sdk/models/shared/computeconfig.go:
-    last_write_checksum: sha1:eb8cb19d70c4a669095294ae0c1e3fc1023cfd02
+    last_write_checksum: sha1:434e04f3e4d2d602afb1208522e415143f67f1ae
   internal/sdk/models/shared/computeenvcomputeconfig.go:
     last_write_checksum: sha1:4164a145840d6564dcfad17ce60af7d585ef5480
   internal/sdk/models/shared/computeenvqueryattribute.go:
@@ -3196,7 +3196,7 @@ trackedFiles:
   internal/sdk/models/shared/googlebatchconfig.go:
     last_write_checksum: sha1:fb5e0fab2a40048b3688de2f11a6efe8795c1afa
   internal/sdk/models/shared/googlecloudconfig.go:
-    last_write_checksum: sha1:091469b0285b2e2edc96bcb143ffb3310df8af61
+    last_write_checksum: sha1:616efeaa58a7df5b13ad17f726d4c40cf4242bf6
   internal/sdk/models/shared/googlecredential.go:
     id: a084779f2e36
     last_write_checksum: sha1:5803a6d9da3f63e8f0f8fac0eb985c0fac7adfa0

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -14386,13 +14386,7 @@ components:
             $ref: '#/components/schemas/ConfigEnvVariable'
         fusion2Enabled:
           type: boolean
-          x-speakeasy-name-override: enable_fusion
-          x-speakeasy-plan-validators: FusionEnabledValidator
-          description: |
-            Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,
-            speeding up most operations.
-
-            Requires `enable_wave = true`.
+          x-speakeasy-terraform-ignore: true
         gpuEnabled:
           type: boolean
           description: |
@@ -14499,13 +14493,7 @@ components:
           x-speakeasy-param-force-new: true
         waveEnabled:
           type: boolean
-          title: "Wave Enabled"
-          description: |
-            Allow access to private container repositories and the provisioning of containers in your
-            Nextflow pipelines via the Wave containers service.
-
-            Required when `enable_fusion` is true.
-          x-speakeasy-name-override: enable_wave
+          x-speakeasy-terraform-ignore: true
         workDir:
           description: |
             S3 working directory for workflow execution. Must be a `s3://` URI in
@@ -14802,13 +14790,7 @@ components:
             Each variable can target the head node, compute nodes, or both.
         fusion2Enabled:
           type: boolean
-          x-speakeasy-name-override: enable_fusion
-          x-speakeasy-plan-validators: FusionEnabledValidator
-          description: |
-            Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-            speeding up most operations.
-
-            Requires `enable_wave = true`.
+          x-speakeasy-terraform-ignore: true
         instanceType:
           type: string
           description: |
@@ -14882,13 +14864,7 @@ components:
           x-speakeasy-param-force-new: true
         waveEnabled:
           type: boolean
-          title: "Wave Enabled"
-          description: |
-            Allow access to private container repositories and the provisioning of containers in your
-            Nextflow pipelines via the Wave containers service.
-
-            Required when `enable_fusion` is true.
-          x-speakeasy-name-override: enable_wave
+          x-speakeasy-terraform-ignore: true
         workDir:
           description: |
             Azure Blob Storage container path for Nextflow work directory.
@@ -18042,13 +18018,7 @@ components:
             Each variable can target the head node, compute nodes, or both.
         fusion2Enabled:
           type: boolean
-          x-speakeasy-name-override: enable_fusion
-          x-speakeasy-plan-validators: FusionEnabledValidator
-          description: |
-            Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-            speeding up most operations.
-
-            Requires `enable_wave = true`.
+          x-speakeasy-terraform-ignore: true
         gpuEnabled:
           type: boolean
           description: |
@@ -18105,13 +18075,7 @@ components:
           x-speakeasy-param-force-new: true
         waveEnabled:
           type: boolean
-          title: "Wave Enabled"
-          description: |
-            Allow access to private container repositories and the provisioning of containers in your
-            Nextflow pipelines via the Wave containers service.
-
-            Required when `enable_fusion` is true.
-          x-speakeasy-name-override: enable_wave
+          x-speakeasy-terraform-ignore: true
         workDir:
           description: |
             Google Cloud Storage bucket path for Nextflow work directory where intermediate

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.763.1
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:7e1b7cc8b5051fcbadcc1845fb0d164d1f18237011af7c9e6a26418f911df438
-        sourceBlobDigest: sha256:004d3d2313b36ec6b2a678c2cd144402dbcd2e62db976566cacb75cea2f74e8d
+        sourceRevisionDigest: sha256:e85a6a80223ab3edc94df5a86ff0935ef8f6f43cad0b71179918c37beecd5d14
+        sourceBlobDigest: sha256:e8c00e6f07533292ce2d95d769e65e333c94e1619121c69d04422a14cc7cb13c
         tags:
             - latest
             - 1.153.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:7e1b7cc8b5051fcbadcc1845fb0d164d1f18237011af7c9e6a26418f911df438
-        sourceBlobDigest: sha256:004d3d2313b36ec6b2a678c2cd144402dbcd2e62db976566cacb75cea2f74e8d
+        sourceRevisionDigest: sha256:e85a6a80223ab3edc94df5a86ff0935ef8f6f43cad0b71179918c37beecd5d14
+        sourceBlobDigest: sha256:e8c00e6f07533292ce2d95d769e65e333c94e1619121c69d04422a14cc7cb13c
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -452,14 +452,6 @@ When enabled, Graviton-based EC2 instances will be selected for cost savings.
 When using Fusion v2 without fast instance storage, this defaults to 100 GB with GP3 volume type.
 - `ec2_key_pair` (String) EC2 key pair name for SSH access to compute instances.
 Key pair must exist in the specified region.
-- `enable_fusion` (Boolean) Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
 - `environment` (Attributes List) Array of environment variables for the compute environment (see [below for nested schema](#nestedatt--launch--compute_env--config--aws_cloud--environment))
 - `gpu_enabled` (Boolean) Enable GPU support for compute instances.
 When enabled, GPU-capable instance types will be selected.
@@ -631,14 +623,6 @@ Read-Only:
 
 - `data_collection_endpoint` (String) Azure Monitor data collection endpoint URL for diagnostic telemetry.
 - `data_collection_rule_id` (String) Azure Monitor data collection rule resource ID associated with the endpoint.
-- `enable_fusion` (Boolean) Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
 - `environment` (Attributes List) Array of environment variables for the compute environment (see [below for nested schema](#nestedatt--launch--compute_env--config--azure_cloud--environment))
 - `instance_type` (String) Azure VM size for compute instances (e.g., Standard_D4s_v3, Standard_F8s_v2).
 - `log_table_name` (String) Azure Log Analytics table name for execution logs.
@@ -865,14 +849,6 @@ Read-Only:
 - `arm64_enabled` (Boolean) Enable ARM64 (Tau T2A) machine types for compute instances.
 When enabled, ARM-based machines will be selected for cost savings.
 - `boot_disk_size_gb` (Number) Size of the boot disk in GB for compute instances.
-- `enable_fusion` (Boolean) Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
 - `environment` (Attributes List) Array of environment variables for the compute environment (see [below for nested schema](#nestedatt--launch--compute_env--config--google_cloud--environment))
 - `gpu_enabled` (Boolean) Enable GPU support for compute instances.
 When enabled, GPU-capable machine types will be selected.

--- a/docs/resources/aws_cloud_ce.md
+++ b/docs/resources/aws_cloud_ce.md
@@ -196,16 +196,6 @@ Requires replacement if changed.
 - `ec2_key_pair` (String) EC2 key pair name for SSH access to compute instances.
 Key pair must exist in the specified region.
 Requires replacement if changed.
-- `enable_fusion` (Boolean) Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-Requires replacement if changed.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
-Requires replacement if changed.
 - `environment` (Attributes List) Requires replacement if changed. (see [below for nested schema](#nestedatt--config--environment))
 - `gpu_enabled` (Boolean) Enable GPU support for compute instances.
 When enabled, GPU-capable instance types will be selected.

--- a/docs/resources/azure_cloud_ce.md
+++ b/docs/resources/azure_cloud_ce.md
@@ -126,16 +126,6 @@ Optional:
 
 - `data_collection_endpoint` (String) Azure Monitor data collection endpoint URL for diagnostic telemetry. Requires replacement if changed.
 - `data_collection_rule_id` (String) Azure Monitor data collection rule resource ID associated with the endpoint. Requires replacement if changed.
-- `enable_fusion` (Boolean) Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-Requires replacement if changed.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
-Requires replacement if changed.
 - `environment` (Attributes List) Array of environment variables for the compute environment.
 Each variable can target the head node, compute nodes, or both.
 Requires replacement if changed. (see [below for nested schema](#nestedatt--config--environment))

--- a/docs/resources/compute_env.md
+++ b/docs/resources/compute_env.md
@@ -411,16 +411,6 @@ Requires replacement if changed.
 - `ec2_key_pair` (String) EC2 key pair name for SSH access to compute instances.
 Key pair must exist in the specified region.
 Requires replacement if changed.
-- `enable_fusion` (Boolean) Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-Requires replacement if changed.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
-Requires replacement if changed.
 - `environment` (Attributes List) Array of environment variables for the compute environment. Requires replacement if changed. (see [below for nested schema](#nestedatt--compute_env--config--aws_cloud--environment))
 - `gpu_enabled` (Boolean) Enable GPU support for compute instances.
 When enabled, GPU-capable instance types will be selected.
@@ -603,16 +593,6 @@ Optional:
 
 - `data_collection_endpoint` (String) Azure Monitor data collection endpoint URL for diagnostic telemetry. Requires replacement if changed.
 - `data_collection_rule_id` (String) Azure Monitor data collection rule resource ID associated with the endpoint. Requires replacement if changed.
-- `enable_fusion` (Boolean) Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-Requires replacement if changed.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
-Requires replacement if changed.
 - `environment` (Attributes List) Array of environment variables for the compute environment. Requires replacement if changed. (see [below for nested schema](#nestedatt--compute_env--config--azure_cloud--environment))
 - `instance_type` (String) Azure VM size for compute instances (e.g., Standard_D4s_v3, Standard_F8s_v2). Requires replacement if changed.
 - `log_table_name` (String) Azure Log Analytics table name for execution logs. Requires replacement if changed.
@@ -866,16 +846,6 @@ Optional:
 When enabled, ARM-based machines will be selected for cost savings.
 Requires replacement if changed.
 - `boot_disk_size_gb` (Number) Size of the boot disk in GB for compute instances. Requires replacement if changed.
-- `enable_fusion` (Boolean) Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-Requires replacement if changed.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
-Requires replacement if changed.
 - `environment` (Attributes List) Array of environment variables for the compute environment. Requires replacement if changed. (see [below for nested schema](#nestedatt--compute_env--config--google_cloud--environment))
 - `gpu_enabled` (Boolean) Enable GPU support for compute instances.
 When enabled, GPU-capable machine types will be selected.

--- a/docs/resources/gcp_cloud_ce.md
+++ b/docs/resources/gcp_cloud_ce.md
@@ -132,16 +132,6 @@ Optional:
 When enabled, ARM-based machines will be selected for cost savings.
 Requires replacement if changed.
 - `boot_disk_size_gb` (Number) Size of the boot disk in GB for compute instances. Requires replacement if changed.
-- `enable_fusion` (Boolean) Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-Requires replacement if changed.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
-Requires replacement if changed.
 - `environment` (Attributes List) Array of environment variables for the compute environment.
 Each variable can target the head node, compute nodes, or both.
 Requires replacement if changed. (see [below for nested schema](#nestedatt--config--environment))

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -409,14 +409,6 @@ When enabled, Graviton-based EC2 instances will be selected for cost savings.
 When using Fusion v2 without fast instance storage, this defaults to 100 GB with GP3 volume type.
 - `ec2_key_pair` (String) EC2 key pair name for SSH access to compute instances.
 Key pair must exist in the specified region.
-- `enable_fusion` (Boolean) Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
 - `environment` (Attributes List) Array of environment variables for the compute environment (see [below for nested schema](#nestedatt--launch--compute_env--config--aws_cloud--environment))
 - `gpu_enabled` (Boolean) Enable GPU support for compute instances.
 When enabled, GPU-capable instance types will be selected.
@@ -588,14 +580,6 @@ Read-Only:
 
 - `data_collection_endpoint` (String) Azure Monitor data collection endpoint URL for diagnostic telemetry.
 - `data_collection_rule_id` (String) Azure Monitor data collection rule resource ID associated with the endpoint.
-- `enable_fusion` (Boolean) Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
 - `environment` (Attributes List) Array of environment variables for the compute environment (see [below for nested schema](#nestedatt--launch--compute_env--config--azure_cloud--environment))
 - `instance_type` (String) Azure VM size for compute instances (e.g., Standard_D4s_v3, Standard_F8s_v2).
 - `log_table_name` (String) Azure Log Analytics table name for execution logs.
@@ -822,14 +806,6 @@ Read-Only:
 - `arm64_enabled` (Boolean) Enable ARM64 (Tau T2A) machine types for compute instances.
 When enabled, ARM-based machines will be selected for cost savings.
 - `boot_disk_size_gb` (Number) Size of the boot disk in GB for compute instances.
-- `enable_fusion` (Boolean) Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-speeding up most operations.
-
-Requires `enable_wave = true`.
-- `enable_wave` (Boolean) Allow access to private container repositories and the provisioning of containers in your
-Nextflow pipelines via the Wave containers service.
-
-Required when `enable_fusion` is true.
 - `environment` (Attributes List) Array of environment variables for the compute environment (see [below for nested schema](#nestedatt--launch--compute_env--config--google_cloud--environment))
 - `gpu_enabled` (Boolean) Enable GPU support for compute instances.
 When enabled, GPU-capable machine types will be selected.

--- a/internal/provider/action_resource.go
+++ b/internal/provider/action_resource.go
@@ -649,20 +649,6 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 												MarkdownDescription: `EC2 key pair name for SSH access to compute instances.` + "\n" +
 													`Key pair must exist in the specified region.`,
 											},
-											"enable_fusion": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-													`speeding up most operations.` + "\n" +
-													`` + "\n" +
-													`Requires ` + "`" + `enable_wave = true` + "`" + `.`,
-											},
-											"enable_wave": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-													`Nextflow pipelines via the Wave containers service.` + "\n" +
-													`` + "\n" +
-													`Required when ` + "`" + `enable_fusion` + "`" + ` is true.`,
-											},
 											"environment": schema.ListNestedAttribute{
 												Computed: true,
 												NestedObject: schema.NestedAttributeObject{
@@ -991,20 +977,6 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 											"data_collection_rule_id": schema.StringAttribute{
 												Computed:    true,
 												Description: `Azure Monitor data collection rule resource ID associated with the endpoint.`,
-											},
-											"enable_fusion": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-													`speeding up most operations.` + "\n" +
-													`` + "\n" +
-													`Requires ` + "`" + `enable_wave = true` + "`" + `.`,
-											},
-											"enable_wave": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-													`Nextflow pipelines via the Wave containers service.` + "\n" +
-													`` + "\n" +
-													`Required when ` + "`" + `enable_fusion` + "`" + ` is true.`,
 											},
 											"environment": schema.ListNestedAttribute{
 												Computed: true,
@@ -1519,20 +1491,6 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 											"boot_disk_size_gb": schema.Int32Attribute{
 												Computed:    true,
 												Description: `Size of the boot disk in GB for compute instances.`,
-											},
-											"enable_fusion": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-													`speeding up most operations.` + "\n" +
-													`` + "\n" +
-													`Requires ` + "`" + `enable_wave = true` + "`" + `.`,
-											},
-											"enable_wave": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-													`Nextflow pipelines via the Wave containers service.` + "\n" +
-													`` + "\n" +
-													`Required when ` + "`" + `enable_fusion` + "`" + ` is true.`,
 											},
 											"environment": schema.ListNestedAttribute{
 												Computed: true,

--- a/internal/provider/action_resource_sdk.go
+++ b/internal/provider/action_resource_sdk.go
@@ -170,8 +170,6 @@ func (r *ActionResourceModel) RefreshFromSharedActionResponseDto(ctx context.Con
 					r.Launch.ComputeEnv.Config.AwsCloud.Arm64Enabled = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.Arm64Enabled)
 					r.Launch.ComputeEnv.Config.AwsCloud.EbsBootSize = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.EbsBootSize))
 					r.Launch.ComputeEnv.Config.AwsCloud.Ec2KeyPair = types.StringPointerValue(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.Ec2KeyPair)
-					r.Launch.ComputeEnv.Config.AwsCloud.EnableFusion = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.EnableFusion)
-					r.Launch.ComputeEnv.Config.AwsCloud.EnableWave = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.EnableWave)
 					r.Launch.ComputeEnv.Config.AwsCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem1 := range resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.Environment {
@@ -306,8 +304,6 @@ func (r *ActionResourceModel) RefreshFromSharedActionResponseDto(ctx context.Con
 					r.Launch.ComputeEnv.Config.GoogleCloud = &tfTypes.GoogleCloudConfiguration{}
 					r.Launch.ComputeEnv.Config.GoogleCloud.Arm64Enabled = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.Arm64Enabled)
 					r.Launch.ComputeEnv.Config.GoogleCloud.BootDiskSizeGb = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.BootDiskSizeGb))
-					r.Launch.ComputeEnv.Config.GoogleCloud.EnableFusion = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.EnableFusion)
-					r.Launch.ComputeEnv.Config.GoogleCloud.EnableWave = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.EnableWave)
 					r.Launch.ComputeEnv.Config.GoogleCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem4 := range resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.Environment {
@@ -410,8 +406,6 @@ func (r *ActionResourceModel) RefreshFromSharedActionResponseDto(ctx context.Con
 					r.Launch.ComputeEnv.Config.AzureCloud = &tfTypes.AzureCloudConfiguration{}
 					r.Launch.ComputeEnv.Config.AzureCloud.DataCollectionEndpoint = types.StringPointerValue(resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.DataCollectionEndpoint)
 					r.Launch.ComputeEnv.Config.AzureCloud.DataCollectionRuleID = types.StringPointerValue(resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.DataCollectionRuleID)
-					r.Launch.ComputeEnv.Config.AzureCloud.EnableFusion = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.EnableFusion)
-					r.Launch.ComputeEnv.Config.AzureCloud.EnableWave = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.EnableWave)
 					r.Launch.ComputeEnv.Config.AzureCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem6 := range resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.Environment {

--- a/internal/provider/awscloudce_resource.go
+++ b/internal/provider/awscloudce_resource.go
@@ -32,7 +32,6 @@ import (
 	tfTypes "github.com/seqeralabs/terraform-provider-seqera/internal/provider/types"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk"
 	stateupgraders "github.com/seqeralabs/terraform-provider-seqera/internal/stateupgraders"
-	custom_boolvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/boolvalidators"
 	custom_objectvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/objectvalidators"
 	speakeasy_objectvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/objectvalidators"
 	custom_stringvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/stringvalidators"
@@ -136,35 +135,6 @@ func (r *AwsCloudCEResource) Schema(ctx context.Context, req resource.SchemaRequ
 						},
 						MarkdownDescription: `EC2 key pair name for SSH access to compute instances.` + "\n" +
 							`Key pair must exist in the specified region.` + "\n" +
-							`Requires replacement if changed.`,
-					},
-					"enable_fusion": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						PlanModifiers: []planmodifier.Bool{
-							boolplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
-						MarkdownDescription: `Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-							`speeding up most operations.` + "\n" +
-							`` + "\n" +
-							`Requires ` + "`" + `enable_wave = true` + "`" + `.` + "\n" +
-							`Requires replacement if changed.`,
-						Validators: []validator.Bool{
-							custom_boolvalidators.FusionEnabledValidator(),
-						},
-					},
-					"enable_wave": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						PlanModifiers: []planmodifier.Bool{
-							boolplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
-						MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-							`Nextflow pipelines via the Wave containers service.` + "\n" +
-							`` + "\n" +
-							`Required when ` + "`" + `enable_fusion` + "`" + ` is true.` + "\n" +
 							`Requires replacement if changed.`,
 					},
 					"environment": schema.ListNestedAttribute{

--- a/internal/provider/awscloudce_resource_sdk.go
+++ b/internal/provider/awscloudce_resource_sdk.go
@@ -27,8 +27,6 @@ func (r *AwsCloudCEResourceModel) RefreshFromSharedAwsCloudCEComputeConfig(ctx c
 		r.Config.Arm64Enabled = types.BoolPointerValue(resp.Config.Arm64Enabled)
 		r.Config.EbsBootSize = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.EbsBootSize))
 		r.Config.Ec2KeyPair = types.StringPointerValue(resp.Config.Ec2KeyPair)
-		r.Config.EnableFusion = types.BoolPointerValue(resp.Config.EnableFusion)
-		r.Config.EnableWave = types.BoolPointerValue(resp.Config.EnableWave)
 		r.Config.Environment = []tfTypes.ConfigEnvVariable{}
 
 		for _, environmentItem := range resp.Config.Environment {
@@ -292,12 +290,6 @@ func (r *AwsCloudCEResourceModel) ToSharedAwsCloudCEComputeConfigInput(ctx conte
 			Value:   value,
 		})
 	}
-	enableFusion := new(bool)
-	if !r.Config.EnableFusion.IsUnknown() && !r.Config.EnableFusion.IsNull() {
-		*enableFusion = r.Config.EnableFusion.ValueBool()
-	} else {
-		enableFusion = nil
-	}
 	gpuEnabled := new(bool)
 	if !r.Config.GpuEnabled.IsUnknown() && !r.Config.GpuEnabled.IsNull() {
 		*gpuEnabled = r.Config.GpuEnabled.ValueBool()
@@ -382,12 +374,6 @@ func (r *AwsCloudCEResourceModel) ToSharedAwsCloudCEComputeConfigInput(ctx conte
 	} else {
 		subnetID = nil
 	}
-	enableWave := new(bool)
-	if !r.Config.EnableWave.IsUnknown() && !r.Config.EnableWave.IsNull() {
-		*enableWave = r.Config.EnableWave.ValueBool()
-	} else {
-		enableWave = nil
-	}
 	workDir := new(string)
 	if !r.Config.WorkDir.IsUnknown() && !r.Config.WorkDir.IsNull() {
 		*workDir = r.Config.WorkDir.ValueString()
@@ -400,7 +386,6 @@ func (r *AwsCloudCEResourceModel) ToSharedAwsCloudCEComputeConfigInput(ctx conte
 		EbsBootSize:               ebsBootSize,
 		Ec2KeyPair:                ec2KeyPair,
 		Environment:               environment,
-		EnableFusion:              enableFusion,
 		GpuEnabled:                gpuEnabled,
 		ImageID:                   imageID,
 		InstanceProfileArn:        instanceProfileArn,
@@ -414,7 +399,6 @@ func (r *AwsCloudCEResourceModel) ToSharedAwsCloudCEComputeConfigInput(ctx conte
 		IntelligentComputeEnabled: intelligentComputeEnabled,
 		SecurityGroups:            securityGroups,
 		SubnetID:                  subnetID,
-		EnableWave:                enableWave,
 		WorkDir:                   workDir,
 	}
 	out := shared.AwsCloudCEComputeConfigInput{

--- a/internal/provider/azurecloudce_resource.go
+++ b/internal/provider/azurecloudce_resource.go
@@ -30,7 +30,6 @@ import (
 	tfTypes "github.com/seqeralabs/terraform-provider-seqera/internal/provider/types"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk"
 	stateupgraders "github.com/seqeralabs/terraform-provider-seqera/internal/stateupgraders"
-	custom_boolvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/boolvalidators"
 	custom_objectvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/objectvalidators"
 	speakeasy_objectvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/objectvalidators"
 	custom_stringvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/stringvalidators"
@@ -107,35 +106,6 @@ func (r *AzureCloudCEResource) Schema(ctx context.Context, req resource.SchemaRe
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `Azure Monitor data collection rule resource ID associated with the endpoint. Requires replacement if changed.`,
-					},
-					"enable_fusion": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						PlanModifiers: []planmodifier.Bool{
-							boolplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
-						MarkdownDescription: `Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-							`speeding up most operations.` + "\n" +
-							`` + "\n" +
-							`Requires ` + "`" + `enable_wave = true` + "`" + `.` + "\n" +
-							`Requires replacement if changed.`,
-						Validators: []validator.Bool{
-							custom_boolvalidators.FusionEnabledValidator(),
-						},
-					},
-					"enable_wave": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						PlanModifiers: []planmodifier.Bool{
-							boolplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
-						MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-							`Nextflow pipelines via the Wave containers service.` + "\n" +
-							`` + "\n" +
-							`Required when ` + "`" + `enable_fusion` + "`" + ` is true.` + "\n" +
-							`Requires replacement if changed.`,
 					},
 					"environment": schema.ListNestedAttribute{
 						Computed: true,

--- a/internal/provider/azurecloudce_resource_sdk.go
+++ b/internal/provider/azurecloudce_resource_sdk.go
@@ -20,8 +20,6 @@ func (r *AzureCloudCEResourceModel) RefreshFromSharedAzureCloudCEComputeConfig(c
 		r.Config = &tfTypes.AzCloudConfig{}
 		r.Config.DataCollectionEndpoint = types.StringPointerValue(resp.Config.DataCollectionEndpoint)
 		r.Config.DataCollectionRuleID = types.StringPointerValue(resp.Config.DataCollectionRuleID)
-		r.Config.EnableFusion = types.BoolPointerValue(resp.Config.EnableFusion)
-		r.Config.EnableWave = types.BoolPointerValue(resp.Config.EnableWave)
 		r.Config.Environment = []tfTypes.ConfigEnvVariable{}
 
 		for _, environmentItem := range resp.Config.Environment {
@@ -256,12 +254,6 @@ func (r *AzureCloudCEResourceModel) ToSharedAzureCloudCEComputeConfigInput(ctx c
 			Value:   value,
 		})
 	}
-	enableFusion := new(bool)
-	if !r.Config.EnableFusion.IsUnknown() && !r.Config.EnableFusion.IsNull() {
-		*enableFusion = r.Config.EnableFusion.ValueBool()
-	} else {
-		enableFusion = nil
-	}
 	instanceType := new(string)
 	if !r.Config.InstanceType.IsUnknown() && !r.Config.InstanceType.IsNull() {
 		*instanceType = r.Config.InstanceType.ValueString()
@@ -334,12 +326,6 @@ func (r *AzureCloudCEResourceModel) ToSharedAzureCloudCEComputeConfigInput(ctx c
 	} else {
 		subscriptionID = nil
 	}
-	enableWave := new(bool)
-	if !r.Config.EnableWave.IsUnknown() && !r.Config.EnableWave.IsNull() {
-		*enableWave = r.Config.EnableWave.ValueBool()
-	} else {
-		enableWave = nil
-	}
 	workDir := new(string)
 	if !r.Config.WorkDir.IsUnknown() && !r.Config.WorkDir.IsNull() {
 		*workDir = r.Config.WorkDir.ValueString()
@@ -350,7 +336,6 @@ func (r *AzureCloudCEResourceModel) ToSharedAzureCloudCEComputeConfigInput(ctx c
 		DataCollectionEndpoint:  dataCollectionEndpoint,
 		DataCollectionRuleID:    dataCollectionRuleID,
 		Environment:             environment,
-		EnableFusion:            enableFusion,
 		InstanceType:            instanceType,
 		LogTableName:            logTableName,
 		LogWorkspaceID:          logWorkspaceID,
@@ -363,7 +348,6 @@ func (r *AzureCloudCEResourceModel) ToSharedAzureCloudCEComputeConfigInput(ctx c
 		Region:                  region,
 		ResourceGroup:           resourceGroup,
 		SubscriptionID:          subscriptionID,
-		EnableWave:              enableWave,
 		WorkDir:                 workDir,
 	}
 	out := shared.AzureCloudCEComputeConfigInput{

--- a/internal/provider/computeenv_resource.go
+++ b/internal/provider/computeenv_resource.go
@@ -1047,33 +1047,6 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 											`Key pair must exist in the specified region.` + "\n" +
 											`Requires replacement if changed.`,
 									},
-									"enable_fusion": schema.BoolAttribute{
-										Computed: true,
-										Optional: true,
-										PlanModifiers: []planmodifier.Bool{
-											boolplanmodifier.RequiresReplaceIfConfigured(),
-										},
-										MarkdownDescription: `Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-											`speeding up most operations.` + "\n" +
-											`` + "\n" +
-											`Requires ` + "`" + `enable_wave = true` + "`" + `.` + "\n" +
-											`Requires replacement if changed.`,
-										Validators: []validator.Bool{
-											custom_boolvalidators.FusionEnabledValidator(),
-										},
-									},
-									"enable_wave": schema.BoolAttribute{
-										Computed: true,
-										Optional: true,
-										PlanModifiers: []planmodifier.Bool{
-											boolplanmodifier.RequiresReplaceIfConfigured(),
-										},
-										MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-											`Nextflow pipelines via the Wave containers service.` + "\n" +
-											`` + "\n" +
-											`Required when ` + "`" + `enable_fusion` + "`" + ` is true.` + "\n" +
-											`Requires replacement if changed.`,
-									},
 									"environment": schema.ListNestedAttribute{
 										Computed: true,
 										Optional: true,
@@ -1819,33 +1792,6 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 											stringplanmodifier.RequiresReplaceIfConfigured(),
 										},
 										Description: `Azure Monitor data collection rule resource ID associated with the endpoint. Requires replacement if changed.`,
-									},
-									"enable_fusion": schema.BoolAttribute{
-										Computed: true,
-										Optional: true,
-										PlanModifiers: []planmodifier.Bool{
-											boolplanmodifier.RequiresReplaceIfConfigured(),
-										},
-										MarkdownDescription: `Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-											`speeding up most operations.` + "\n" +
-											`` + "\n" +
-											`Requires ` + "`" + `enable_wave = true` + "`" + `.` + "\n" +
-											`Requires replacement if changed.`,
-										Validators: []validator.Bool{
-											custom_boolvalidators.FusionEnabledValidator(),
-										},
-									},
-									"enable_wave": schema.BoolAttribute{
-										Computed: true,
-										Optional: true,
-										PlanModifiers: []planmodifier.Bool{
-											boolplanmodifier.RequiresReplaceIfConfigured(),
-										},
-										MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-											`Nextflow pipelines via the Wave containers service.` + "\n" +
-											`` + "\n" +
-											`Required when ` + "`" + `enable_fusion` + "`" + ` is true.` + "\n" +
-											`Requires replacement if changed.`,
 									},
 									"environment": schema.ListNestedAttribute{
 										Computed: true,
@@ -3028,33 +2974,6 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 											int32planmodifier.RequiresReplaceIfConfigured(),
 										},
 										Description: `Size of the boot disk in GB for compute instances. Requires replacement if changed.`,
-									},
-									"enable_fusion": schema.BoolAttribute{
-										Computed: true,
-										Optional: true,
-										PlanModifiers: []planmodifier.Bool{
-											boolplanmodifier.RequiresReplaceIfConfigured(),
-										},
-										MarkdownDescription: `Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-											`speeding up most operations.` + "\n" +
-											`` + "\n" +
-											`Requires ` + "`" + `enable_wave = true` + "`" + `.` + "\n" +
-											`Requires replacement if changed.`,
-										Validators: []validator.Bool{
-											custom_boolvalidators.FusionEnabledValidator(),
-										},
-									},
-									"enable_wave": schema.BoolAttribute{
-										Computed: true,
-										Optional: true,
-										PlanModifiers: []planmodifier.Bool{
-											boolplanmodifier.RequiresReplaceIfConfigured(),
-										},
-										MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-											`Nextflow pipelines via the Wave containers service.` + "\n" +
-											`` + "\n" +
-											`Required when ` + "`" + `enable_fusion` + "`" + ` is true.` + "\n" +
-											`Requires replacement if changed.`,
 									},
 									"environment": schema.ListNestedAttribute{
 										Computed: true,

--- a/internal/provider/computeenv_resource_sdk.go
+++ b/internal/provider/computeenv_resource_sdk.go
@@ -137,8 +137,6 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 					r.ComputeEnv.Config.AwsCloud.Arm64Enabled = types.BoolPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.Arm64Enabled)
 					r.ComputeEnv.Config.AwsCloud.EbsBootSize = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.AWSCloudConfiguration.EbsBootSize))
 					r.ComputeEnv.Config.AwsCloud.Ec2KeyPair = types.StringPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.Ec2KeyPair)
-					r.ComputeEnv.Config.AwsCloud.EnableFusion = types.BoolPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.EnableFusion)
-					r.ComputeEnv.Config.AwsCloud.EnableWave = types.BoolPointerValue(resp.ComputeEnv.Config.AWSCloudConfiguration.EnableWave)
 					r.ComputeEnv.Config.AwsCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem1 := range resp.ComputeEnv.Config.AWSCloudConfiguration.Environment {
@@ -329,8 +327,6 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 					r.ComputeEnv.Config.AzureCloud = &tfTypes.AzureCloudConfiguration{}
 					r.ComputeEnv.Config.AzureCloud.DataCollectionEndpoint = types.StringPointerValue(resp.ComputeEnv.Config.AzureCloudConfiguration.DataCollectionEndpoint)
 					r.ComputeEnv.Config.AzureCloud.DataCollectionRuleID = types.StringPointerValue(resp.ComputeEnv.Config.AzureCloudConfiguration.DataCollectionRuleID)
-					r.ComputeEnv.Config.AzureCloud.EnableFusion = types.BoolPointerValue(resp.ComputeEnv.Config.AzureCloudConfiguration.EnableFusion)
-					r.ComputeEnv.Config.AzureCloud.EnableWave = types.BoolPointerValue(resp.ComputeEnv.Config.AzureCloudConfiguration.EnableWave)
 					r.ComputeEnv.Config.AzureCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem5 := range resp.ComputeEnv.Config.AzureCloudConfiguration.Environment {
@@ -420,8 +416,6 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 					r.ComputeEnv.Config.GoogleCloud = &tfTypes.GoogleCloudConfiguration{}
 					r.ComputeEnv.Config.GoogleCloud.Arm64Enabled = types.BoolPointerValue(resp.ComputeEnv.Config.GoogleCloudConfiguration.Arm64Enabled)
 					r.ComputeEnv.Config.GoogleCloud.BootDiskSizeGb = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.GoogleCloudConfiguration.BootDiskSizeGb))
-					r.ComputeEnv.Config.GoogleCloud.EnableFusion = types.BoolPointerValue(resp.ComputeEnv.Config.GoogleCloudConfiguration.EnableFusion)
-					r.ComputeEnv.Config.GoogleCloud.EnableWave = types.BoolPointerValue(resp.ComputeEnv.Config.GoogleCloudConfiguration.EnableWave)
 					r.ComputeEnv.Config.GoogleCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem7 := range resp.ComputeEnv.Config.GoogleCloudConfiguration.Environment {
@@ -1339,12 +1333,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				Value:   value1,
 			})
 		}
-		enableFusion1 := new(bool)
-		if !r.ComputeEnv.Config.AwsCloud.EnableFusion.IsUnknown() && !r.ComputeEnv.Config.AwsCloud.EnableFusion.IsNull() {
-			*enableFusion1 = r.ComputeEnv.Config.AwsCloud.EnableFusion.ValueBool()
-		} else {
-			enableFusion1 = nil
-		}
 		gpuEnabled1 := new(bool)
 		if !r.ComputeEnv.Config.AwsCloud.GpuEnabled.IsUnknown() && !r.ComputeEnv.Config.AwsCloud.GpuEnabled.IsNull() {
 			*gpuEnabled1 = r.ComputeEnv.Config.AwsCloud.GpuEnabled.ValueBool()
@@ -1429,12 +1417,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			subnetID = nil
 		}
-		enableWave1 := new(bool)
-		if !r.ComputeEnv.Config.AwsCloud.EnableWave.IsUnknown() && !r.ComputeEnv.Config.AwsCloud.EnableWave.IsNull() {
-			*enableWave1 = r.ComputeEnv.Config.AwsCloud.EnableWave.ValueBool()
-		} else {
-			enableWave1 = nil
-		}
 		workDir1 := new(string)
 		if !r.ComputeEnv.Config.AwsCloud.WorkDir.IsUnknown() && !r.ComputeEnv.Config.AwsCloud.WorkDir.IsNull() {
 			*workDir1 = r.ComputeEnv.Config.AwsCloud.WorkDir.ValueString()
@@ -1447,7 +1429,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			EbsBootSize:               ebsBootSize1,
 			Ec2KeyPair:                ec2KeyPair1,
 			Environment:               environment1,
-			EnableFusion:              enableFusion1,
 			GpuEnabled:                gpuEnabled1,
 			ImageID:                   imageId1,
 			InstanceProfileArn:        instanceProfileArn,
@@ -1461,7 +1442,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			IntelligentComputeEnabled: intelligentComputeEnabled,
 			SecurityGroups:            securityGroups1,
 			SubnetID:                  subnetID,
-			EnableWave:                enableWave1,
 			WorkDir:                   workDir1,
 		}
 	}
@@ -1635,11 +1615,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				Value:   value3,
 			})
 		}
-		enableFusion2 := new(bool)
+		enableFusion1 := new(bool)
 		if !r.ComputeEnv.Config.GoogleBatch.EnableFusion.IsUnknown() && !r.ComputeEnv.Config.GoogleBatch.EnableFusion.IsNull() {
-			*enableFusion2 = r.ComputeEnv.Config.GoogleBatch.EnableFusion.ValueBool()
+			*enableFusion1 = r.ComputeEnv.Config.GoogleBatch.EnableFusion.ValueBool()
 		} else {
-			enableFusion2 = nil
+			enableFusion1 = nil
 		}
 		fusionSnapshots1 := new(bool)
 		if !r.ComputeEnv.Config.GoogleBatch.FusionSnapshots.IsUnknown() && !r.ComputeEnv.Config.GoogleBatch.FusionSnapshots.IsNull() {
@@ -1763,11 +1743,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			usePrivateAddress = nil
 		}
-		enableWave2 := new(bool)
+		enableWave1 := new(bool)
 		if !r.ComputeEnv.Config.GoogleBatch.EnableWave.IsUnknown() && !r.ComputeEnv.Config.GoogleBatch.EnableWave.IsNull() {
-			*enableWave2 = r.ComputeEnv.Config.GoogleBatch.EnableWave.ValueBool()
+			*enableWave1 = r.ComputeEnv.Config.GoogleBatch.EnableWave.ValueBool()
 		} else {
-			enableWave2 = nil
+			enableWave1 = nil
 		}
 		workDir3 := new(string)
 		if !r.ComputeEnv.Config.GoogleBatch.WorkDir.IsUnknown() && !r.ComputeEnv.Config.GoogleBatch.WorkDir.IsNull() {
@@ -1784,7 +1764,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			CPUPlatform:                 cpuPlatform,
 			DebugMode:                   debugMode,
 			Environment:                 environment3,
-			EnableFusion:                enableFusion2,
+			EnableFusion:                enableFusion1,
 			FusionSnapshots:             fusionSnapshots1,
 			HeadJobCpus:                 headJobCpus1,
 			HeadJobInstanceTemplate:     headJobInstanceTemplate,
@@ -1806,7 +1786,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			SSHImage:                    sshImage,
 			Subnetwork:                  subnetwork,
 			UsePrivateAddress:           usePrivateAddress,
-			EnableWave:                  enableWave2,
+			EnableWave:                  enableWave1,
 			WorkDir:                     workDir3,
 		}
 	}
@@ -1862,12 +1842,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				Value:   value4,
 			})
 		}
-		enableFusion3 := new(bool)
-		if !r.ComputeEnv.Config.GoogleCloud.EnableFusion.IsUnknown() && !r.ComputeEnv.Config.GoogleCloud.EnableFusion.IsNull() {
-			*enableFusion3 = r.ComputeEnv.Config.GoogleCloud.EnableFusion.ValueBool()
-		} else {
-			enableFusion3 = nil
-		}
 		gpuEnabled2 := new(bool)
 		if !r.ComputeEnv.Config.GoogleCloud.GpuEnabled.IsUnknown() && !r.ComputeEnv.Config.GoogleCloud.GpuEnabled.IsNull() {
 			*gpuEnabled2 = r.ComputeEnv.Config.GoogleCloud.GpuEnabled.ValueBool()
@@ -1922,12 +1896,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			serviceAccountEmail = nil
 		}
-		enableWave3 := new(bool)
-		if !r.ComputeEnv.Config.GoogleCloud.EnableWave.IsUnknown() && !r.ComputeEnv.Config.GoogleCloud.EnableWave.IsNull() {
-			*enableWave3 = r.ComputeEnv.Config.GoogleCloud.EnableWave.ValueBool()
-		} else {
-			enableWave3 = nil
-		}
 		workDir4 := new(string)
 		if !r.ComputeEnv.Config.GoogleCloud.WorkDir.IsUnknown() && !r.ComputeEnv.Config.GoogleCloud.WorkDir.IsNull() {
 			*workDir4 = r.ComputeEnv.Config.GoogleCloud.WorkDir.ValueString()
@@ -1944,7 +1912,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			Arm64Enabled:        arm64Enabled2,
 			BootDiskSizeGb:      bootDiskSizeGb1,
 			Environment:         environment4,
-			EnableFusion:        enableFusion3,
 			GpuEnabled:          gpuEnabled2,
 			ImageID:             imageId2,
 			InstanceType:        instanceType1,
@@ -1954,7 +1921,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			ProjectID:           projectId1,
 			Region:              region3,
 			ServiceAccountEmail: serviceAccountEmail,
-			EnableWave:          enableWave3,
 			WorkDir:             workDir4,
 			Zone:                zone,
 		}
@@ -2125,11 +2091,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				WorkerPool:        workerPool,
 			}
 		}
-		enableFusion4 := new(bool)
+		enableFusion2 := new(bool)
 		if !r.ComputeEnv.Config.AzureBatch.EnableFusion.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.EnableFusion.IsNull() {
-			*enableFusion4 = r.ComputeEnv.Config.AzureBatch.EnableFusion.ValueBool()
+			*enableFusion2 = r.ComputeEnv.Config.AzureBatch.EnableFusion.ValueBool()
 		} else {
-			enableFusion4 = nil
+			enableFusion2 = nil
 		}
 		headJobCpus2 := new(int)
 		if !r.ComputeEnv.Config.AzureBatch.HeadJobCpus.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.HeadJobCpus.IsNull() {
@@ -2218,11 +2184,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			tokenDuration = nil
 		}
-		enableWave4 := new(bool)
+		enableWave2 := new(bool)
 		if !r.ComputeEnv.Config.AzureBatch.EnableWave.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.EnableWave.IsNull() {
-			*enableWave4 = r.ComputeEnv.Config.AzureBatch.EnableWave.ValueBool()
+			*enableWave2 = r.ComputeEnv.Config.AzureBatch.EnableWave.ValueBool()
 		} else {
-			enableWave4 = nil
+			enableWave2 = nil
 		}
 		workDir5 := new(string)
 		if !r.ComputeEnv.Config.AzureBatch.WorkDir.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.WorkDir.IsNull() {
@@ -2244,7 +2210,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			DeleteTasksOnCompletion:       deleteTasksOnCompletion,
 			Environment:                   environment5,
 			Forge:                         forge1,
-			EnableFusion:                  enableFusion4,
+			EnableFusion:                  enableFusion2,
 			HeadJobCpus:                   headJobCpus2,
 			HeadJobMemoryMb:               headJobMemoryMb2,
 			HeadPool:                      headPool1,
@@ -2260,7 +2226,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			SubnetID:                      subnetId1,
 			TerminateJobsOnCompletion:     terminateJobsOnCompletion,
 			TokenDuration:                 tokenDuration,
-			EnableWave:                    enableWave4,
+			EnableWave:                    enableWave2,
 			WorkDir:                       workDir5,
 			WorkerPool:                    workerPool1,
 		}
@@ -2316,12 +2282,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				Name:    name6,
 				Value:   value6,
 			})
-		}
-		enableFusion5 := new(bool)
-		if !r.ComputeEnv.Config.AzureCloud.EnableFusion.IsUnknown() && !r.ComputeEnv.Config.AzureCloud.EnableFusion.IsNull() {
-			*enableFusion5 = r.ComputeEnv.Config.AzureCloud.EnableFusion.ValueBool()
-		} else {
-			enableFusion5 = nil
 		}
 		instanceType2 := new(string)
 		if !r.ComputeEnv.Config.AzureCloud.InstanceType.IsUnknown() && !r.ComputeEnv.Config.AzureCloud.InstanceType.IsNull() {
@@ -2395,12 +2355,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			subscriptionID = nil
 		}
-		enableWave5 := new(bool)
-		if !r.ComputeEnv.Config.AzureCloud.EnableWave.IsUnknown() && !r.ComputeEnv.Config.AzureCloud.EnableWave.IsNull() {
-			*enableWave5 = r.ComputeEnv.Config.AzureCloud.EnableWave.ValueBool()
-		} else {
-			enableWave5 = nil
-		}
 		workDir6 := new(string)
 		if !r.ComputeEnv.Config.AzureCloud.WorkDir.IsUnknown() && !r.ComputeEnv.Config.AzureCloud.WorkDir.IsNull() {
 			*workDir6 = r.ComputeEnv.Config.AzureCloud.WorkDir.ValueString()
@@ -2411,7 +2365,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			DataCollectionEndpoint:  dataCollectionEndpoint,
 			DataCollectionRuleID:    dataCollectionRuleID,
 			Environment:             environment6,
-			EnableFusion:            enableFusion5,
 			InstanceType:            instanceType2,
 			LogTableName:            logTableName,
 			LogWorkspaceID:          logWorkspaceID,
@@ -2424,7 +2377,6 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			Region:                  region5,
 			ResourceGroup:           resourceGroup,
 			SubscriptionID:          subscriptionID,
-			EnableWave:              enableWave5,
 			WorkDir:                 workDir6,
 		}
 	}
@@ -2903,11 +2855,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				Value:   value10,
 			})
 		}
-		enableFusion6 := new(bool)
+		enableFusion3 := new(bool)
 		if !r.ComputeEnv.Config.EksPlatform.EnableFusion.IsUnknown() && !r.ComputeEnv.Config.EksPlatform.EnableFusion.IsNull() {
-			*enableFusion6 = r.ComputeEnv.Config.EksPlatform.EnableFusion.ValueBool()
+			*enableFusion3 = r.ComputeEnv.Config.EksPlatform.EnableFusion.ValueBool()
 		} else {
-			enableFusion6 = nil
+			enableFusion3 = nil
 		}
 		headJobCpus4 := new(int)
 		if !r.ComputeEnv.Config.EksPlatform.HeadJobCpus.IsUnknown() && !r.ComputeEnv.Config.EksPlatform.HeadJobCpus.IsNull() {
@@ -2996,11 +2948,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			storageMountPath1 = nil
 		}
-		enableWave6 := new(bool)
+		enableWave3 := new(bool)
 		if !r.ComputeEnv.Config.EksPlatform.EnableWave.IsUnknown() && !r.ComputeEnv.Config.EksPlatform.EnableWave.IsNull() {
-			*enableWave6 = r.ComputeEnv.Config.EksPlatform.EnableWave.ValueBool()
+			*enableWave3 = r.ComputeEnv.Config.EksPlatform.EnableWave.ValueBool()
 		} else {
-			enableWave6 = nil
+			enableWave3 = nil
 		}
 		workDir10 := new(string)
 		if !r.ComputeEnv.Config.EksPlatform.WorkDir.IsUnknown() && !r.ComputeEnv.Config.EksPlatform.WorkDir.IsNull() {
@@ -3012,7 +2964,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			ClusterName:           clusterName,
 			ComputeServiceAccount: computeServiceAccount1,
 			Environment:           environment10,
-			EnableFusion:          enableFusion6,
+			EnableFusion:          enableFusion3,
 			HeadJobCpus:           headJobCpus4,
 			HeadJobMemoryMb:       headJobMemoryMb4,
 			HeadPodSpec:           headPodSpec1,
@@ -3028,7 +2980,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			SslCert:               sslCert1,
 			StorageClaimName:      storageClaimName1,
 			StorageMountPath:      storageMountPath1,
-			EnableWave:            enableWave6,
+			EnableWave:            enableWave3,
 			WorkDir:               workDir10,
 		}
 	}
@@ -3081,11 +3033,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				Value:   value11,
 			})
 		}
-		enableFusion7 := new(bool)
+		enableFusion4 := new(bool)
 		if !r.ComputeEnv.Config.GkePlatform.EnableFusion.IsUnknown() && !r.ComputeEnv.Config.GkePlatform.EnableFusion.IsNull() {
-			*enableFusion7 = r.ComputeEnv.Config.GkePlatform.EnableFusion.ValueBool()
+			*enableFusion4 = r.ComputeEnv.Config.GkePlatform.EnableFusion.ValueBool()
 		} else {
-			enableFusion7 = nil
+			enableFusion4 = nil
 		}
 		headJobCpus5 := new(int)
 		if !r.ComputeEnv.Config.GkePlatform.HeadJobCpus.IsUnknown() && !r.ComputeEnv.Config.GkePlatform.HeadJobCpus.IsNull() {
@@ -3174,11 +3126,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 		} else {
 			storageMountPath2 = nil
 		}
-		enableWave7 := new(bool)
+		enableWave4 := new(bool)
 		if !r.ComputeEnv.Config.GkePlatform.EnableWave.IsUnknown() && !r.ComputeEnv.Config.GkePlatform.EnableWave.IsNull() {
-			*enableWave7 = r.ComputeEnv.Config.GkePlatform.EnableWave.ValueBool()
+			*enableWave4 = r.ComputeEnv.Config.GkePlatform.EnableWave.ValueBool()
 		} else {
-			enableWave7 = nil
+			enableWave4 = nil
 		}
 		workDir11 := new(string)
 		if !r.ComputeEnv.Config.GkePlatform.WorkDir.IsUnknown() && !r.ComputeEnv.Config.GkePlatform.WorkDir.IsNull() {
@@ -3190,7 +3142,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			ClusterName:           clusterName1,
 			ComputeServiceAccount: computeServiceAccount2,
 			Environment:           environment11,
-			EnableFusion:          enableFusion7,
+			EnableFusion:          enableFusion4,
 			HeadJobCpus:           headJobCpus5,
 			HeadJobMemoryMb:       headJobMemoryMb5,
 			HeadPodSpec:           headPodSpec2,
@@ -3206,7 +3158,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			SslCert:               sslCert2,
 			StorageClaimName:      storageClaimName2,
 			StorageMountPath:      storageMountPath2,
-			EnableWave:            enableWave7,
+			EnableWave:            enableWave4,
 			WorkDir:               workDir11,
 		}
 	}

--- a/internal/provider/gcpcloudce_resource.go
+++ b/internal/provider/gcpcloudce_resource.go
@@ -32,7 +32,6 @@ import (
 	tfTypes "github.com/seqeralabs/terraform-provider-seqera/internal/provider/types"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk"
 	stateupgraders "github.com/seqeralabs/terraform-provider-seqera/internal/stateupgraders"
-	custom_boolvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/boolvalidators"
 	custom_objectvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/objectvalidators"
 	speakeasy_objectvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/objectvalidators"
 	custom_stringvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/stringvalidators"
@@ -111,35 +110,6 @@ func (r *GCPCloudCEResource) Schema(ctx context.Context, req resource.SchemaRequ
 							speakeasy_int32planmodifier.SuppressDiff(speakeasy_int32planmodifier.ExplicitSuppress),
 						},
 						Description: `Size of the boot disk in GB for compute instances. Requires replacement if changed.`,
-					},
-					"enable_fusion": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						PlanModifiers: []planmodifier.Bool{
-							boolplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
-						MarkdownDescription: `Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-							`speeding up most operations.` + "\n" +
-							`` + "\n" +
-							`Requires ` + "`" + `enable_wave = true` + "`" + `.` + "\n" +
-							`Requires replacement if changed.`,
-						Validators: []validator.Bool{
-							custom_boolvalidators.FusionEnabledValidator(),
-						},
-					},
-					"enable_wave": schema.BoolAttribute{
-						Computed: true,
-						Optional: true,
-						PlanModifiers: []planmodifier.Bool{
-							boolplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
-						MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-							`Nextflow pipelines via the Wave containers service.` + "\n" +
-							`` + "\n" +
-							`Required when ` + "`" + `enable_fusion` + "`" + ` is true.` + "\n" +
-							`Requires replacement if changed.`,
 					},
 					"environment": schema.ListNestedAttribute{
 						Computed: true,

--- a/internal/provider/gcpcloudce_resource_sdk.go
+++ b/internal/provider/gcpcloudce_resource_sdk.go
@@ -45,8 +45,6 @@ func (r *GCPCloudCEResourceModel) RefreshFromSharedGCPCloudCEComputeConfig(ctx c
 		r.Config = &tfTypes.GoogleCloudConfig{}
 		r.Config.Arm64Enabled = types.BoolPointerValue(resp.Config.Arm64Enabled)
 		r.Config.BootDiskSizeGb = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.BootDiskSizeGb))
-		r.Config.EnableFusion = types.BoolPointerValue(resp.Config.EnableFusion)
-		r.Config.EnableWave = types.BoolPointerValue(resp.Config.EnableWave)
 		r.Config.Environment = []tfTypes.ConfigEnvVariable{}
 
 		for _, environmentItem := range resp.Config.Environment {
@@ -276,12 +274,6 @@ func (r *GCPCloudCEResourceModel) ToSharedGCPCloudCEComputeConfigInput(ctx conte
 			Value:   value,
 		})
 	}
-	enableFusion := new(bool)
-	if !r.Config.EnableFusion.IsUnknown() && !r.Config.EnableFusion.IsNull() {
-		*enableFusion = r.Config.EnableFusion.ValueBool()
-	} else {
-		enableFusion = nil
-	}
 	gpuEnabled := new(bool)
 	if !r.Config.GpuEnabled.IsUnknown() && !r.Config.GpuEnabled.IsNull() {
 		*gpuEnabled = r.Config.GpuEnabled.ValueBool()
@@ -336,12 +328,6 @@ func (r *GCPCloudCEResourceModel) ToSharedGCPCloudCEComputeConfigInput(ctx conte
 	} else {
 		serviceAccountEmail = nil
 	}
-	enableWave := new(bool)
-	if !r.Config.EnableWave.IsUnknown() && !r.Config.EnableWave.IsNull() {
-		*enableWave = r.Config.EnableWave.ValueBool()
-	} else {
-		enableWave = nil
-	}
 	workDir := new(string)
 	if !r.Config.WorkDir.IsUnknown() && !r.Config.WorkDir.IsNull() {
 		*workDir = r.Config.WorkDir.ValueString()
@@ -358,7 +344,6 @@ func (r *GCPCloudCEResourceModel) ToSharedGCPCloudCEComputeConfigInput(ctx conte
 		Arm64Enabled:        arm64Enabled,
 		BootDiskSizeGb:      bootDiskSizeGb,
 		Environment:         environment,
-		EnableFusion:        enableFusion,
 		GpuEnabled:          gpuEnabled,
 		ImageID:             imageID,
 		InstanceType:        instanceType,
@@ -368,7 +353,6 @@ func (r *GCPCloudCEResourceModel) ToSharedGCPCloudCEComputeConfigInput(ctx conte
 		ProjectID:           projectID,
 		Region:              region,
 		ServiceAccountEmail: serviceAccountEmail,
-		EnableWave:          enableWave,
 		WorkDir:             workDir,
 		Zone:                zone,
 	}

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -539,20 +539,6 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 												MarkdownDescription: `EC2 key pair name for SSH access to compute instances.` + "\n" +
 													`Key pair must exist in the specified region.`,
 											},
-											"enable_fusion": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-													`speeding up most operations.` + "\n" +
-													`` + "\n" +
-													`Requires ` + "`" + `enable_wave = true` + "`" + `.`,
-											},
-											"enable_wave": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-													`Nextflow pipelines via the Wave containers service.` + "\n" +
-													`` + "\n" +
-													`Required when ` + "`" + `enable_fusion` + "`" + ` is true.`,
-											},
 											"environment": schema.ListNestedAttribute{
 												Computed: true,
 												NestedObject: schema.NestedAttributeObject{
@@ -881,20 +867,6 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 											"data_collection_rule_id": schema.StringAttribute{
 												Computed:    true,
 												Description: `Azure Monitor data collection rule resource ID associated with the endpoint.`,
-											},
-											"enable_fusion": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-													`speeding up most operations.` + "\n" +
-													`` + "\n" +
-													`Requires ` + "`" + `enable_wave = true` + "`" + `.`,
-											},
-											"enable_wave": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-													`Nextflow pipelines via the Wave containers service.` + "\n" +
-													`` + "\n" +
-													`Required when ` + "`" + `enable_fusion` + "`" + ` is true.`,
 											},
 											"environment": schema.ListNestedAttribute{
 												Computed: true,
@@ -1409,20 +1381,6 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 											"boot_disk_size_gb": schema.Int32Attribute{
 												Computed:    true,
 												Description: `Size of the boot disk in GB for compute instances.`,
-											},
-											"enable_fusion": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,` + "\n" +
-													`speeding up most operations.` + "\n" +
-													`` + "\n" +
-													`Requires ` + "`" + `enable_wave = true` + "`" + `.`,
-											},
-											"enable_wave": schema.BoolAttribute{
-												Computed: true,
-												MarkdownDescription: `Allow access to private container repositories and the provisioning of containers in your` + "\n" +
-													`Nextflow pipelines via the Wave containers service.` + "\n" +
-													`` + "\n" +
-													`Required when ` + "`" + `enable_fusion` + "`" + ` is true.`,
 											},
 											"environment": schema.ListNestedAttribute{
 												Computed: true,

--- a/internal/provider/pipeline_resource_sdk.go
+++ b/internal/provider/pipeline_resource_sdk.go
@@ -148,8 +148,6 @@ func (r *PipelineResourceModel) RefreshFromSharedDescribeLaunchResponse(ctx cont
 					r.Launch.ComputeEnv.Config.AwsCloud.Arm64Enabled = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.Arm64Enabled)
 					r.Launch.ComputeEnv.Config.AwsCloud.EbsBootSize = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.EbsBootSize))
 					r.Launch.ComputeEnv.Config.AwsCloud.Ec2KeyPair = types.StringPointerValue(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.Ec2KeyPair)
-					r.Launch.ComputeEnv.Config.AwsCloud.EnableFusion = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.EnableFusion)
-					r.Launch.ComputeEnv.Config.AwsCloud.EnableWave = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.EnableWave)
 					r.Launch.ComputeEnv.Config.AwsCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem1 := range resp.Launch.ComputeEnv.Config.AWSCloudConfiguration.Environment {
@@ -284,8 +282,6 @@ func (r *PipelineResourceModel) RefreshFromSharedDescribeLaunchResponse(ctx cont
 					r.Launch.ComputeEnv.Config.GoogleCloud = &tfTypes.GoogleCloudConfiguration{}
 					r.Launch.ComputeEnv.Config.GoogleCloud.Arm64Enabled = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.Arm64Enabled)
 					r.Launch.ComputeEnv.Config.GoogleCloud.BootDiskSizeGb = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.BootDiskSizeGb))
-					r.Launch.ComputeEnv.Config.GoogleCloud.EnableFusion = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.EnableFusion)
-					r.Launch.ComputeEnv.Config.GoogleCloud.EnableWave = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.EnableWave)
 					r.Launch.ComputeEnv.Config.GoogleCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem4 := range resp.Launch.ComputeEnv.Config.GoogleCloudConfiguration.Environment {
@@ -388,8 +384,6 @@ func (r *PipelineResourceModel) RefreshFromSharedDescribeLaunchResponse(ctx cont
 					r.Launch.ComputeEnv.Config.AzureCloud = &tfTypes.AzureCloudConfiguration{}
 					r.Launch.ComputeEnv.Config.AzureCloud.DataCollectionEndpoint = types.StringPointerValue(resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.DataCollectionEndpoint)
 					r.Launch.ComputeEnv.Config.AzureCloud.DataCollectionRuleID = types.StringPointerValue(resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.DataCollectionRuleID)
-					r.Launch.ComputeEnv.Config.AzureCloud.EnableFusion = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.EnableFusion)
-					r.Launch.ComputeEnv.Config.AzureCloud.EnableWave = types.BoolPointerValue(resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.EnableWave)
 					r.Launch.ComputeEnv.Config.AzureCloud.Environment = []tfTypes.ConfigEnvVariable{}
 
 					for _, environmentItem6 := range resp.Launch.ComputeEnv.Config.AzureCloudConfiguration.Environment {

--- a/internal/provider/types/aws_cloud_config.go
+++ b/internal/provider/types/aws_cloud_config.go
@@ -12,8 +12,6 @@ type AwsCloudConfig struct {
 	Arm64Enabled              types.Bool          `tfsdk:"arm64_enabled"`
 	EbsBootSize               types.Int32         `tfsdk:"ebs_boot_size"`
 	Ec2KeyPair                types.String        `tfsdk:"ec2_key_pair"`
-	EnableFusion              types.Bool          `tfsdk:"enable_fusion"`
-	EnableWave                types.Bool          `tfsdk:"enable_wave"`
 	Environment               []ConfigEnvVariable `tfsdk:"environment"`
 	GpuEnabled                types.Bool          `tfsdk:"gpu_enabled"`
 	ImageID                   types.String        `tfsdk:"image_id"`

--- a/internal/provider/types/aws_cloud_configuration.go
+++ b/internal/provider/types/aws_cloud_configuration.go
@@ -13,7 +13,6 @@ type AWSCloudConfiguration struct {
 	EbsBootSize               types.Int32         `tfsdk:"ebs_boot_size"`
 	Ec2KeyPair                types.String        `tfsdk:"ec2_key_pair"`
 	Environment               []ConfigEnvVariable `tfsdk:"environment"`
-	EnableFusion              types.Bool          `tfsdk:"enable_fusion"`
 	GpuEnabled                types.Bool          `tfsdk:"gpu_enabled"`
 	ImageID                   types.String        `tfsdk:"image_id"`
 	InstanceProfileArn        types.String        `tfsdk:"instance_profile_arn"`
@@ -27,6 +26,5 @@ type AWSCloudConfiguration struct {
 	IntelligentComputeEnabled types.Bool          `tfsdk:"intelligent_compute_enabled"`
 	SecurityGroups            basetypes.ListValue `tfsdk:"security_groups"`
 	SubnetID                  types.String        `tfsdk:"subnet_id"`
-	EnableWave                types.Bool          `tfsdk:"enable_wave"`
 	WorkDir                   types.String        `tfsdk:"work_dir"`
 }

--- a/internal/provider/types/az_cloud_config.go
+++ b/internal/provider/types/az_cloud_config.go
@@ -9,8 +9,6 @@ import (
 type AzCloudConfig struct {
 	DataCollectionEndpoint  types.String        `tfsdk:"data_collection_endpoint"`
 	DataCollectionRuleID    types.String        `tfsdk:"data_collection_rule_id"`
-	EnableFusion            types.Bool          `tfsdk:"enable_fusion"`
-	EnableWave              types.Bool          `tfsdk:"enable_wave"`
 	Environment             []ConfigEnvVariable `tfsdk:"environment"`
 	InstanceType            types.String        `tfsdk:"instance_type"`
 	LogTableName            types.String        `tfsdk:"log_table_name"`

--- a/internal/provider/types/azure_cloud_configuration.go
+++ b/internal/provider/types/azure_cloud_configuration.go
@@ -10,7 +10,6 @@ type AzureCloudConfiguration struct {
 	DataCollectionEndpoint  types.String        `tfsdk:"data_collection_endpoint"`
 	DataCollectionRuleID    types.String        `tfsdk:"data_collection_rule_id"`
 	Environment             []ConfigEnvVariable `tfsdk:"environment"`
-	EnableFusion            types.Bool          `tfsdk:"enable_fusion"`
 	InstanceType            types.String        `tfsdk:"instance_type"`
 	LogTableName            types.String        `tfsdk:"log_table_name"`
 	LogWorkspaceID          types.String        `tfsdk:"log_workspace_id"`
@@ -23,6 +22,5 @@ type AzureCloudConfiguration struct {
 	Region                  types.String        `tfsdk:"region"`
 	ResourceGroup           types.String        `tfsdk:"resource_group"`
 	SubscriptionID          types.String        `tfsdk:"subscription_id"`
-	EnableWave              types.Bool          `tfsdk:"enable_wave"`
 	WorkDir                 types.String        `tfsdk:"work_dir"`
 }

--- a/internal/provider/types/google_cloud_config.go
+++ b/internal/provider/types/google_cloud_config.go
@@ -9,8 +9,6 @@ import (
 type GoogleCloudConfig struct {
 	Arm64Enabled        types.Bool          `tfsdk:"arm64_enabled"`
 	BootDiskSizeGb      types.Int32         `tfsdk:"boot_disk_size_gb"`
-	EnableFusion        types.Bool          `tfsdk:"enable_fusion"`
-	EnableWave          types.Bool          `tfsdk:"enable_wave"`
 	Environment         []ConfigEnvVariable `tfsdk:"environment"`
 	GpuEnabled          types.Bool          `tfsdk:"gpu_enabled"`
 	ImageID             types.String        `tfsdk:"image_id"`

--- a/internal/provider/types/google_cloud_configuration.go
+++ b/internal/provider/types/google_cloud_configuration.go
@@ -10,7 +10,6 @@ type GoogleCloudConfiguration struct {
 	Arm64Enabled        types.Bool          `tfsdk:"arm64_enabled"`
 	BootDiskSizeGb      types.Int32         `tfsdk:"boot_disk_size_gb"`
 	Environment         []ConfigEnvVariable `tfsdk:"environment"`
-	EnableFusion        types.Bool          `tfsdk:"enable_fusion"`
 	GpuEnabled          types.Bool          `tfsdk:"gpu_enabled"`
 	ImageID             types.String        `tfsdk:"image_id"`
 	InstanceType        types.String        `tfsdk:"instance_type"`
@@ -20,7 +19,6 @@ type GoogleCloudConfiguration struct {
 	ProjectID           types.String        `tfsdk:"project_id"`
 	Region              types.String        `tfsdk:"region"`
 	ServiceAccountEmail types.String        `tfsdk:"service_account_email"`
-	EnableWave          types.Bool          `tfsdk:"enable_wave"`
 	WorkDir             types.String        `tfsdk:"work_dir"`
 	Zone                types.String        `tfsdk:"zone"`
 }

--- a/internal/sdk/models/shared/awscloudconfig.go
+++ b/internal/sdk/models/shared/awscloudconfig.go
@@ -20,14 +20,9 @@ type AwsCloudConfig struct {
 	// EC2 key pair name for SSH access to compute instances.
 	// Key pair must exist in the specified region.
 	//
-	Ec2KeyPair  *string             `json:"ec2KeyPair,omitempty"`
-	Environment []ConfigEnvVariable `json:"environment,omitempty"`
-	// Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,
-	// speeding up most operations.
-	//
-	// Requires `enable_wave = true`.
-	//
-	EnableFusion *bool `json:"fusion2Enabled,omitempty"`
+	Ec2KeyPair     *string             `json:"ec2KeyPair,omitempty"`
+	Environment    []ConfigEnvVariable `json:"environment,omitempty"`
+	Fusion2Enabled *bool               `json:"fusion2Enabled,omitempty"`
 	// Enable GPU support for compute instances.
 	// When enabled, GPU-capable instance types will be selected.
 	//
@@ -79,13 +74,8 @@ type AwsCloudConfig struct {
 	// Subnet ID where compute instances will be launched.
 	// Must be in the same VPC and region as the compute environment.
 	//
-	SubnetID *string `json:"subnetId,omitempty"`
-	// Allow access to private container repositories and the provisioning of containers in your
-	// Nextflow pipelines via the Wave containers service.
-	//
-	// Required when `enable_fusion` is true.
-	//
-	EnableWave *bool `json:"waveEnabled,omitempty"`
+	SubnetID    *string `json:"subnetId,omitempty"`
+	WaveEnabled *bool   `json:"waveEnabled,omitempty"`
 	// S3 working directory for workflow execution. Must be a `s3://` URI in
 	// the same region as the compute environment (e.g. `s3://my-bucket/work`).
 	// Max 100 characters.
@@ -135,11 +125,11 @@ func (a *AwsCloudConfig) GetEnvironment() []ConfigEnvVariable {
 	return a.Environment
 }
 
-func (a *AwsCloudConfig) GetEnableFusion() *bool {
+func (a *AwsCloudConfig) GetFusion2Enabled() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.EnableFusion
+	return a.Fusion2Enabled
 }
 
 func (a *AwsCloudConfig) GetGpuEnabled() *bool {
@@ -233,11 +223,11 @@ func (a *AwsCloudConfig) GetSubnetID() *string {
 	return a.SubnetID
 }
 
-func (a *AwsCloudConfig) GetEnableWave() *bool {
+func (a *AwsCloudConfig) GetWaveEnabled() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.EnableWave
+	return a.WaveEnabled
 }
 
 func (a *AwsCloudConfig) GetWorkDir() *string {

--- a/internal/sdk/models/shared/azcloudconfig.go
+++ b/internal/sdk/models/shared/azcloudconfig.go
@@ -14,13 +14,8 @@ type AzCloudConfig struct {
 	// Array of environment variables for the compute environment.
 	// Each variable can target the head node, compute nodes, or both.
 	//
-	Environment []ConfigEnvVariable `json:"environment,omitempty"`
-	// Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-	// speeding up most operations.
-	//
-	// Requires `enable_wave = true`.
-	//
-	EnableFusion *bool `json:"fusion2Enabled,omitempty"`
+	Environment    []ConfigEnvVariable `json:"environment,omitempty"`
+	Fusion2Enabled *bool               `json:"fusion2Enabled,omitempty"`
 	// Azure VM size for compute instances (e.g., Standard_D4s_v3, Standard_F8s_v2).
 	//
 	InstanceType *string `json:"instanceType,omitempty"`
@@ -62,12 +57,7 @@ type AzCloudConfig struct {
 	// Azure subscription ID where compute resources will be created.
 	//
 	SubscriptionID *string `json:"subscriptionId,omitempty"`
-	// Allow access to private container repositories and the provisioning of containers in your
-	// Nextflow pipelines via the Wave containers service.
-	//
-	// Required when `enable_fusion` is true.
-	//
-	EnableWave *bool `json:"waveEnabled,omitempty"`
+	WaveEnabled    *bool   `json:"waveEnabled,omitempty"`
 	// Azure Blob Storage container path for Nextflow work directory.
 	// Format: az://container-name/path
 	//
@@ -102,11 +92,11 @@ func (a *AzCloudConfig) GetEnvironment() []ConfigEnvVariable {
 	return a.Environment
 }
 
-func (a *AzCloudConfig) GetEnableFusion() *bool {
+func (a *AzCloudConfig) GetFusion2Enabled() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.EnableFusion
+	return a.Fusion2Enabled
 }
 
 func (a *AzCloudConfig) GetInstanceType() *string {
@@ -193,11 +183,11 @@ func (a *AzCloudConfig) GetSubscriptionID() *string {
 	return a.SubscriptionID
 }
 
-func (a *AzCloudConfig) GetEnableWave() *bool {
+func (a *AzCloudConfig) GetWaveEnabled() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.EnableWave
+	return a.WaveEnabled
 }
 
 func (a *AzCloudConfig) GetWorkDir() *string {

--- a/internal/sdk/models/shared/computeconfig.go
+++ b/internal/sdk/models/shared/computeconfig.go
@@ -1682,13 +1682,8 @@ type AzureCloudConfiguration struct {
 	// Read-only property identifying the compute platform type
 	Discriminator *string `json:"discriminator,omitempty"`
 	// Array of environment variables for the compute environment
-	Environment []ConfigEnvVariable `json:"environment,omitempty"`
-	// Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-	// speeding up most operations.
-	//
-	// Requires `enable_wave = true`.
-	//
-	EnableFusion *bool `json:"fusion2Enabled,omitempty"`
+	Environment    []ConfigEnvVariable `json:"environment,omitempty"`
+	Fusion2Enabled *bool               `json:"fusion2Enabled,omitempty"`
 	// Azure VM size for compute instances (e.g., Standard_D4s_v3, Standard_F8s_v2).
 	//
 	InstanceType *string `json:"instanceType,omitempty"`
@@ -1728,12 +1723,7 @@ type AzureCloudConfiguration struct {
 	// Azure subscription ID where compute resources will be created.
 	//
 	SubscriptionID *string `json:"subscriptionId,omitempty"`
-	// Allow access to private container repositories and the provisioning of containers in your
-	// Nextflow pipelines via the Wave containers service.
-	//
-	// Required when `enable_fusion` is true.
-	//
-	EnableWave *bool `json:"waveEnabled,omitempty"`
+	WaveEnabled    *bool   `json:"waveEnabled,omitempty"`
 	// Working directory path for workflow execution
 	WorkDir *string `json:"workDir,omitempty"`
 }
@@ -1777,11 +1767,11 @@ func (a *AzureCloudConfiguration) GetEnvironment() []ConfigEnvVariable {
 	return a.Environment
 }
 
-func (a *AzureCloudConfiguration) GetEnableFusion() *bool {
+func (a *AzureCloudConfiguration) GetFusion2Enabled() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.EnableFusion
+	return a.Fusion2Enabled
 }
 
 func (a *AzureCloudConfiguration) GetInstanceType() *string {
@@ -1868,11 +1858,11 @@ func (a *AzureCloudConfiguration) GetSubscriptionID() *string {
 	return a.SubscriptionID
 }
 
-func (a *AzureCloudConfiguration) GetEnableWave() *bool {
+func (a *AzureCloudConfiguration) GetWaveEnabled() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.EnableWave
+	return a.WaveEnabled
 }
 
 func (a *AzureCloudConfiguration) GetWorkDir() *string {
@@ -2189,13 +2179,8 @@ type GoogleCloudConfiguration struct {
 	// Read-only property identifying the compute platform type
 	Discriminator *string `json:"discriminator,omitempty"`
 	// Array of environment variables for the compute environment
-	Environment []ConfigEnvVariable `json:"environment,omitempty"`
-	// Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-	// speeding up most operations.
-	//
-	// Requires `enable_wave = true`.
-	//
-	EnableFusion *bool `json:"fusion2Enabled,omitempty"`
+	Environment    []ConfigEnvVariable `json:"environment,omitempty"`
+	Fusion2Enabled *bool               `json:"fusion2Enabled,omitempty"`
 	// Enable GPU support for compute instances.
 	// When enabled, GPU-capable machine types will be selected.
 	//
@@ -2224,12 +2209,7 @@ type GoogleCloudConfiguration struct {
 	// If not specified, the default compute service account is used.
 	//
 	ServiceAccountEmail *string `json:"serviceAccountEmail,omitempty"`
-	// Allow access to private container repositories and the provisioning of containers in your
-	// Nextflow pipelines via the Wave containers service.
-	//
-	// Required when `enable_fusion` is true.
-	//
-	EnableWave *bool `json:"waveEnabled,omitempty"`
+	WaveEnabled         *bool   `json:"waveEnabled,omitempty"`
 	// Working directory path for workflow execution
 	WorkDir *string `json:"workDir,omitempty"`
 	// Google Cloud zone within the configured region (e.g., us-central1-a).
@@ -2277,11 +2257,11 @@ func (g *GoogleCloudConfiguration) GetEnvironment() []ConfigEnvVariable {
 	return g.Environment
 }
 
-func (g *GoogleCloudConfiguration) GetEnableFusion() *bool {
+func (g *GoogleCloudConfiguration) GetFusion2Enabled() *bool {
 	if g == nil {
 		return nil
 	}
-	return g.EnableFusion
+	return g.Fusion2Enabled
 }
 
 func (g *GoogleCloudConfiguration) GetGpuEnabled() *bool {
@@ -2347,11 +2327,11 @@ func (g *GoogleCloudConfiguration) GetServiceAccountEmail() *string {
 	return g.ServiceAccountEmail
 }
 
-func (g *GoogleCloudConfiguration) GetEnableWave() *bool {
+func (g *GoogleCloudConfiguration) GetWaveEnabled() *bool {
 	if g == nil {
 		return nil
 	}
-	return g.EnableWave
+	return g.WaveEnabled
 }
 
 func (g *GoogleCloudConfiguration) GetWorkDir() *string {
@@ -2833,13 +2813,8 @@ type AWSCloudConfiguration struct {
 	//
 	Ec2KeyPair *string `json:"ec2KeyPair,omitempty"`
 	// Array of environment variables for the compute environment
-	Environment []ConfigEnvVariable `json:"environment,omitempty"`
-	// Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,
-	// speeding up most operations.
-	//
-	// Requires `enable_wave = true`.
-	//
-	EnableFusion *bool `json:"fusion2Enabled,omitempty"`
+	Environment    []ConfigEnvVariable `json:"environment,omitempty"`
+	Fusion2Enabled *bool               `json:"fusion2Enabled,omitempty"`
 	// Enable GPU support for compute instances.
 	// When enabled, GPU-capable instance types will be selected.
 	//
@@ -2892,13 +2867,8 @@ type AWSCloudConfiguration struct {
 	// Subnet ID where compute instances will be launched.
 	// Must be in the same VPC and region as the compute environment.
 	//
-	SubnetID *string `json:"subnetId,omitempty"`
-	// Allow access to private container repositories and the provisioning of containers in your
-	// Nextflow pipelines via the Wave containers service.
-	//
-	// Required when `enable_fusion` is true.
-	//
-	EnableWave *bool `json:"waveEnabled,omitempty"`
+	SubnetID    *string `json:"subnetId,omitempty"`
+	WaveEnabled *bool   `json:"waveEnabled,omitempty"`
 	// Working directory path for workflow execution
 	WorkDir *string `json:"workDir,omitempty"`
 }
@@ -2956,11 +2926,11 @@ func (a *AWSCloudConfiguration) GetEnvironment() []ConfigEnvVariable {
 	return a.Environment
 }
 
-func (a *AWSCloudConfiguration) GetEnableFusion() *bool {
+func (a *AWSCloudConfiguration) GetFusion2Enabled() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.EnableFusion
+	return a.Fusion2Enabled
 }
 
 func (a *AWSCloudConfiguration) GetGpuEnabled() *bool {
@@ -3054,11 +3024,11 @@ func (a *AWSCloudConfiguration) GetSubnetID() *string {
 	return a.SubnetID
 }
 
-func (a *AWSCloudConfiguration) GetEnableWave() *bool {
+func (a *AWSCloudConfiguration) GetWaveEnabled() *bool {
 	if a == nil {
 		return nil
 	}
-	return a.EnableWave
+	return a.WaveEnabled
 }
 
 func (a *AWSCloudConfiguration) GetWorkDir() *string {

--- a/internal/sdk/models/shared/googlecloudconfig.go
+++ b/internal/sdk/models/shared/googlecloudconfig.go
@@ -15,13 +15,8 @@ type GoogleCloudConfig struct {
 	// Array of environment variables for the compute environment.
 	// Each variable can target the head node, compute nodes, or both.
 	//
-	Environment []ConfigEnvVariable `json:"environment,omitempty"`
-	// Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-	// speeding up most operations.
-	//
-	// Requires `enable_wave = true`.
-	//
-	EnableFusion *bool `json:"fusion2Enabled,omitempty"`
+	Environment    []ConfigEnvVariable `json:"environment,omitempty"`
+	Fusion2Enabled *bool               `json:"fusion2Enabled,omitempty"`
 	// Enable GPU support for compute instances.
 	// When enabled, GPU-capable machine types will be selected.
 	//
@@ -52,12 +47,7 @@ type GoogleCloudConfig struct {
 	// If not specified, the default compute service account is used.
 	//
 	ServiceAccountEmail *string `json:"serviceAccountEmail,omitempty"`
-	// Allow access to private container repositories and the provisioning of containers in your
-	// Nextflow pipelines via the Wave containers service.
-	//
-	// Required when `enable_fusion` is true.
-	//
-	EnableWave *bool `json:"waveEnabled,omitempty"`
+	WaveEnabled         *bool   `json:"waveEnabled,omitempty"`
 	// Google Cloud Storage bucket path for Nextflow work directory where intermediate
 	// files will be stored.
 	// Format: gs://bucket-name/path
@@ -97,11 +87,11 @@ func (g *GoogleCloudConfig) GetEnvironment() []ConfigEnvVariable {
 	return g.Environment
 }
 
-func (g *GoogleCloudConfig) GetEnableFusion() *bool {
+func (g *GoogleCloudConfig) GetFusion2Enabled() *bool {
 	if g == nil {
 		return nil
 	}
-	return g.EnableFusion
+	return g.Fusion2Enabled
 }
 
 func (g *GoogleCloudConfig) GetGpuEnabled() *bool {
@@ -167,11 +157,11 @@ func (g *GoogleCloudConfig) GetServiceAccountEmail() *string {
 	return g.ServiceAccountEmail
 }
 
-func (g *GoogleCloudConfig) GetEnableWave() *bool {
+func (g *GoogleCloudConfig) GetWaveEnabled() *bool {
 	if g == nil {
 		return nil
 	}
-	return g.EnableWave
+	return g.WaveEnabled
 }
 
 func (g *GoogleCloudConfig) GetWorkDir() *string {

--- a/overlays/compute-env.yaml
+++ b/overlays/compute-env.yaml
@@ -392,23 +392,7 @@ actions:
         Nextflow pipelines via the Wave containers service.
 
         Required when `enable_fusion` is true.
-  - target: $.components.schemas.AwsCloudConfig.properties.waveEnabled
-    update:
-      title: "Wave Enabled"
-      description: |
-        Allow access to private container repositories and the provisioning of containers in your
-        Nextflow pipelines via the Wave containers service.
-
-        Required when `enable_fusion` is true.
   - target: $.components.schemas.AzBatchConfig.properties.waveEnabled
-    update:
-      title: "Wave Enabled"
-      description: |
-        Allow access to private container repositories and the provisioning of containers in your
-        Nextflow pipelines via the Wave containers service.
-
-        Required when `enable_fusion` is true.
-  - target: $.components.schemas.AzCloudConfig.properties.waveEnabled
     update:
       title: "Wave Enabled"
       description: |
@@ -433,14 +417,6 @@ actions:
 
         Required when `enable_fusion` is true.
   - target: $.components.schemas.GoogleBatchConfig.properties.waveEnabled
-    update:
-      title: "Wave Enabled"
-      description: |
-        Allow access to private container repositories and the provisioning of containers in your
-        Nextflow pipelines via the Wave containers service.
-
-        Required when `enable_fusion` is true.
-  - target: $.components.schemas.GoogleCloudConfig.properties.waveEnabled
     update:
       title: "Wave Enabled"
       description: |
@@ -458,13 +434,7 @@ actions:
   - target: $.components.schemas.AwsBatchConfig.properties.waveEnabled
     update:
       x-speakeasy-name-override: enable_wave
-  - target: $.components.schemas.AwsCloudConfig.properties.waveEnabled
-    update:
-      x-speakeasy-name-override: enable_wave
   - target: $.components.schemas.AzBatchConfig.properties.waveEnabled
-    update:
-      x-speakeasy-name-override: enable_wave
-  - target: $.components.schemas.AzCloudConfig.properties.waveEnabled
     update:
       x-speakeasy-name-override: enable_wave
   - target: $.components.schemas.EksComputeConfig.properties.waveEnabled
@@ -474,9 +444,6 @@ actions:
     update:
       x-speakeasy-name-override: enable_wave
   - target: $.components.schemas.GoogleBatchConfig.properties.waveEnabled
-    update:
-      x-speakeasy-name-override: enable_wave
-  - target: $.components.schemas.GoogleCloudConfig.properties.waveEnabled
     update:
       x-speakeasy-name-override: enable_wave
   # NOTE: SeqeraComputeConfig.waveEnabled name override moved to compute-env-seqeracompute.yaml
@@ -492,25 +459,7 @@ actions:
         speeding up most operations.
 
         Requires `enable_wave = true`.
-  - target: $.components.schemas.AwsCloudConfig.properties.fusion2Enabled
-    update:
-      x-speakeasy-name-override: enable_fusion
-      x-speakeasy-plan-validators: FusionEnabledValidator
-      description: |
-        Allow access to your AWS S3-hosted data via the Fusion v2 virtual distributed file system,
-        speeding up most operations.
-
-        Requires `enable_wave = true`.
   - target: $.components.schemas.AzBatchConfig.properties.fusion2Enabled
-    update:
-      x-speakeasy-name-override: enable_fusion
-      x-speakeasy-plan-validators: FusionEnabledValidator
-      description: |
-        Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-        speeding up most operations.
-
-        Requires `enable_wave = true`.
-  - target: $.components.schemas.AzCloudConfig.properties.fusion2Enabled
     update:
       x-speakeasy-name-override: enable_fusion
       x-speakeasy-plan-validators: FusionEnabledValidator
@@ -546,15 +495,6 @@ actions:
         speeding up most operations.
 
         Requires `enable_wave = true`.
-  - target: $.components.schemas.GoogleCloudConfig.properties.fusion2Enabled
-    update:
-      x-speakeasy-name-override: enable_fusion
-      x-speakeasy-plan-validators: FusionEnabledValidator
-      description: |
-        Allow access to your cloud-hosted data via the Fusion v2 virtual distributed file system,
-        speeding up most operations.
-
-        Requires `enable_wave = true`.
 
   # Rename schedEnabled/schedConfig -> intelligent_compute_* on LocalComputeConfig
   - target: $.components.schemas.LocalComputeConfig.properties.schedEnabled
@@ -563,6 +503,29 @@ actions:
   - target: $.components.schemas.LocalComputeConfig.properties.schedConfig
     update:
       x-speakeasy-name-override: intelligent_compute_config
+
+  # ============================================================================
+  # FIELD IGNORE - Cloud compute environments require fusion2 and wave to be
+  # enabled, we can ignore these fields to reduce the configuration surface.
+  # ============================================================================
+  - target: $.components.schemas.AwsCloudConfig.properties.fusion2Enabled
+    update:
+      x-speakeasy-terraform-ignore: true
+  - target: $.components.schemas.AwsCloudConfig.properties.waveEnabled
+    update:
+      x-speakeasy-terraform-ignore: true
+  - target: $.components.schemas.AzCloudConfig.properties.waveEnabled
+    update:
+      x-speakeasy-terraform-ignore: true
+  - target: $.components.schemas.AzCloudConfig.properties.fusion2Enabled
+    update:
+      x-speakeasy-terraform-ignore: true
+  - target: $.components.schemas.GoogleCloudConfig.properties.fusion2Enabled
+    update:
+      x-speakeasy-terraform-ignore: true
+  - target: $.components.schemas.GoogleCloudConfig.properties.waveEnabled
+    update:
+      x-speakeasy-terraform-ignore: true
 
   # ============================================================================
   # AWS CLOUD CONFIG FIELD DESCRIPTIONS


### PR DESCRIPTION
Cloud CEs have a hard requirement for fusion and wave to be enabled, so they are not configurable options for the end user. We decided to ignore rather than have them as read-only to reduce the surface of options the user has to deal with, the backend api handles correctly those missing paramters defaulting to their enablement.