### PR TITLE
release(v0.40.0-RC7): fix seqera_compute soft delete + docs

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -85,5 +85,8 @@ examples/resources/seqera_workspace_participant/import.sh
 # Custom pipeline_schema examples
 examples/resources/seqera_pipeline_schema/resource*.tf
 
+# Custom workflows examples (contrasts with seqera_pipeline)
+examples/resources/seqera_workflows/resource*.tf
+
 # Custom doc templates for subcategory grouping
 templates/

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 944539d5eb90fb3604e747617c347cb0
+  docChecksum: 51dcbbcdfa6a75acadab3f223452494f
   docVersion: 1.153.0
   speakeasyVersion: 1.763.1
   generationVersion: 2.884.4
-  releaseVersion: 0.40.0-RC6
-  configChecksum: 9465a3da4cfd5feaff51e732a2942943
+  releaseVersion: 0.40.0-RC7
+  configChecksum: d370b487b66814edd0b2eeb4bbe4195d
 persistentEdits:
   generation_id: fa9416b7-6c9d-4aa5-b5cb-f5815d4b62d8
   pristine_commit_hash: 8b727d9d7ead153a998336c81b01bdba5fdfbcbb
@@ -40,7 +40,7 @@ trackedFiles:
     pristine_git_object: 8e707bb129af1da185ba30b4c289b0160819c437
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:d47cefdbf3739214bd40b10abdfdaa48bb815de5
+    last_write_checksum: sha1:0785a3e3d0838ed0508b67c41333bcadaa7a0461
     pristine_git_object: 7b241353e887cd10c08b0653d13c2227ce91f456
   examples/resources/seqera_action/import-by-string-id.tf:
     id: 7b9e1b28088a
@@ -288,10 +288,6 @@ trackedFiles:
     id: d72df2a453b1
     last_write_checksum: sha1:1dd1888af4d5c75b32ea48158075371806c131dd
     pristine_git_object: ebe5c685294e2baca949dfdf846337e51207d59d
-  examples/resources/seqera_workflows/resource.tf:
-    id: c2c588ebe140
-    last_write_checksum: sha1:e63046630016c1fb47e2e7c5e82ebe3d99d9712a
-    pristine_git_object: b1516351f7d8275a0a4bca3db3bd1a49dd05c3e7
   examples/resources/seqera_workspace/import-by-string-id.tf:
     id: c349aba83f4f
     last_write_checksum: sha1:38ef913efe9add7d8d7219f9eb050d050e5bcef4
@@ -426,22 +422,22 @@ trackedFiles:
     pristine_git_object: 0ea64fbeb1fd7709d7241a8e06d34bfe9d0323d3
   internal/provider/action_resource.go:
     id: f7c19bf35b58
-    last_write_checksum: sha1:2a0aa203381a7a1d0ac1fb3d0625e30f545b49ff
+    last_write_checksum: sha1:12dd90aaec7743631a371310185a8942cb56a3c3
     pristine_git_object: fc35041e2f1cf6db01d04e9e9e861df96d042782
   internal/provider/action_resource_sdk.go:
     id: 28576317893d
-    last_write_checksum: sha1:87a99c8577e72bffc8250681e9c8ed746c187df3
+    last_write_checksum: sha1:fafb9bf73fdc5da9c6dfb519233d5eee16c869fc
     pristine_git_object: b987eb32b2d86ebe52fb9875e9e4b6eb9f30af6e
   internal/provider/awsbatchce_resource.go:
     id: aeeab49ad69b
-    last_write_checksum: sha1:5ad5abfcac0271e0183291c3b3248770c890c002
+    last_write_checksum: sha1:85257e3303b081ec2485fd2d8aa1a764cd3c214b
     pristine_git_object: 136a1cfb3f23c1c396175224b78c790e8d4b9808
   internal/provider/awsbatchce_resource_sdk.go:
     id: acddb134f02d
     last_write_checksum: sha1:dd22a3ae2798e141de8f3e1276835425b926c9b7
     pristine_git_object: 91db6c7b9d563b0b0fa5e57c712ed1952c1d54d2
   internal/provider/awscloudce_resource.go:
-    last_write_checksum: sha1:3acd5333cca7a6ffa393ee2be87d0e6dd514196c
+    last_write_checksum: sha1:ab9e16853cd3011662e56a305d0e0a8919ce5b1f
   internal/provider/awscloudce_resource_sdk.go:
     last_write_checksum: sha1:4f5e42dd40c14f3e02755107b26c101d2217230c
   internal/provider/awscomputeenv_resource.go:
@@ -461,11 +457,11 @@ trackedFiles:
     last_write_checksum: sha1:7af2249a39b89d7643f4442b37c0cea80922eade
     pristine_git_object: fb79abddd43fc8a362ddaff379637c1def78665a
   internal/provider/azurebatchce_resource.go:
-    last_write_checksum: sha1:dfa7e30d707a35e30f7ee63fe29150f4208527d2
+    last_write_checksum: sha1:e452e863bd534d4d8132c78e084e109cf0e50af8
   internal/provider/azurebatchce_resource_sdk.go:
     last_write_checksum: sha1:23105b512e07f34339c8e74e54a3f0d3f73fd7af
   internal/provider/azurecloudce_resource.go:
-    last_write_checksum: sha1:b255065b9b3d256edb26151d6900f87b61170d1a
+    last_write_checksum: sha1:73f3875c6e5be74a32d273e590cd53455ac2f5cd
   internal/provider/azurecloudce_resource_sdk.go:
     last_write_checksum: sha1:86d28c885f46283e51159c3b77a99da6cc79dfd6
   internal/provider/azurecloudcredential_resource.go:
@@ -502,7 +498,7 @@ trackedFiles:
     pristine_git_object: 0c1b43d5db49b023cf3c7408c198a4d66c795d8a
   internal/provider/computeenv_resource.go:
     id: f4162f219efd
-    last_write_checksum: sha1:ee20c7266d94a929b1b76e9f2c9e9f1a9f7d020c
+    last_write_checksum: sha1:37ecc739af78a3e3550964c8850f28ead06b1f6a
     pristine_git_object: d5550a0a3bc980d281c55531d71458e7e4968b48
   internal/provider/computeenv_resource_sdk.go:
     id: 1e29eea44332
@@ -561,11 +557,11 @@ trackedFiles:
     last_write_checksum: sha1:2518480b1bf5983bf0d0fec9a47e654d138db587
     pristine_git_object: d3d10cadef9504a6a38441129ada6ccaf494496e
   internal/provider/gcpbatchce_resource.go:
-    last_write_checksum: sha1:fd172b6536175ed1545153bdbc54f0f23711f6ac
+    last_write_checksum: sha1:db712970cb96eb0a668502065893bd427b3b2b8e
   internal/provider/gcpbatchce_resource_sdk.go:
     last_write_checksum: sha1:51e775539dce2e1ce359466ed81b14de76f2892f
   internal/provider/gcpcloudce_resource.go:
-    last_write_checksum: sha1:0fbdab27c664c8bf2755ad9b83f0f20693720fed
+    last_write_checksum: sha1:8bfd30f1d8a430efd90ada3ea14af53646fb36e1
   internal/provider/gcpcloudce_resource_sdk.go:
     last_write_checksum: sha1:5b1d35a7ef5389f58dbe11030bbd09508c444e6d
   internal/provider/giteacredential_resource.go:
@@ -618,7 +614,7 @@ trackedFiles:
     pristine_git_object: 287907880a7125e9ffa8b77e8bbaa57d776887c4
   internal/provider/managedcomputece_resource.go:
     id: 7e0eecddbc1e
-    last_write_checksum: sha1:4102214810a4bec60c21dc304d36da106219aaaa
+    last_write_checksum: sha1:977b42c1f24183393d620a83c7eea5fd4fba32a3
     pristine_git_object: adccfb0da743b49f39ee880f81d9b6a12b4a2e27
   internal/provider/managedcomputece_resource_sdk.go:
     id: 834a6a05996d
@@ -633,10 +629,10 @@ trackedFiles:
     last_write_checksum: sha1:62e7d80e48a82f86cdf811dca8a8c84aa1d41f82
     pristine_git_object: fe81d09c0d5656f2f24a007997800ddfa455d8b7
   internal/provider/pipeline_resource.go:
-    last_write_checksum: sha1:4f91c765b347af607ba60ceef847ce16357ecda0
+    last_write_checksum: sha1:e0cc057b2d57e4feb3705d7bfe6bb89bbda46cba
   internal/provider/pipeline_resource_sdk.go:
     id: c3bca9acd758
-    last_write_checksum: sha1:b3e2cb4961d852f08af3d4bb2290e4addfa7a8b8
+    last_write_checksum: sha1:2e27fe60f7e2059a3d5841149d4010626af3742d
     pristine_git_object: eb186d4cf2287bf1eec7eb07d9b9c7e0386b7b26
   internal/provider/pipelinesecret_resource.go:
     id: 5319f8284106
@@ -770,6 +766,8 @@ trackedFiles:
     id: c403b8e4a1d7
     last_write_checksum: sha1:6f4934c3be48ebd95c2a3394bf20d66416bbf201
     pristine_git_object: 34466719915d7901b6891482d43ebdf8a82252b5
+  internal/provider/types/action_launch_request.go:
+    last_write_checksum: sha1:b7cc63d8b2a9d50ca2e05896b2b94fa6b19eb1bc
   internal/provider/types/action_tower_action_config.go:
     id: 0636d437cb70
     last_write_checksum: sha1:88f1aa72102b724b6169fdafab127e8f23d62790
@@ -850,10 +848,10 @@ trackedFiles:
     last_write_checksum: sha1:66a7936e0f73a5446275df3e2b07fc1fa286edb4
   internal/provider/types/compute_env_compute_config.go:
     id: 6553ec9a03cb
-    last_write_checksum: sha1:91886b1e1b2b5f6f983f1d93dca7442cabc4aea1
+    last_write_checksum: sha1:b0930c86e9284d2b6b2a5aace944103e86ace4ec
     pristine_git_object: 4e2b91d1eb0b29699d4a1d4e6603011abd8a7418
   internal/provider/types/compute_env_compute_config1.go:
-    last_write_checksum: sha1:f270ed9a97be0c70f5c04fc5ce185f994e7c14fb
+    last_write_checksum: sha1:e7da0bbd53931459d7ea789e3dd9b5b4278726b5
   internal/provider/types/compute_env_response_dto_resources.go:
     id: 3bca39bd37e3
     last_write_checksum: sha1:7a1754b0c9d14a5b1c9bd9668b219a56176ecfef
@@ -1006,7 +1004,7 @@ trackedFiles:
     last_write_checksum: sha1:8c29831f2b0773a5637372ca12724590a7822cba
   internal/provider/types/workflow_launch_request.go:
     id: af36165a8643
-    last_write_checksum: sha1:2fe3451f25482f9e6450857447438ff1f4329e8a
+    last_write_checksum: sha1:da6a2369d040d118d0f6a679374c1c78b66f5fb7
     pristine_git_object: 11b31ac54b41f1ff6655e5775689da9baec929f7
   internal/provider/types/workflow_max_db_dto.go:
     last_write_checksum: sha1:8df582ee6d45569a8cbae0de0bb43d90b6c1ff59
@@ -1016,11 +1014,11 @@ trackedFiles:
     pristine_git_object: 9cc78dd1f7684941df14144df744dad2b23885f9
   internal/provider/workflows_resource.go:
     id: efcad015245a
-    last_write_checksum: sha1:8ef4ed6ba904af8f18acba7ef5e817404d74e1b4
+    last_write_checksum: sha1:335b12b5b9ec8277986b15fa4c56d0c69f18843d
     pristine_git_object: 2ec8cdfba570a37c74c14055a3d9ffa12fe8881c
   internal/provider/workflows_resource_sdk.go:
     id: ee2d992725aa
-    last_write_checksum: sha1:48562f6b108cc43f42138db79cbefa8b2190b9c3
+    last_write_checksum: sha1:0ae2d06bab1aedbad8e9fd41e6078eb7efc9599e
     pristine_git_object: 32dd5a54a21939c3cfa3c2ada55b841cb54032f9
   internal/provider/workspace_resource.go:
     id: 4255ab3c913f
@@ -2314,6 +2312,8 @@ trackedFiles:
     id: cd30fa613358
     last_write_checksum: sha1:ad02e4ee4991f38caab91983a4832a9eb47be28e
     pristine_git_object: 730a625fa6922c93c90574273666fec9cdc3b496
+  internal/sdk/models/shared/actionlaunchrequest.go:
+    last_write_checksum: sha1:26d364b7453683e375bf24864057b6167e4a425c
   internal/sdk/models/shared/actionqueryattribute.go:
     id: fc49f81f9928
     last_write_checksum: sha1:4b9dd187de1586826868830da4ff5ae13fbbcef7
@@ -2512,7 +2512,7 @@ trackedFiles:
     pristine_git_object: e8d0f3a5a1ba367ab5d3de41c39c6fe2709b63bb
   internal/sdk/models/shared/createactionrequest.go:
     id: 3535c016c767
-    last_write_checksum: sha1:5900754b412e34dc7b2198aa9c4d99a7b2777d4a
+    last_write_checksum: sha1:6f7a45af9d9671abbb1aa59277a0de252d181de6
     pristine_git_object: e31748303dcf8afdd83f767b842dea31f7066eab
   internal/sdk/models/shared/createactionresponse.go:
     id: 3ac726a6a7cf
@@ -3720,7 +3720,7 @@ trackedFiles:
     pristine_git_object: df0e25bf5dcb57896c10e2e781522b8b5fef05c7
   internal/sdk/models/shared/updateactionrequest.go:
     id: 9f97f091423d
-    last_write_checksum: sha1:f5f52f0a0d1567dcbcafc5d7aa9040370564a365
+    last_write_checksum: sha1:86010a054529ceb20b2216d88cdd4e0701aaca00
     pristine_git_object: 44d1c2364849e064e9cdc3652ba65ee6c1af0f83
   internal/sdk/models/shared/updateawscredentialsrequest.go:
     id: da5abce18ae5
@@ -3908,7 +3908,7 @@ trackedFiles:
     pristine_git_object: 3bc4009b3e5d627558d496fdfa955c0de921bde3
   internal/sdk/models/shared/workflowlaunchrequest.go:
     id: 2b0df021cbad
-    last_write_checksum: sha1:1b0e23437884986811d89c2415ccafea6fc1ea1e
+    last_write_checksum: sha1:e1b8f6cefabaf32216c2207d9813ecac742d389d
     pristine_git_object: 610d44495458858e298def213b53372951961f8e
   internal/sdk/models/shared/workflowlaunchresponse.go:
     id: 58befbe96295
@@ -3988,7 +3988,7 @@ trackedFiles:
     last_write_checksum: sha1:4254ac7cabfdf1410c8e69888cc51a81318bbfb4
   internal/sdk/seqera.go:
     id: b1c23bc5193c
-    last_write_checksum: sha1:07491cfa5040075892703718e1742ff1fe401b76
+    last_write_checksum: sha1:98410acfc0828ab1f4064ca2eaee271235efe9fa
     pristine_git_object: 89364ed6208c4c999b317d23d7d954d63ac46bc5
   internal/sdk/serviceinfo.go:
     id: 085db9a15b34

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 0.40.0-RC6
+  version: 0.40.0-RC7
   additionalActions: []
   additionalDataSources:
     - datasource: custom_role_data.NewDataSource

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -15651,6 +15651,8 @@ components:
           type: boolean
           nullable: true
           description: Whether compute environment is deleted (null means not deleted)
+          x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         description:
           type: string
           nullable: true
@@ -15745,6 +15747,7 @@ components:
           type: boolean
           readOnly: true
           x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         description:
           type: string
           maxLength: 2000
@@ -15941,7 +15944,7 @@ components:
         cron:
           $ref: '#/components/schemas/CronActionRequest'
         launch:
-          $ref: '#/components/schemas/WorkflowLaunchRequest'
+          $ref: '#/components/schemas/ActionLaunchRequest'
         name:
           type: string
         source:
@@ -17486,11 +17489,17 @@ components:
           nullable: true
       x-speakeasy-entity: Workflows
       x-speakeasy-entity-description: |
-        Manage workflow executions and pipeline runs.
+        Launch and track an individual workflow run on the Seqera Platform
+        — equivalent to a Run on the Runs page.
 
-        Workflows represent individual executions of Nextflow pipelines,
-        containing execution status, parameters, results, and monitoring
-        information for computational workflows.
+        Each `seqera_workflows` resource maps to one execution of a
+        Nextflow pipeline against a specific compute environment. Use it
+        when Terraform itself should trigger runs (one-off validations,
+        CI fan-outs, post-CE-change smoke tests).
+
+        Reach for `seqera_pipeline` instead when you want a persistent,
+        re-launchable definition on the Launchpad rather than a single
+        run.
     DescribeWorkspaceResponse:
       type: object
       properties:
@@ -20161,11 +20170,15 @@ components:
           x-speakeasy-param-suppress-computed-diff: true
       x-speakeasy-entity: Pipeline
       x-speakeasy-entity-description: |
-        Manage Nextflow pipeline definitions and configurations.
+        Manage saved pipeline definitions on the Seqera Platform Launchpad.
 
-        Pipelines define reusable workflow templates with parameters,
-        compute environment settings, and execution configurations
-        for scalable bioinformatics and data processing workflows.
+        A `seqera_pipeline` is a reusable launch template — repository,
+        revision, default parameters, and a default compute environment —
+        that users can launch on demand from the UI or API.
+
+        Reach for `seqera_workflows` instead when Terraform itself should
+        trigger an individual workflow run (for example, a validation
+        launch after a compute environment change).
       description: |
         Represents a pipeline configuration in the Seqera Platform.
         Contains pipeline metadata, configuration settings, and execution parameters
@@ -21737,7 +21750,7 @@ components:
         cron:
           $ref: '#/components/schemas/CronActionRequest'
         launch:
-          $ref: '#/components/schemas/WorkflowLaunchRequest'
+          $ref: '#/components/schemas/ActionLaunchRequest'
         name:
           type: string
     UpdateComputeEnvRequest:
@@ -22585,12 +22598,9 @@ components:
           example: 4096
         id:
           type: string
-          description: |
-            Launch identifier. Server-generated on workflow launch and pipeline
-            create — leave unset. Echoed back by the provider on
-            `seqera_action` updates so the backend can confirm the launch
-            identity hasn't changed.
+          description: Server-generated launch identifier.
           x-speakeasy-param-readonly: true
+          x-speakeasy-terraform-ignore: true
         labelIds:
           type: array
           items:
@@ -23093,6 +23103,16 @@ components:
       x-enum-varnames:
         - individual
         - team
+    ActionLaunchRequest:
+      type: object
+      description: Launch payload for `seqera_action` Create / Update endpoints.
+      allOf:
+        - $ref: '#/components/schemas/WorkflowLaunchRequest'
+      properties:
+        id:
+          type: string
+          description: Server-generated launch identifier; echoed back on Update.
+          x-speakeasy-param-readonly: true
     # AWS-specific compute environment schema
     AWSComputeEnv_ComputeConfig:
       x-speakeasy-entity: AWSComputeEnv
@@ -23281,6 +23301,7 @@ components:
           type: boolean
           description: Flag indicating if the compute environment has been deleted
           x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         config:
           description: AWS-specific compute environment configuration
           $ref: '#/components/schemas/AwsBatchConfig'
@@ -23420,6 +23441,7 @@ components:
           type: boolean
           description: Flag indicating if the compute environment has been deleted
           x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         config:
           description: AWS Cloud compute environment configuration
           $ref: '#/components/schemas/AwsCloudConfig'
@@ -23533,6 +23555,7 @@ components:
           type: boolean
           description: Flag indicating if the compute environment has been deleted
           x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         config:
           description: Azure Batch compute environment configuration
           $ref: '#/components/schemas/AzBatchConfig'
@@ -23646,6 +23669,7 @@ components:
           type: boolean
           description: Flag indicating if the compute environment has been deleted
           x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         config:
           description: Azure Cloud compute environment configuration
           $ref: '#/components/schemas/AzCloudConfig'
@@ -23758,6 +23782,7 @@ components:
           type: boolean
           description: Flag indicating if the compute environment has been deleted
           x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         config:
           description: Google Cloud Batch compute environment configuration
           $ref: '#/components/schemas/GoogleBatchConfig'
@@ -23871,6 +23896,7 @@ components:
           type: boolean
           description: Flag indicating if the compute environment has been deleted
           x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         config:
           description: Google Cloud compute environment configuration
           $ref: '#/components/schemas/GoogleCloudConfig'
@@ -23999,6 +24025,7 @@ components:
           type: boolean
           description: Flag indicating if the compute environment has been deleted
           x-speakeasy-param-readonly: true
+          x-speakeasy-soft-delete-property: true
         region:
           type: string
           description: |
@@ -25087,12 +25114,7 @@ components:
         credentials:
           $ref: '#/components/schemas/GoogleCredential'
     GiteaCredential:
-      # PILOT: transform-based hoisting (see OVERLAY_GUIDE.md →
-      # "Hoisting Nested API Structures"). The API wire format is
-      # { name, provider, keys: { username, password }, ... }. The
-      # transform flattens that on read and re-nests it on write so
-      # the Terraform schema sees `username` and `password` at the
-      # resource root — no `keys` block, no per-field name-overrides.
+      # See docs-internal/OVERLAY_GUIDE.md → "Hoisting Nested API Structures".
       x-speakeasy-entity: GiteaCredential
       x-speakeasy-entity-version: 1
       x-speakeasy-entity-description: 'Manage Gitea credentials in Seqera platform using this resource. **Note:** This is a workspace-scoped resource. To manage user-context (personal) credentials, use the generic `seqera_credential` resource.

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.763.1
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:500e2671d472515d97c04d7725918bdeb2b95770008789dade923a5450701fbe
-        sourceBlobDigest: sha256:a252b2c2751c684b1ba0546264d4c42aa7e9fb16010984b47c150c2184e85763
+        sourceRevisionDigest: sha256:8c3a3dd2dd2f5b64144576f0b0ae9749ef1e24c20a1b5e1073900e14bc2b972e
+        sourceBlobDigest: sha256:9179d8805eb60345eac56dcce285365c6f6a9a2e1c853a6f3a5775ac51e98028
         tags:
             - latest
             - 1.153.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:500e2671d472515d97c04d7725918bdeb2b95770008789dade923a5450701fbe
-        sourceBlobDigest: sha256:a252b2c2751c684b1ba0546264d4c42aa7e9fb16010984b47c150c2184e85763
+        sourceRevisionDigest: sha256:8c3a3dd2dd2f5b64144576f0b0ae9749ef1e24c20a1b5e1073900e14bc2b972e
+        sourceBlobDigest: sha256:9179d8805eb60345eac56dcce285365c6f6a9a2e1c853a6f3a5775ac51e98028
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ terraform {
   required_providers {
     seqera = {
       source  = "seqeralabs/seqera"
-      version = "0.40.0-RC5"
+      version = "0.40.0-RC7"
     }
   }
 }

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -122,7 +122,7 @@ resource "seqera_action" "tower_advanced" {
 
 ### Required
 
-- `launch` (Attributes) (see [below for nested schema](#nestedatt--launch))
+- `launch` (Attributes) Launch payload for `seqera_action` Create / Update endpoints. (see [below for nested schema](#nestedatt--launch))
 - `name` (String) Human-readable name for the action
 - `workspace_id` (Number) Workspace numeric identifier
 
@@ -178,10 +178,7 @@ Optional:
 Read-Only:
 
 - `compute_env` (Attributes) (see [below for nested schema](#nestedatt--launch--compute_env))
-- `id` (String) Launch identifier. Server-generated on workflow launch and pipeline
-create — leave unset. Echoed back by the provider on
-`seqera_action` updates so the backend can confirm the launch
-identity hasn't changed.
+- `id` (String) Server-generated launch identifier; echoed back on Update.
 - `launch_container` (String)
 - `optimization_id` (String) Optimization profile ID
 - `optimization_targets` (String) Optimization targets
@@ -199,7 +196,6 @@ Read-Only:
 pre/post run scripts, and environment-specific parameters. (see [below for nested schema](#nestedatt--launch--compute_env--config))
 - `credentials_id` (String)
 - `date_created` (String)
-- `deleted` (Boolean)
 - `description` (String)
 - `last_updated` (String)
 - `last_used` (String)

--- a/docs/resources/aws_batch_ce.md
+++ b/docs/resources/aws_batch_ce.md
@@ -120,7 +120,6 @@ resource "seqera_aws_batch_ce" "manual" {
 
 - `compute_env_id` (String) Compute environment string identifier
 - `date_created` (String) Timestamp when the compute environment was created
-- `deleted` (Boolean) Flag indicating if the compute environment has been deleted
 - `id` (String) Unique identifier for the compute environment
 - `last_updated` (String) Timestamp when the compute environment was last updated
 - `last_used` (String) Timestamp when the compute environment was last used

--- a/docs/resources/aws_cloud_ce.md
+++ b/docs/resources/aws_cloud_ce.md
@@ -161,7 +161,6 @@ resource "seqera_aws_cloud_ce" "intelligent" {
 
 - `compute_env_id` (String) Compute environment string identifier
 - `date_created` (String) Timestamp when the compute environment was created
-- `deleted` (Boolean) Flag indicating if the compute environment has been deleted
 - `id` (String) Unique identifier for the compute environment
 - `last_updated` (String) Timestamp when the compute environment was last updated
 - `last_used` (String) Timestamp when the compute environment was last used

--- a/docs/resources/azure_batch_ce.md
+++ b/docs/resources/azure_batch_ce.md
@@ -123,7 +123,6 @@ resource "seqera_azure_batch_ce" "managed_identity" {
 
 - `compute_env_id` (String) Compute environment string identifier
 - `date_created` (String) Timestamp when the compute environment was created
-- `deleted` (Boolean) Flag indicating if the compute environment has been deleted
 - `id` (String) Unique identifier for the compute environment
 - `last_updated` (String) Timestamp when the compute environment was last updated
 - `last_used` (String) Timestamp when the compute environment was last used

--- a/docs/resources/azure_cloud_ce.md
+++ b/docs/resources/azure_cloud_ce.md
@@ -102,7 +102,6 @@ resource "seqera_azure_cloud_ce" "managed_identity" {
 
 - `compute_env_id` (String) Compute environment string identifier
 - `date_created` (String) Timestamp when the compute environment was created
-- `deleted` (Boolean) Flag indicating if the compute environment has been deleted
 - `id` (String) Unique identifier for the compute environment
 - `last_updated` (String) Timestamp when the compute environment was last updated
 - `last_used` (String) Timestamp when the compute environment was last used

--- a/docs/resources/compute_env.md
+++ b/docs/resources/compute_env.md
@@ -117,7 +117,6 @@ Read-Only:
 - `aws_account_id` (String)
 - `compute_env_id` (String)
 - `date_created` (String)
-- `deleted` (Boolean) Whether compute environment is deleted (null means not deleted)
 - `labels` (Attributes List) (see [below for nested schema](#nestedatt--compute_env--labels))
 - `last_updated` (String)
 - `last_used` (String) Last time this compute environment was used (null if never used)

--- a/docs/resources/gcp_batch_ce.md
+++ b/docs/resources/gcp_batch_ce.md
@@ -100,7 +100,6 @@ resource "seqera_gcp_batch_ce" "private_network" {
 
 - `compute_env_id` (String) Compute environment string identifier
 - `date_created` (String) Timestamp when the compute environment was created
-- `deleted` (Boolean) Flag indicating if the compute environment has been deleted
 - `id` (String) Unique identifier for the compute environment
 - `last_updated` (String) Timestamp when the compute environment was last updated
 - `last_used` (String) Timestamp when the compute environment was last used

--- a/docs/resources/gcp_cloud_ce.md
+++ b/docs/resources/gcp_cloud_ce.md
@@ -105,7 +105,6 @@ resource "seqera_gcp_cloud_ce" "gpu" {
 
 - `compute_env_id` (String) Compute environment string identifier
 - `date_created` (String) Timestamp when the compute environment was created
-- `deleted` (Boolean) Flag indicating if the compute environment has been deleted
 - `id` (String) Unique identifier for the compute environment
 - `last_updated` (String) Timestamp when the compute environment was last updated
 - `last_used` (String) Timestamp when the compute environment was last used

--- a/docs/resources/managed_compute_ce.md
+++ b/docs/resources/managed_compute_ce.md
@@ -125,7 +125,6 @@ Requires replacement if changed.
 
 - `compute_env_id` (String) Compute environment string identifier
 - `date_created` (String) Timestamp when the compute environment was created
-- `deleted` (Boolean) Flag indicating if the compute environment has been deleted
 - `id` (String) Unique identifier for the compute environment
 - `last_updated` (String) Timestamp when the compute environment was last updated
 - `last_used` (String) Timestamp when the compute environment was last used

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -2,19 +2,26 @@
 page_title: "seqera_pipeline Resource - terraform-provider-seqera"
 subcategory: "Pipelines"
 description: |-
-  Manage Nextflow pipeline definitions and configurations.
-  Pipelines define reusable workflow templates with parameters,
-  compute environment settings, and execution configurations
-  for scalable bioinformatics and data processing workflows.
+  Manage saved pipeline definitions on the Seqera Platform Launchpad.
+  A seqera_pipeline is a reusable launch template — repository,
+  revision, default parameters, and a default compute environment —
+  that users can launch on demand from the UI or API.
+  Reach for seqera_workflows instead when Terraform itself should
+  trigger an individual workflow run (for example, a validation
+  launch after a compute environment change).
 ---
 
 # seqera_pipeline (Resource)
 
-Manage Nextflow pipeline definitions and configurations.
+Manage saved pipeline definitions on the Seqera Platform Launchpad.
 
-Pipelines define reusable workflow templates with parameters,
-compute environment settings, and execution configurations
-for scalable bioinformatics and data processing workflows.
+A `seqera_pipeline` is a reusable launch template — repository,
+revision, default parameters, and a default compute environment —
+that users can launch on demand from the UI or API.
+
+Reach for `seqera_workflows` instead when Terraform itself should
+trigger an individual workflow run (for example, a validation
+launch after a compute environment change).
 
 ## Example Usage
 
@@ -136,10 +143,6 @@ Optional:
 Read-Only:
 
 - `compute_env` (Attributes) (see [below for nested schema](#nestedatt--launch--compute_env))
-- `id` (String) Launch identifier. Server-generated on workflow launch and pipeline
-create — leave unset. Echoed back by the provider on
-`seqera_action` updates so the backend can confirm the launch
-identity hasn't changed.
 - `launch_container` (String)
 - `optimization_id` (String) Optimization profile ID
 - `optimization_targets` (String) Optimization targets
@@ -157,7 +160,6 @@ Read-Only:
 pre/post run scripts, and environment-specific parameters. (see [below for nested schema](#nestedatt--launch--compute_env--config))
 - `credentials_id` (String)
 - `date_created` (String)
-- `deleted` (Boolean)
 - `description` (String)
 - `last_updated` (String)
 - `last_used` (String)

--- a/docs/resources/workflows.md
+++ b/docs/resources/workflows.md
@@ -2,62 +2,75 @@
 page_title: "seqera_workflows Resource - terraform-provider-seqera"
 subcategory: "Pipelines"
 description: |-
-  Manage workflow executions and pipeline runs.
-  Workflows represent individual executions of Nextflow pipelines,
-  containing execution status, parameters, results, and monitoring
-  information for computational workflows.
+  Launch and track an individual workflow run on the Seqera Platform
+  — equivalent to a Run on the Runs page.
+  Each seqera_workflows resource maps to one execution of a
+  Nextflow pipeline against a specific compute environment. Use it
+  when Terraform itself should trigger runs (one-off validations,
+  CI fan-outs, post-CE-change smoke tests).
+  Reach for seqera_pipeline instead when you want a persistent,
+  re-launchable definition on the Launchpad rather than a single
+  run.
 ---
 
 # seqera_workflows (Resource)
 
-Manage workflow executions and pipeline runs.
+Launch and track an individual workflow run on the Seqera Platform
+— equivalent to a Run on the Runs page.
 
-Workflows represent individual executions of Nextflow pipelines,
-containing execution status, parameters, results, and monitoring
-information for computational workflows.
+Each `seqera_workflows` resource maps to one execution of a
+Nextflow pipeline against a specific compute environment. Use it
+when Terraform itself should trigger runs (one-off validations,
+CI fan-outs, post-CE-change smoke tests).
+
+Reach for `seqera_pipeline` instead when you want a persistent,
+re-launchable definition on the Launchpad rather than a single
+run.
 
 ## Example Usage
 
 ```terraform
-resource "seqera_workflows" "my_workflows" {
-  compute_env_id = "4g09tT4pW4JFUvXTHdB6zP"
-  config_profiles = [
-    "docker",
-    "aws",
-  ]
-  config_text        = "process {\n  executor = 'awsbatch'\n  queue = 'my-queue'\n}\n"
-  entry_name         = "main.nf"
-  force              = false
-  head_job_cpus      = 2
-  head_job_memory_mb = 4096
-  label_ids = [
-    1001,
-    1002,
-    1003,
-  ]
-  main_script         = "main.nf"
-  params_text         = "{\n  \"input\": \"s3://my-bucket/input.csv\",\n  \"output_dir\": \"s3://my-bucket/results\"\n}\n"
-  pipeline            = "https://github.com/nextflow-io/hello"
-  pipeline_schema_id  = 10
-  post_run_script     = "#!/bin/bash\necho \"Workflow completed\"\naws s3 sync ./results s3://my-bucket/results\n"
-  pre_run_script      = "#!/bin/bash\necho \"Starting workflow execution\"\naws s3 sync s3://my-bucket/data ./data\n"
-  pull_latest         = true
-  resume              = true
-  revision            = "main"
-  run_name            = "nextflow-hello"
-  schema_name         = "nextflow_schema.json"
-  source_workspace_id = 2
-  stub_run            = false
-  tower_config        = "...my_tower_config..."
-  user_secrets = [
-    "MY_API_KEY",
-    "DATABASE_PASSWORD",
-  ]
-  work_dir     = "s3://my-bucket/work"
-  workspace_id = 10
+# seqera_workflows — launch an individual workflow run on the Seqera
+# Platform. Each resource maps to one Run on the Runs page.
+#
+# Use this when Terraform itself should trigger a run (e.g. a validation
+# launch after a compute environment change, or a CI fan-out across CEs).
+# For a saved, re-launchable pipeline definition on the Launchpad, use
+# `seqera_pipeline` instead.
+
+# Minimal launch against an existing compute environment.
+resource "seqera_workflows" "hello" {
+  workspace_id   = seqera_workspace.main.id
+  compute_env_id = seqera_aws_batch_ce.production.compute_env_id
+  work_dir       = seqera_aws_batch_ce.production.config.work_dir
+
+  pipeline = "https://github.com/nextflow-io/hello"
+  revision = "master"
+  run_name = "hello-tf-launch"
+}
+```
+
+### With Params
+
+```terraform
+# Launch a parameterised pipeline run with a workspace-scoped secret.
+resource "seqera_workflows" "with_params" {
+  workspace_id   = seqera_workspace.main.id
+  compute_env_id = seqera_aws_batch_ce.production.compute_env_id
+  work_dir       = seqera_aws_batch_ce.production.config.work_dir
+
+  pipeline = "https://github.com/nf-core/rnaseq"
+  revision = "3.14.0"
+  run_name = "rnaseq-${formatdate("YYYYMMDD-hhmm", timestamp())}"
+
+  params_text = jsonencode({
+    input  = "s3://my-bucket/samplesheet.csv"
+    outdir = "s3://my-bucket/results"
+    genome = "GRCh38"
+  })
+
   workspace_secrets = [
-    "WORKSPACE_TOKEN",
-    "SHARED_CREDENTIALS",
+    seqera_pipeline_secret.api_token.name,
   ]
 }
 ```
@@ -99,10 +112,6 @@ resource "seqera_workflows" "my_workflows" {
 
 ### Read-Only
 
-- `id` (String) Launch identifier. Server-generated on workflow launch and pipeline
-create — leave unset. Echoed back by the provider on
-`seqera_action` updates so the backend can confirm the launch
-identity hasn't changed.
 - `intelligent_compute_enabled` (Boolean)
 - `pipeline_info` (Attributes) (see [below for nested schema](#nestedatt--pipeline_info))
 - `workflow` (Attributes) Represents a workflow execution record.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     seqera = {
       source  = "seqeralabs/seqera"
-      version = "0.40.0-RC6"
+      version = "0.40.0-RC7"
     }
   }
 }

--- a/examples/resources/seqera_workflows/resource.tf
+++ b/examples/resources/seqera_workflows/resource.tf
@@ -1,41 +1,18 @@
-resource "seqera_workflows" "my_workflows" {
-  compute_env_id = "4g09tT4pW4JFUvXTHdB6zP"
-  config_profiles = [
-    "docker",
-    "aws",
-  ]
-  config_text        = "process {\n  executor = 'awsbatch'\n  queue = 'my-queue'\n}\n"
-  entry_name         = "main.nf"
-  force              = false
-  head_job_cpus      = 2
-  head_job_memory_mb = 4096
-  label_ids = [
-    1001,
-    1002,
-    1003,
-  ]
-  main_script         = "main.nf"
-  params_text         = "{\n  \"input\": \"s3://my-bucket/input.csv\",\n  \"output_dir\": \"s3://my-bucket/results\"\n}\n"
-  pipeline            = "https://github.com/nextflow-io/hello"
-  pipeline_schema_id  = 10
-  post_run_script     = "#!/bin/bash\necho \"Workflow completed\"\naws s3 sync ./results s3://my-bucket/results\n"
-  pre_run_script      = "#!/bin/bash\necho \"Starting workflow execution\"\naws s3 sync s3://my-bucket/data ./data\n"
-  pull_latest         = true
-  resume              = true
-  revision            = "main"
-  run_name            = "nextflow-hello"
-  schema_name         = "nextflow_schema.json"
-  source_workspace_id = 2
-  stub_run            = false
-  tower_config        = "...my_tower_config..."
-  user_secrets = [
-    "MY_API_KEY",
-    "DATABASE_PASSWORD",
-  ]
-  work_dir     = "s3://my-bucket/work"
-  workspace_id = 10
-  workspace_secrets = [
-    "WORKSPACE_TOKEN",
-    "SHARED_CREDENTIALS",
-  ]
+# seqera_workflows — launch an individual workflow run on the Seqera
+# Platform. Each resource maps to one Run on the Runs page.
+#
+# Use this when Terraform itself should trigger a run (e.g. a validation
+# launch after a compute environment change, or a CI fan-out across CEs).
+# For a saved, re-launchable pipeline definition on the Launchpad, use
+# `seqera_pipeline` instead.
+
+# Minimal launch against an existing compute environment.
+resource "seqera_workflows" "hello" {
+  workspace_id   = seqera_workspace.main.id
+  compute_env_id = seqera_aws_batch_ce.production.compute_env_id
+  work_dir       = seqera_aws_batch_ce.production.config.work_dir
+
+  pipeline = "https://github.com/nextflow-io/hello"
+  revision = "master"
+  run_name = "hello-tf-launch"
 }

--- a/examples/resources/seqera_workflows/resource_with_params.tf
+++ b/examples/resources/seqera_workflows/resource_with_params.tf
@@ -1,0 +1,20 @@
+# Launch a parameterised pipeline run with a workspace-scoped secret.
+resource "seqera_workflows" "with_params" {
+  workspace_id   = seqera_workspace.main.id
+  compute_env_id = seqera_aws_batch_ce.production.compute_env_id
+  work_dir       = seqera_aws_batch_ce.production.config.work_dir
+
+  pipeline = "https://github.com/nf-core/rnaseq"
+  revision = "3.14.0"
+  run_name = "rnaseq-${formatdate("YYYYMMDD-hhmm", timestamp())}"
+
+  params_text = jsonencode({
+    input  = "s3://my-bucket/samplesheet.csv"
+    outdir = "s3://my-bucket/results"
+    genome = "GRCh38"
+  })
+
+  workspace_secrets = [
+    seqera_pipeline_secret.api_token.name,
+  ]
+}

--- a/internal/provider/action_resource.go
+++ b/internal/provider/action_resource.go
@@ -40,20 +40,20 @@ type ActionResource struct {
 
 // ActionResourceModel describes the resource data model.
 type ActionResourceModel struct {
-	ActionID      types.String                   `tfsdk:"action_id"`
-	Bucket        *tfTypes.BucketActionRequest   `tfsdk:"bucket"`
-	Config        *tfTypes.ActionConfigType      `tfsdk:"config"`
-	Cron          *tfTypes.CronActionRequest     `tfsdk:"cron"`
-	Error         types.String                   `tfsdk:"error"`
-	HookID        types.String                   `tfsdk:"hook_id"`
-	HookURL       types.String                   `tfsdk:"hook_url"`
-	ID            types.String                   `tfsdk:"id"`
-	Launch        *tfTypes.WorkflowLaunchRequest `tfsdk:"launch"`
-	Name          types.String                   `tfsdk:"name"`
-	NextExecution types.String                   `tfsdk:"next_execution"`
-	Source        types.String                   `tfsdk:"source"`
-	Status        types.String                   `tfsdk:"status"`
-	WorkspaceID   types.Int64                    `queryParam:"style=form,explode=true,name=workspaceId" tfsdk:"workspace_id"`
+	ActionID      types.String                 `tfsdk:"action_id"`
+	Bucket        *tfTypes.BucketActionRequest `tfsdk:"bucket"`
+	Config        *tfTypes.ActionConfigType    `tfsdk:"config"`
+	Cron          *tfTypes.CronActionRequest   `tfsdk:"cron"`
+	Error         types.String                 `tfsdk:"error"`
+	HookID        types.String                 `tfsdk:"hook_id"`
+	HookURL       types.String                 `tfsdk:"hook_url"`
+	ID            types.String                 `tfsdk:"id"`
+	Launch        *tfTypes.ActionLaunchRequest `tfsdk:"launch"`
+	Name          types.String                 `tfsdk:"name"`
+	NextExecution types.String                 `tfsdk:"next_execution"`
+	Source        types.String                 `tfsdk:"source"`
+	Status        types.String                 `tfsdk:"status"`
+	WorkspaceID   types.Int64                  `queryParam:"style=form,explode=true,name=workspaceId" tfsdk:"workspace_id"`
 }
 
 func (r *ActionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -2262,9 +2262,6 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							"date_created": schema.StringAttribute{
 								Computed: true,
 							},
-							"deleted": schema.BoolAttribute{
-								Computed: true,
-							},
 							"description": schema.StringAttribute{
 								Computed: true,
 							},
@@ -2335,11 +2332,8 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Description: `Head job memory allocation in MB`,
 					},
 					"id": schema.StringAttribute{
-						Computed: true,
-						MarkdownDescription: `Launch identifier. Server-generated on workflow launch and pipeline` + "\n" +
-							`create — leave unset. Echoed back by the provider on` + "\n" +
-							`` + "`" + `seqera_action` + "`" + ` updates so the backend can confirm the launch` + "\n" +
-							`identity hasn't changed.`,
+						Computed:    true,
+						Description: `Server-generated launch identifier; echoed back on Update.`,
 					},
 					"label_ids": schema.ListAttribute{
 						Optional:    true,
@@ -2463,6 +2457,7 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						ElementType: types.StringType,
 					},
 				},
+				Description: `Launch payload for ` + "`" + `seqera_action` + "`" + ` Create / Update endpoints.`,
 			},
 			"name": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/action_resource_sdk.go
+++ b/internal/provider/action_resource_sdk.go
@@ -56,7 +56,7 @@ func (r *ActionResourceModel) RefreshFromSharedActionResponseDto(ctx context.Con
 		r.ID = types.StringPointerValue(resp.ID)
 		if resp.Launch != nil {
 			launchPriorData := r.Launch
-			r.Launch = &tfTypes.WorkflowLaunchRequest{}
+			r.Launch = &tfTypes.ActionLaunchRequest{}
 			if resp.Launch.ComputeEnv == nil {
 				r.Launch.ComputeEnv = nil
 			} else {
@@ -1159,7 +1159,7 @@ func (r *ActionResourceModel) ToSharedCreateActionRequest(ctx context.Context) (
 	for workspaceSecretsIndex := range r.Launch.WorkspaceSecrets {
 		workspaceSecrets = append(workspaceSecrets, r.Launch.WorkspaceSecrets[workspaceSecretsIndex].ValueString())
 	}
-	launch := shared.WorkflowLaunchRequest{
+	launch := shared.ActionLaunchRequest{
 		ComputeEnvID:     computeEnvID,
 		ConfigProfiles:   configProfiles,
 		ConfigText:       configText,
@@ -1272,7 +1272,7 @@ func (r *ActionResourceModel) ToSharedUpdateActionRequest(ctx context.Context) (
 			Timezone:   timezone,
 		}
 	}
-	var launch *shared.WorkflowLaunchRequest
+	var launch *shared.ActionLaunchRequest
 	computeEnvID := new(string)
 	if !r.Launch.ComputeEnvID.IsUnknown() && !r.Launch.ComputeEnvID.IsNull() {
 		*computeEnvID = r.Launch.ComputeEnvID.ValueString()
@@ -1406,7 +1406,7 @@ func (r *ActionResourceModel) ToSharedUpdateActionRequest(ctx context.Context) (
 	for workspaceSecretsIndex := range r.Launch.WorkspaceSecrets {
 		workspaceSecrets = append(workspaceSecrets, r.Launch.WorkspaceSecrets[workspaceSecretsIndex].ValueString())
 	}
-	launch = &shared.WorkflowLaunchRequest{
+	launch = &shared.ActionLaunchRequest{
 		ComputeEnvID:     computeEnvID,
 		ConfigProfiles:   configProfiles,
 		ConfigText:       configText,

--- a/internal/provider/awsbatchce_resource.go
+++ b/internal/provider/awsbatchce_resource.go
@@ -62,7 +62,7 @@ type AWSBatchCEResourceModel struct {
 	Config        *tfTypes.AwsBatchConfig `tfsdk:"config"`
 	CredentialsID types.String            `tfsdk:"credentials_id"`
 	DateCreated   types.String            `tfsdk:"date_created"`
-	Deleted       types.Bool              `tfsdk:"deleted"`
+	Deleted       types.Bool              `tfsdk:"-"`
 	Description   types.String            `tfsdk:"description"`
 	ID            types.String            `tfsdk:"id"`
 	LabelIds      []types.Int64           `tfsdk:"label_ids"`
@@ -843,13 +843,6 @@ func (r *AWSBatchCEResource) Schema(ctx context.Context, req resource.SchemaRequ
 				},
 				Description: `Timestamp when the compute environment was created`,
 			},
-			"deleted": schema.BoolAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-				},
-				Description: `Flag indicating if the compute environment has been deleted`,
-			},
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
@@ -1100,6 +1093,11 @@ func (r *AWSBatchCEResource) Read(ctx context.Context, req resource.ReadRequest,
 	resp.Diagnostics.Append(data.RefreshFromSharedDescribeAWSBatchCEResponse(ctx, res.DescribeAWSBatchCEResponse)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.Deleted.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/awscloudce_resource.go
+++ b/internal/provider/awscloudce_resource.go
@@ -58,7 +58,7 @@ type AwsCloudCEResourceModel struct {
 	Config        *tfTypes.AwsCloudConfig `tfsdk:"config"`
 	CredentialsID types.String            `tfsdk:"credentials_id"`
 	DateCreated   types.String            `tfsdk:"date_created"`
-	Deleted       types.Bool              `tfsdk:"deleted"`
+	Deleted       types.Bool              `tfsdk:"-"`
 	Description   types.String            `tfsdk:"description"`
 	ID            types.String            `tfsdk:"id"`
 	LabelIds      []types.Int64           `tfsdk:"label_ids"`
@@ -426,13 +426,6 @@ func (r *AwsCloudCEResource) Schema(ctx context.Context, req resource.SchemaRequ
 				},
 				Description: `Timestamp when the compute environment was created`,
 			},
-			"deleted": schema.BoolAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-				},
-				Description: `Flag indicating if the compute environment has been deleted`,
-			},
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
@@ -683,6 +676,11 @@ func (r *AwsCloudCEResource) Read(ctx context.Context, req resource.ReadRequest,
 	resp.Diagnostics.Append(data.RefreshFromSharedDescribeAwsCloudCEResponse(ctx, res.DescribeAwsCloudCEResponse)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.Deleted.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/azurebatchce_resource.go
+++ b/internal/provider/azurebatchce_resource.go
@@ -60,7 +60,7 @@ type AzureBatchCEResourceModel struct {
 	Config        *tfTypes.AzBatchConfig `tfsdk:"config"`
 	CredentialsID types.String           `tfsdk:"credentials_id"`
 	DateCreated   types.String           `tfsdk:"date_created"`
-	Deleted       types.Bool             `tfsdk:"deleted"`
+	Deleted       types.Bool             `tfsdk:"-"`
 	Description   types.String           `tfsdk:"description"`
 	ID            types.String           `tfsdk:"id"`
 	LabelIds      []types.Int64          `tfsdk:"label_ids"`
@@ -566,13 +566,6 @@ func (r *AzureBatchCEResource) Schema(ctx context.Context, req resource.SchemaRe
 				},
 				Description: `Timestamp when the compute environment was created`,
 			},
-			"deleted": schema.BoolAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-				},
-				Description: `Flag indicating if the compute environment has been deleted`,
-			},
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
@@ -823,6 +816,11 @@ func (r *AzureBatchCEResource) Read(ctx context.Context, req resource.ReadReques
 	resp.Diagnostics.Append(data.RefreshFromSharedDescribeAzureBatchCEResponse(ctx, res.DescribeAzureBatchCEResponse)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.Deleted.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/azurecloudce_resource.go
+++ b/internal/provider/azurecloudce_resource.go
@@ -56,7 +56,7 @@ type AzureCloudCEResourceModel struct {
 	Config        *tfTypes.AzCloudConfig `tfsdk:"config"`
 	CredentialsID types.String           `tfsdk:"credentials_id"`
 	DateCreated   types.String           `tfsdk:"date_created"`
-	Deleted       types.Bool             `tfsdk:"deleted"`
+	Deleted       types.Bool             `tfsdk:"-"`
 	Description   types.String           `tfsdk:"description"`
 	ID            types.String           `tfsdk:"id"`
 	LabelIds      []types.Int64          `tfsdk:"label_ids"`
@@ -322,13 +322,6 @@ func (r *AzureCloudCEResource) Schema(ctx context.Context, req resource.SchemaRe
 				},
 				Description: `Timestamp when the compute environment was created`,
 			},
-			"deleted": schema.BoolAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-				},
-				Description: `Flag indicating if the compute environment has been deleted`,
-			},
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
@@ -579,6 +572,11 @@ func (r *AzureCloudCEResource) Read(ctx context.Context, req resource.ReadReques
 	resp.Diagnostics.Append(data.RefreshFromSharedDescribeAzureCloudCEResponse(ctx, res.DescribeAzureCloudCEResponse)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.Deleted.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/computeenv_resource.go
+++ b/internal/provider/computeenv_resource.go
@@ -4897,13 +4897,6 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 					},
-					"deleted": schema.BoolAttribute{
-						Computed: true,
-						PlanModifiers: []planmodifier.Bool{
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
-						Description: `Whether compute environment is deleted (null means not deleted)`,
-					},
 					"description": schema.StringAttribute{
 						Computed: true,
 						Optional: true,

--- a/internal/provider/gcpbatchce_resource.go
+++ b/internal/provider/gcpbatchce_resource.go
@@ -61,7 +61,7 @@ type GCPBatchCEResourceModel struct {
 	Config        *tfTypes.GoogleBatchConfig `tfsdk:"config"`
 	CredentialsID types.String               `tfsdk:"credentials_id"`
 	DateCreated   types.String               `tfsdk:"date_created"`
-	Deleted       types.Bool                 `tfsdk:"deleted"`
+	Deleted       types.Bool                 `tfsdk:"-"`
 	Description   types.String               `tfsdk:"description"`
 	ID            types.String               `tfsdk:"id"`
 	LabelIds      []types.Int64              `tfsdk:"label_ids"`
@@ -502,13 +502,6 @@ func (r *GCPBatchCEResource) Schema(ctx context.Context, req resource.SchemaRequ
 				},
 				Description: `Timestamp when the compute environment was created`,
 			},
-			"deleted": schema.BoolAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-				},
-				Description: `Flag indicating if the compute environment has been deleted`,
-			},
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
@@ -759,6 +752,11 @@ func (r *GCPBatchCEResource) Read(ctx context.Context, req resource.ReadRequest,
 	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGCPBatchCEResponse(ctx, res.DescribeGCPBatchCEResponse)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.Deleted.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/gcpcloudce_resource.go
+++ b/internal/provider/gcpcloudce_resource.go
@@ -58,7 +58,7 @@ type GCPCloudCEResourceModel struct {
 	Config        *tfTypes.GoogleCloudConfig `tfsdk:"config"`
 	CredentialsID types.String               `tfsdk:"credentials_id"`
 	DateCreated   types.String               `tfsdk:"date_created"`
-	Deleted       types.Bool                 `tfsdk:"deleted"`
+	Deleted       types.Bool                 `tfsdk:"-"`
 	Description   types.String               `tfsdk:"description"`
 	ID            types.String               `tfsdk:"id"`
 	LabelIds      []types.Int64              `tfsdk:"label_ids"`
@@ -313,13 +313,6 @@ func (r *GCPCloudCEResource) Schema(ctx context.Context, req resource.SchemaRequ
 				},
 				Description: `Timestamp when the compute environment was created`,
 			},
-			"deleted": schema.BoolAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-				},
-				Description: `Flag indicating if the compute environment has been deleted`,
-			},
 			"description": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
@@ -570,6 +563,11 @@ func (r *GCPCloudCEResource) Read(ctx context.Context, req resource.ReadRequest,
 	resp.Diagnostics.Append(data.RefreshFromSharedDescribeGCPCloudCEResponse(ctx, res.DescribeGCPCloudCEResponse)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.Deleted.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/managedcomputece_resource.go
+++ b/internal/provider/managedcomputece_resource.go
@@ -55,7 +55,7 @@ type ManagedComputeCEResourceModel struct {
 	ComputeEnvID        types.String                `tfsdk:"compute_env_id"`
 	DataRetentionPolicy types.Bool                  `tfsdk:"data_retention_policy"`
 	DateCreated         types.String                `tfsdk:"date_created"`
-	Deleted             types.Bool                  `tfsdk:"deleted"`
+	Deleted             types.Bool                  `tfsdk:"-"`
 	Environment         []tfTypes.ConfigEnvVariable `tfsdk:"environment"`
 	ID                  types.String                `tfsdk:"id"`
 	InstanceSize        types.String                `tfsdk:"instance_size"`
@@ -106,13 +106,6 @@ func (r *ManagedComputeCEResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Timestamp when the compute environment was created`,
-			},
-			"deleted": schema.BoolAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.Bool{
-					speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-				},
-				Description: `Flag indicating if the compute environment has been deleted`,
 			},
 			"environment": schema.ListNestedAttribute{
 				Computed: true,
@@ -504,6 +497,11 @@ func (r *ManagedComputeCEResource) Read(ctx context.Context, req resource.ReadRe
 	resp.Diagnostics.Append(data.RefreshFromSharedDescribeManagedComputeCEResponse(ctx, res.DescribeManagedComputeCEResponse)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.Deleted.IsNull() {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -65,7 +65,7 @@ func (r *PipelineResource) Metadata(ctx context.Context, req resource.MetadataRe
 
 func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage Nextflow pipeline definitions and configurations.\n\nPipelines define reusable workflow templates with parameters,\ncompute environment settings, and execution configurations\nfor scalable bioinformatics and data processing workflows.\n",
+		MarkdownDescription: "Manage saved pipeline definitions on the Seqera Platform Launchpad.\n\nA `seqera_pipeline` is a reusable launch template — repository,\nrevision, default parameters, and a default compute environment —\nthat users can launch on demand from the UI or API.\n\nReach for `seqera_workflows` instead when Terraform itself should\ntrigger an individual workflow run (for example, a validation\nlaunch after a compute environment change).\n",
 		Attributes: map[string]schema.Attribute{
 			"description": schema.StringAttribute{
 				Computed:    true,
@@ -2160,9 +2160,6 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 							"date_created": schema.StringAttribute{
 								Computed: true,
 							},
-							"deleted": schema.BoolAttribute{
-								Computed: true,
-							},
 							"description": schema.StringAttribute{
 								Computed: true,
 							},
@@ -2231,13 +2228,6 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 						Computed:    true,
 						Optional:    true,
 						Description: `Head job memory allocation in MB`,
-					},
-					"id": schema.StringAttribute{
-						Computed: true,
-						MarkdownDescription: `Launch identifier. Server-generated on workflow launch and pipeline` + "\n" +
-							`create — leave unset. Echoed back by the provider on` + "\n" +
-							`` + "`" + `seqera_action` + "`" + ` updates so the backend can confirm the launch` + "\n" +
-							`identity hasn't changed.`,
 					},
 					"label_ids": schema.ListAttribute{
 						Optional:    true,

--- a/internal/provider/pipeline_resource_sdk.go
+++ b/internal/provider/pipeline_resource_sdk.go
@@ -772,7 +772,6 @@ func (r *PipelineResourceModel) RefreshFromSharedDescribeLaunchResponse(ctx cont
 			r.Launch.EntryName = types.StringPointerValue(resp.Launch.EntryName)
 			r.Launch.HeadJobCpus = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Launch.HeadJobCpus))
 			r.Launch.HeadJobMemoryMb = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Launch.HeadJobMemoryMb))
-			r.Launch.ID = types.StringPointerValue(resp.Launch.ID)
 			r.Launch.LaunchContainer = types.StringPointerValue(resp.Launch.LaunchContainer)
 			r.Launch.MainScript = types.StringPointerValue(resp.Launch.MainScript)
 			r.Launch.OptimizationID = types.StringPointerValue(resp.Launch.OptimizationID)
@@ -1029,12 +1028,6 @@ func (r *PipelineResourceModel) ToSharedCreatePipelineRequest(ctx context.Contex
 	} else {
 		headJobMemoryMb = nil
 	}
-	id := new(string)
-	if !r.Launch.ID.IsUnknown() && !r.Launch.ID.IsNull() {
-		*id = r.Launch.ID.ValueString()
-	} else {
-		id = nil
-	}
 	labelIds1 := make([]int64, 0, len(r.Launch.LabelIds))
 	for labelIdsIndex1 := range r.Launch.LabelIds {
 		labelIds1 = append(labelIds1, r.Launch.LabelIds[labelIdsIndex1].ValueInt64())
@@ -1135,7 +1128,6 @@ func (r *PipelineResourceModel) ToSharedCreatePipelineRequest(ctx context.Contex
 		EntryName:        entryName,
 		HeadJobCpus:      headJobCpus,
 		HeadJobMemoryMb:  headJobMemoryMb,
-		ID:               id,
 		LabelIds:         labelIds1,
 		MainScript:       mainScript,
 		ParamsText:       paramsText,
@@ -1234,12 +1226,6 @@ func (r *PipelineResourceModel) ToSharedUpdatePipelineRequest(ctx context.Contex
 		*headJobMemoryMb = int(r.Launch.HeadJobMemoryMb.ValueInt32())
 	} else {
 		headJobMemoryMb = nil
-	}
-	id := new(string)
-	if !r.Launch.ID.IsUnknown() && !r.Launch.ID.IsNull() {
-		*id = r.Launch.ID.ValueString()
-	} else {
-		id = nil
 	}
 	labelIds1 := make([]int64, 0, len(r.Launch.LabelIds))
 	for labelIdsIndex1 := range r.Launch.LabelIds {
@@ -1341,7 +1327,6 @@ func (r *PipelineResourceModel) ToSharedUpdatePipelineRequest(ctx context.Contex
 		EntryName:        entryName,
 		HeadJobCpus:      headJobCpus,
 		HeadJobMemoryMb:  headJobMemoryMb,
-		ID:               id,
 		LabelIds:         labelIds1,
 		MainScript:       mainScript,
 		ParamsText:       paramsText,

--- a/internal/provider/types/action_launch_request.go
+++ b/internal/provider/types/action_launch_request.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-type WorkflowLaunchRequest struct {
+type ActionLaunchRequest struct {
 	ComputeEnv          *ComputeEnvComputeConfig `tfsdk:"compute_env"`
 	ComputeEnvID        types.String             `tfsdk:"compute_env_id"`
 	ConfigProfiles      []types.String           `tfsdk:"config_profiles"`
@@ -14,6 +14,7 @@ type WorkflowLaunchRequest struct {
 	EntryName           types.String             `tfsdk:"entry_name"`
 	HeadJobCpus         types.Int32              `tfsdk:"head_job_cpus"`
 	HeadJobMemoryMb     types.Int32              `tfsdk:"head_job_memory_mb"`
+	ID                  types.String             `tfsdk:"id"`
 	LabelIds            []types.Int64            `tfsdk:"label_ids"`
 	LaunchContainer     types.String             `tfsdk:"launch_container"`
 	MainScript          types.String             `tfsdk:"main_script"`

--- a/internal/provider/types/compute_env_compute_config.go
+++ b/internal/provider/types/compute_env_compute_config.go
@@ -10,7 +10,7 @@ type ComputeEnvComputeConfig struct {
 	Config        *ComputeConfig `tfsdk:"config"`
 	CredentialsID types.String   `tfsdk:"credentials_id"`
 	DateCreated   types.String   `tfsdk:"date_created"`
-	Deleted       types.Bool     `tfsdk:"deleted"`
+	Deleted       types.Bool     `tfsdk:"-"`
 	Description   types.String   `tfsdk:"description"`
 	ComputeEnvID  types.String   `tfsdk:"compute_env_id"`
 	LastUpdated   types.String   `tfsdk:"last_updated"`

--- a/internal/provider/types/compute_env_compute_config1.go
+++ b/internal/provider/types/compute_env_compute_config1.go
@@ -12,7 +12,7 @@ type ComputeEnvComputeConfig1 struct {
 	Config            *ComputeConfig                  `tfsdk:"config"`
 	CredentialsID     types.String                    `tfsdk:"credentials_id"`
 	DateCreated       types.String                    `tfsdk:"date_created"`
-	Deleted           types.Bool                      `tfsdk:"deleted"`
+	Deleted           types.Bool                      `tfsdk:"-"`
 	Description       types.String                    `tfsdk:"description"`
 	Labels            []LabelDbDto                    `tfsdk:"labels"`
 	LastUpdated       types.String                    `tfsdk:"last_updated"`

--- a/internal/provider/workflows_resource.go
+++ b/internal/provider/workflows_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_int64planmodifier "github.com/seqeralabs/terraform-provider-seqera/internal/planmodifiers/int64planmodifier"
-	speakeasy_stringplanmodifier "github.com/seqeralabs/terraform-provider-seqera/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/seqeralabs/terraform-provider-seqera/internal/provider/types"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk"
 	custom_stringvalidators "github.com/seqeralabs/terraform-provider-seqera/internal/validators/stringvalidators"
@@ -48,7 +47,6 @@ type WorkflowsResourceModel struct {
 	Force                     types.Bool                       `queryParam:"style=form,explode=true,name=force" tfsdk:"force"`
 	HeadJobCpus               types.Int32                      `tfsdk:"head_job_cpus"`
 	HeadJobMemoryMb           types.Int32                      `tfsdk:"head_job_memory_mb"`
-	ID                        types.String                     `tfsdk:"id"`
 	IntelligentComputeEnabled types.Bool                       `tfsdk:"intelligent_compute_enabled"`
 	LabelIds                  []types.Int64                    `tfsdk:"label_ids"`
 	MainScript                types.String                     `tfsdk:"main_script"`
@@ -80,7 +78,7 @@ func (r *WorkflowsResource) Metadata(ctx context.Context, req resource.MetadataR
 
 func (r *WorkflowsResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage workflow executions and pipeline runs.\n\nWorkflows represent individual executions of Nextflow pipelines,\ncontaining execution status, parameters, results, and monitoring\ninformation for computational workflows.\n",
+		MarkdownDescription: "Launch and track an individual workflow run on the Seqera Platform\n— equivalent to a Run on the Runs page.\n\nEach `seqera_workflows` resource maps to one execution of a\nNextflow pipeline against a specific compute environment. Use it\nwhen Terraform itself should trigger runs (one-off validations,\nCI fan-outs, post-CE-change smoke tests).\n\nReach for `seqera_pipeline` instead when you want a persistent,\nre-launchable definition on the Launchpad rather than a single\nrun.\n",
 		Attributes: map[string]schema.Attribute{
 			"compute_env_id": schema.StringAttribute{
 				Optional: true,
@@ -128,16 +126,6 @@ func (r *WorkflowsResource) Schema(ctx context.Context, req resource.SchemaReque
 					int32planmodifier.RequiresReplaceIfConfigured(),
 				},
 				Description: `Head job memory allocation in MB. Requires replacement if changed.`,
-			},
-			"id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				MarkdownDescription: `Launch identifier. Server-generated on workflow launch and pipeline` + "\n" +
-					`create — leave unset. Echoed back by the provider on` + "\n" +
-					`` + "`" + `seqera_action` + "`" + ` updates so the backend can confirm the launch` + "\n" +
-					`identity hasn't changed.`,
 			},
 			"intelligent_compute_enabled": schema.BoolAttribute{
 				Computed: true,

--- a/internal/provider/workflows_resource_sdk.go
+++ b/internal/provider/workflows_resource_sdk.go
@@ -245,12 +245,6 @@ func (r *WorkflowsResourceModel) ToSharedWorkflowLaunchRequest(ctx context.Conte
 	} else {
 		headJobMemoryMb = nil
 	}
-	id := new(string)
-	if !r.ID.IsUnknown() && !r.ID.IsNull() {
-		*id = r.ID.ValueString()
-	} else {
-		id = nil
-	}
 	labelIds := make([]int64, 0, len(r.LabelIds))
 	for labelIdsIndex := range r.LabelIds {
 		labelIds = append(labelIds, r.LabelIds[labelIdsIndex].ValueInt64())
@@ -351,7 +345,6 @@ func (r *WorkflowsResourceModel) ToSharedWorkflowLaunchRequest(ctx context.Conte
 		EntryName:        entryName,
 		HeadJobCpus:      headJobCpus,
 		HeadJobMemoryMb:  headJobMemoryMb,
-		ID:               id,
 		LabelIds:         labelIds,
 		MainScript:       mainScript,
 		ParamsText:       paramsText,

--- a/internal/sdk/models/shared/actionlaunchrequest.go
+++ b/internal/sdk/models/shared/actionlaunchrequest.go
@@ -2,7 +2,8 @@
 
 package shared
 
-type WorkflowLaunchRequest struct {
+// ActionLaunchRequest - Launch payload for `seqera_action` Create / Update endpoints.
+type ActionLaunchRequest struct {
 	ComputeEnvID   *string  `json:"computeEnvId,omitempty"`
 	ConfigProfiles []string `json:"configProfiles,omitempty"`
 	// Nextflow configuration text
@@ -13,7 +14,7 @@ type WorkflowLaunchRequest struct {
 	HeadJobCpus *int `json:"headJobCpus,omitempty"`
 	// Head job memory allocation in MB
 	HeadJobMemoryMb *int `json:"headJobMemoryMb,omitempty"`
-	// Server-generated launch identifier.
+	// Server-generated launch identifier; echoed back on Update.
 	ID       *string `json:"id,omitempty"`
 	LabelIds []int64 `json:"labelIds,omitempty"`
 	// Main script path
@@ -43,170 +44,170 @@ type WorkflowLaunchRequest struct {
 	WorkspaceSecrets []string `json:"workspaceSecrets,omitempty"`
 }
 
-func (w *WorkflowLaunchRequest) GetComputeEnvID() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetComputeEnvID() *string {
+	if a == nil {
 		return nil
 	}
-	return w.ComputeEnvID
+	return a.ComputeEnvID
 }
 
-func (w *WorkflowLaunchRequest) GetConfigProfiles() []string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetConfigProfiles() []string {
+	if a == nil {
 		return nil
 	}
-	return w.ConfigProfiles
+	return a.ConfigProfiles
 }
 
-func (w *WorkflowLaunchRequest) GetConfigText() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetConfigText() *string {
+	if a == nil {
 		return nil
 	}
-	return w.ConfigText
+	return a.ConfigText
 }
 
-func (w *WorkflowLaunchRequest) GetEntryName() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetEntryName() *string {
+	if a == nil {
 		return nil
 	}
-	return w.EntryName
+	return a.EntryName
 }
 
-func (w *WorkflowLaunchRequest) GetHeadJobCpus() *int {
-	if w == nil {
+func (a *ActionLaunchRequest) GetHeadJobCpus() *int {
+	if a == nil {
 		return nil
 	}
-	return w.HeadJobCpus
+	return a.HeadJobCpus
 }
 
-func (w *WorkflowLaunchRequest) GetHeadJobMemoryMb() *int {
-	if w == nil {
+func (a *ActionLaunchRequest) GetHeadJobMemoryMb() *int {
+	if a == nil {
 		return nil
 	}
-	return w.HeadJobMemoryMb
+	return a.HeadJobMemoryMb
 }
 
-func (w *WorkflowLaunchRequest) GetID() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetID() *string {
+	if a == nil {
 		return nil
 	}
-	return w.ID
+	return a.ID
 }
 
-func (w *WorkflowLaunchRequest) GetLabelIds() []int64 {
-	if w == nil {
+func (a *ActionLaunchRequest) GetLabelIds() []int64 {
+	if a == nil {
 		return nil
 	}
-	return w.LabelIds
+	return a.LabelIds
 }
 
-func (w *WorkflowLaunchRequest) GetMainScript() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetMainScript() *string {
+	if a == nil {
 		return nil
 	}
-	return w.MainScript
+	return a.MainScript
 }
 
-func (w *WorkflowLaunchRequest) GetParamsText() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetParamsText() *string {
+	if a == nil {
 		return nil
 	}
-	return w.ParamsText
+	return a.ParamsText
 }
 
-func (w *WorkflowLaunchRequest) GetPipeline() string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetPipeline() string {
+	if a == nil {
 		return ""
 	}
-	return w.Pipeline
+	return a.Pipeline
 }
 
-func (w *WorkflowLaunchRequest) GetPipelineSchemaID() *int64 {
-	if w == nil {
+func (a *ActionLaunchRequest) GetPipelineSchemaID() *int64 {
+	if a == nil {
 		return nil
 	}
-	return w.PipelineSchemaID
+	return a.PipelineSchemaID
 }
 
-func (w *WorkflowLaunchRequest) GetPostRunScript() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetPostRunScript() *string {
+	if a == nil {
 		return nil
 	}
-	return w.PostRunScript
+	return a.PostRunScript
 }
 
-func (w *WorkflowLaunchRequest) GetPreRunScript() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetPreRunScript() *string {
+	if a == nil {
 		return nil
 	}
-	return w.PreRunScript
+	return a.PreRunScript
 }
 
-func (w *WorkflowLaunchRequest) GetPullLatest() *bool {
-	if w == nil {
+func (a *ActionLaunchRequest) GetPullLatest() *bool {
+	if a == nil {
 		return nil
 	}
-	return w.PullLatest
+	return a.PullLatest
 }
 
-func (w *WorkflowLaunchRequest) GetResume() *bool {
-	if w == nil {
+func (a *ActionLaunchRequest) GetResume() *bool {
+	if a == nil {
 		return nil
 	}
-	return w.Resume
+	return a.Resume
 }
 
-func (w *WorkflowLaunchRequest) GetRevision() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetRevision() *string {
+	if a == nil {
 		return nil
 	}
-	return w.Revision
+	return a.Revision
 }
 
-func (w *WorkflowLaunchRequest) GetRunName() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetRunName() *string {
+	if a == nil {
 		return nil
 	}
-	return w.RunName
+	return a.RunName
 }
 
-func (w *WorkflowLaunchRequest) GetSchemaName() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetSchemaName() *string {
+	if a == nil {
 		return nil
 	}
-	return w.SchemaName
+	return a.SchemaName
 }
 
-func (w *WorkflowLaunchRequest) GetStubRun() *bool {
-	if w == nil {
+func (a *ActionLaunchRequest) GetStubRun() *bool {
+	if a == nil {
 		return nil
 	}
-	return w.StubRun
+	return a.StubRun
 }
 
-func (w *WorkflowLaunchRequest) GetTowerConfig() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetTowerConfig() *string {
+	if a == nil {
 		return nil
 	}
-	return w.TowerConfig
+	return a.TowerConfig
 }
 
-func (w *WorkflowLaunchRequest) GetUserSecrets() []string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetUserSecrets() []string {
+	if a == nil {
 		return nil
 	}
-	return w.UserSecrets
+	return a.UserSecrets
 }
 
-func (w *WorkflowLaunchRequest) GetWorkDir() *string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetWorkDir() *string {
+	if a == nil {
 		return nil
 	}
-	return w.WorkDir
+	return a.WorkDir
 }
 
-func (w *WorkflowLaunchRequest) GetWorkspaceSecrets() []string {
-	if w == nil {
+func (a *ActionLaunchRequest) GetWorkspaceSecrets() []string {
+	if a == nil {
 		return nil
 	}
-	return w.WorkspaceSecrets
+	return a.WorkspaceSecrets
 }

--- a/internal/sdk/models/shared/createactionrequest.go
+++ b/internal/sdk/models/shared/createactionrequest.go
@@ -3,11 +3,12 @@
 package shared
 
 type CreateActionRequest struct {
-	Bucket *BucketActionRequest  `json:"bucket,omitempty"`
-	Cron   *CronActionRequest    `json:"cron,omitempty"`
-	Launch WorkflowLaunchRequest `json:"launch"`
-	Name   string                `json:"name"`
-	Source *ActionSource         `json:"source,omitempty"`
+	Bucket *BucketActionRequest `json:"bucket,omitempty"`
+	Cron   *CronActionRequest   `json:"cron,omitempty"`
+	// Launch payload for `seqera_action` Create / Update endpoints.
+	Launch ActionLaunchRequest `json:"launch"`
+	Name   string              `json:"name"`
+	Source *ActionSource       `json:"source,omitempty"`
 }
 
 func (c *CreateActionRequest) GetBucket() *BucketActionRequest {
@@ -24,9 +25,9 @@ func (c *CreateActionRequest) GetCron() *CronActionRequest {
 	return c.Cron
 }
 
-func (c *CreateActionRequest) GetLaunch() WorkflowLaunchRequest {
+func (c *CreateActionRequest) GetLaunch() ActionLaunchRequest {
 	if c == nil {
-		return WorkflowLaunchRequest{}
+		return ActionLaunchRequest{}
 	}
 	return c.Launch
 }

--- a/internal/sdk/models/shared/updateactionrequest.go
+++ b/internal/sdk/models/shared/updateactionrequest.go
@@ -3,10 +3,11 @@
 package shared
 
 type UpdateActionRequest struct {
-	Bucket *BucketActionRequest   `json:"bucket,omitempty"`
-	Cron   *CronActionRequest     `json:"cron,omitempty"`
-	Launch *WorkflowLaunchRequest `json:"launch,omitempty"`
-	Name   *string                `json:"name,omitempty"`
+	Bucket *BucketActionRequest `json:"bucket,omitempty"`
+	Cron   *CronActionRequest   `json:"cron,omitempty"`
+	// Launch payload for `seqera_action` Create / Update endpoints.
+	Launch *ActionLaunchRequest `json:"launch,omitempty"`
+	Name   *string              `json:"name,omitempty"`
 }
 
 func (u *UpdateActionRequest) GetBucket() *BucketActionRequest {
@@ -23,7 +24,7 @@ func (u *UpdateActionRequest) GetCron() *CronActionRequest {
 	return u.Cron
 }
 
-func (u *UpdateActionRequest) GetLaunch() *WorkflowLaunchRequest {
+func (u *UpdateActionRequest) GetLaunch() *ActionLaunchRequest {
 	if u == nil {
 		return nil
 	}

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -173,9 +173,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
-		SDKVersion: "0.40.0-RC6",
+		SDKVersion: "0.40.0-RC7",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC6 2.884.4 1.153.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC7 2.884.4 1.153.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/overlays/actions.yaml
+++ b/overlays/actions.yaml
@@ -176,6 +176,33 @@ actions:
       - name
       - launch
 
+  # `ActionLaunchRequest` wraps `WorkflowLaunchRequest` and re-adds the `id`
+  # field that workflows.yaml hides. `seqera_action` Update echoes the
+  # existing launch id back to the backend; `seqera_workflows` doesn't need
+  # (or have a source for) the same field — keeping the schemas separate
+  # avoids cross-resource interference.
+
+  - target: $.components.schemas
+    update:
+      ActionLaunchRequest:
+        type: object
+        description: Launch payload for `seqera_action` Create / Update endpoints.
+        allOf:
+          - $ref: '#/components/schemas/WorkflowLaunchRequest'
+        properties:
+          id:
+            type: string
+            description: Server-generated launch identifier; echoed back on Update.
+            x-speakeasy-param-readonly: true
+
+  - target: $.components.schemas.CreateActionRequest.properties.launch
+    update:
+      $ref: '#/components/schemas/ActionLaunchRequest'
+
+  - target: $.components.schemas.UpdateActionRequest.properties.launch
+    update:
+      $ref: '#/components/schemas/ActionLaunchRequest'
+
   # ============================================================================
   # SCHEMA DESCRIPTIONS
   # ============================================================================

--- a/overlays/compute-env.yaml
+++ b/overlays/compute-env.yaml
@@ -153,9 +153,40 @@ actions:
   - target: $.components.schemas.ComputeEnv_ComputeConfig_.properties.lastUsed
     update:
       x-speakeasy-param-readonly: true
+  # Soft-delete handling — Tower returns 200 OK with `deleted: true` for a
+  # destroyed CE rather than a 404. Mark the field so Speakeasy treats a
+  # truthy value as resource-gone and the next plan re-creates the CE.
+  # Complements `x-speakeasy-entity-missing-codes: [400, 404]` (used per
+  # Read operation) which handles the fully-purged case.
   - target: $.components.schemas.ComputeEnv_ComputeConfig_.properties.deleted
     update:
       x-speakeasy-param-readonly: true
+      x-speakeasy-soft-delete-property: true
+  - target: $.components.schemas.ComputeEnvResponseDto.properties.deleted
+    update:
+      x-speakeasy-param-readonly: true
+      x-speakeasy-soft-delete-property: true
+  - target: $.components.schemas.AWSBatchCE_ComputeConfig.properties.deleted
+    update:
+      x-speakeasy-soft-delete-property: true
+  - target: $.components.schemas.AwsCloudCE_ComputeConfig.properties.deleted
+    update:
+      x-speakeasy-soft-delete-property: true
+  - target: $.components.schemas.AzureBatchCE_ComputeConfig.properties.deleted
+    update:
+      x-speakeasy-soft-delete-property: true
+  - target: $.components.schemas.AzureCloudCE_ComputeConfig.properties.deleted
+    update:
+      x-speakeasy-soft-delete-property: true
+  - target: $.components.schemas.GCPBatchCE_ComputeConfig.properties.deleted
+    update:
+      x-speakeasy-soft-delete-property: true
+  - target: $.components.schemas.GCPCloudCE_ComputeConfig.properties.deleted
+    update:
+      x-speakeasy-soft-delete-property: true
+  - target: $.components.schemas.ManagedComputeCE_ComputeConfig.properties.deleted
+    update:
+      x-speakeasy-soft-delete-property: true
   - target: $.components.schemas.ComputeEnv_ComputeConfig_.properties.status
     update:
       x-speakeasy-param-readonly: true

--- a/overlays/pipelines.yaml
+++ b/overlays/pipelines.yaml
@@ -52,11 +52,15 @@ actions:
     update:
       x-speakeasy-entity: Pipeline
       x-speakeasy-entity-description: |
-        Manage Nextflow pipeline definitions and configurations.
+        Manage saved pipeline definitions on the Seqera Platform Launchpad.
 
-        Pipelines define reusable workflow templates with parameters,
-        compute environment settings, and execution configurations
-        for scalable bioinformatics and data processing workflows.
+        A `seqera_pipeline` is a reusable launch template — repository,
+        revision, default parameters, and a default compute environment —
+        that users can launch on demand from the UI or API.
+
+        Reach for `seqera_workflows` instead when Terraform itself should
+        trigger an individual workflow run (for example, a validation
+        launch after a compute environment change).
       description: |
         Represents a pipeline configuration in the Seqera Platform.
         Contains pipeline metadata, configuration settings, and execution parameters

--- a/overlays/workflows.yaml
+++ b/overlays/workflows.yaml
@@ -37,11 +37,17 @@ actions:
     update:
       x-speakeasy-entity: Workflows
       x-speakeasy-entity-description: |
-        Manage workflow executions and pipeline runs.
+        Launch and track an individual workflow run on the Seqera Platform
+        — equivalent to a Run on the Runs page.
 
-        Workflows represent individual executions of Nextflow pipelines,
-        containing execution status, parameters, results, and monitoring
-        information for computational workflows.
+        Each `seqera_workflows` resource maps to one execution of a
+        Nextflow pipeline against a specific compute environment. Use it
+        when Terraform itself should trigger runs (one-off validations,
+        CI fan-outs, post-CE-change smoke tests).
+
+        Reach for `seqera_pipeline` instead when you want a persistent,
+        re-launchable definition on the Launchpad rather than a single
+        run.
 
   - target: $["components"]["schemas"]["WorkflowLaunchRequest"]
     update:
@@ -257,24 +263,17 @@ actions:
   # CLEANUP - Remove unmanageable, internal, and deprecated fields
   # ============================================================================
 
-  # Remove internal/computed fields from WorkflowLaunchRequest that aren't user-configurable.
-  #
-  # NOTE: `id` is intentionally NOT removed — the seqera_action Update endpoint
-  # reuses this request shape and the backend validates that the incoming
-  # `launch.id` matches the action's existing launch (rejecting with HTTP 400
-  # "Launch ID value can't change" when absent). Removing it broke every
-  # action update, which surfaced to users as "actions can't be updated when
-  # secrets are involved". Mark it Read-Only instead so it stays Computed
-  # for create paths (workflow launch, pipeline create) but is echoed back
-  # by the provider on action updates.
+  # `id` is kept on the SDK type (readonly) but hidden from the TF schema
+  # (terraform-ignore). The Update body for `seqera_action` needs it on the
+  # wire, but `seqera_workflows` has no response field to populate a
+  # top-level `id` from, so exposing it would leave the attribute unknown
+  # after apply. `seqera_action.launch.id` is supplied separately by
+  # ActionLaunchRequest (see overlays/actions.yaml).
   - target: $.components.schemas.WorkflowLaunchRequest.properties.id
     update:
-      description: |
-        Launch identifier. Server-generated on workflow launch and pipeline
-        create — leave unset. Echoed back by the provider on
-        `seqera_action` updates so the backend can confirm the launch
-        identity hasn't changed.
+      description: Server-generated launch identifier.
       x-speakeasy-param-readonly: true
+      x-speakeasy-terraform-ignore: true
   - target: $["components"]["schemas"]["WorkflowLaunchRequest"]["properties"]["sessionId"]
     remove: true
   - target: $["components"]["schemas"]["WorkflowLaunchRequest"]["properties"]["resumeDir"]


### PR DESCRIPTION

## Fix CE Deletion

There has been a long outstanding bug where a compute environment was deleted in the UI terraform would fail to unmarshal the response which was fixed in an earlier release 

Now the provider see's the soft-deleted resource and not attempt a recreate the deleted CE as the deletion is A-Sync.

This PR adds the relevant soft-delete keys and triggers appropriate state removal for the A-Sync usecase.  


## Docs

This includes improved docs around `seqera_workflows` resolving #56 