### PR TITLE
fix: Credential Create response ID 0.40.0-RC8

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: 51dcbbcdfa6a75acadab3f223452494f
+  docChecksum: e818e33bf8c72277702e76e329c17b75
   docVersion: 1.153.0
-  speakeasyVersion: 1.763.1
-  generationVersion: 2.884.4
-  releaseVersion: 0.40.0-RC7
-  configChecksum: d370b487b66814edd0b2eeb4bbe4195d
+  speakeasyVersion: 1.763.5
+  generationVersion: 2.884.11
+  releaseVersion: 0.40.0-RC8
+  configChecksum: 1668444cadeb3d20e58e8a44ee68d7ac
 persistentEdits:
   generation_id: fa9416b7-6c9d-4aa5-b5cb-f5815d4b62d8
   pristine_commit_hash: 8b727d9d7ead153a998336c81b01bdba5fdfbcbb
@@ -15,7 +15,7 @@ features:
   terraform:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.3.2
-    core: 3.47.4
+    core: 3.47.5
     deepObjectParams: 0.1.0
     deprecations: 2.82.0
     formatBinary: 0.2.0
@@ -40,7 +40,7 @@ trackedFiles:
     pristine_git_object: 8e707bb129af1da185ba30b4c289b0160819c437
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:0785a3e3d0838ed0508b67c41333bcadaa7a0461
+    last_write_checksum: sha1:9b575b6fc2e72003f9efd9d8251fa0a1ab98d294
     pristine_git_object: 7b241353e887cd10c08b0653d13c2227ce91f456
   examples/resources/seqera_action/import-by-string-id.tf:
     id: 7b9e1b28088a
@@ -302,7 +302,7 @@ trackedFiles:
     pristine_git_object: 6cdb08cff8d5e98c92183f577fc8fbe059d61ff7
   go.mod:
     id: c47645c391ad
-    last_write_checksum: sha1:5671809fb98083f6be47ace78b1d84d8e7c85dc9
+    last_write_checksum: sha1:e557380b6f2440060d7ff3708551e59aa90a0895
     pristine_git_object: 0197aba33874c19d2d4a76f51d3c37929a4d811e
   internal/planmodifiers/boolplanmodifier/suppress_diff.go:
     id: 3cf85b98963e
@@ -422,11 +422,11 @@ trackedFiles:
     pristine_git_object: 0ea64fbeb1fd7709d7241a8e06d34bfe9d0323d3
   internal/provider/action_resource.go:
     id: f7c19bf35b58
-    last_write_checksum: sha1:12dd90aaec7743631a371310185a8942cb56a3c3
+    last_write_checksum: sha1:e46ef89acc6881e64997d73f69e917740b355b93
     pristine_git_object: fc35041e2f1cf6db01d04e9e9e861df96d042782
   internal/provider/action_resource_sdk.go:
     id: 28576317893d
-    last_write_checksum: sha1:fafb9bf73fdc5da9c6dfb519233d5eee16c869fc
+    last_write_checksum: sha1:ebaab06830745dcbec775adb9f231a056b9956ef
     pristine_git_object: b987eb32b2d86ebe52fb9875e9e4b6eb9f30af6e
   internal/provider/awsbatchce_resource.go:
     id: aeeab49ad69b
@@ -434,19 +434,19 @@ trackedFiles:
     pristine_git_object: 136a1cfb3f23c1c396175224b78c790e8d4b9808
   internal/provider/awsbatchce_resource_sdk.go:
     id: acddb134f02d
-    last_write_checksum: sha1:dd22a3ae2798e141de8f3e1276835425b926c9b7
+    last_write_checksum: sha1:740cf5754190349ebbc8e4c0bb03f936131f8797
     pristine_git_object: 91db6c7b9d563b0b0fa5e57c712ed1952c1d54d2
   internal/provider/awscloudce_resource.go:
     last_write_checksum: sha1:ab9e16853cd3011662e56a305d0e0a8919ce5b1f
   internal/provider/awscloudce_resource_sdk.go:
-    last_write_checksum: sha1:4f5e42dd40c14f3e02755107b26c101d2217230c
+    last_write_checksum: sha1:73b7464ac299fa3bd1b2eb0804ab21e282fd973f
   internal/provider/awscomputeenv_resource.go:
     id: 788844f2d22e
     last_write_checksum: sha1:dc043ab61d705afdd471ee6230dbae3f9c86d40e
     pristine_git_object: 251b9b34df068086a2b6c118fd0cdc7384d6fb53
   internal/provider/awscomputeenv_resource_sdk.go:
     id: 9a23d2e0f03e
-    last_write_checksum: sha1:360e7334e473fbb1265ad4deb745acdc23a07c71
+    last_write_checksum: sha1:458b3efe0e21d338579d646e6eaddbdd7b49ad13
     pristine_git_object: 4d4451329e274230a287210d496b8e03aea29724
   internal/provider/awscredential_resource.go:
     id: fd1fb9518f67
@@ -454,39 +454,39 @@ trackedFiles:
     pristine_git_object: 718916f70c62d6cdeb910a896ec32723c62f9346
   internal/provider/awscredential_resource_sdk.go:
     id: 6dd3171fbbcc
-    last_write_checksum: sha1:7af2249a39b89d7643f4442b37c0cea80922eade
+    last_write_checksum: sha1:7c5985ec470f43666b2a5860949f2d8ad5b4a5a1
     pristine_git_object: fb79abddd43fc8a362ddaff379637c1def78665a
   internal/provider/azurebatchce_resource.go:
     last_write_checksum: sha1:e452e863bd534d4d8132c78e084e109cf0e50af8
   internal/provider/azurebatchce_resource_sdk.go:
-    last_write_checksum: sha1:23105b512e07f34339c8e74e54a3f0d3f73fd7af
+    last_write_checksum: sha1:02a46cc8545558a1e2eabaea102115aea025e8bc
   internal/provider/azurecloudce_resource.go:
     last_write_checksum: sha1:73f3875c6e5be74a32d273e590cd53455ac2f5cd
   internal/provider/azurecloudce_resource_sdk.go:
-    last_write_checksum: sha1:86d28c885f46283e51159c3b77a99da6cc79dfd6
+    last_write_checksum: sha1:6c900aeec91332059ab4153de664b8dabcd784ce
   internal/provider/azurecloudcredential_resource.go:
     last_write_checksum: sha1:978b428562ae34f3f2002e91d703e648edb32dac
   internal/provider/azurecloudcredential_resource_sdk.go:
-    last_write_checksum: sha1:7ce1a39c5651fc23651dee3383f0e2251026fedb
+    last_write_checksum: sha1:98e6c39d90143a54f4e406d3e29fdb7b214a6baa
   internal/provider/azurecredential_resource.go:
     id: 4e14a60d78ce
     last_write_checksum: sha1:d9a32f5b55b3a7d1f5f9bf88467b2bacfa2c27de
     pristine_git_object: 0eb0896ee9fe4eed104d1d66e3c5b72221a8e8c1
   internal/provider/azurecredential_resource_sdk.go:
     id: 1cff49867392
-    last_write_checksum: sha1:07a57319f845b88529508d9b0908cb7ce01fd002
+    last_write_checksum: sha1:8aa8abd56361e0ab7058cac34733fe276d68653a
     pristine_git_object: 62f301e24df9501920ae8a9afe8ae7927b82a862
   internal/provider/azureentracredential_resource.go:
     last_write_checksum: sha1:7467274d28fb6c69044172ccf517da543b96f791
   internal/provider/azureentracredential_resource_sdk.go:
-    last_write_checksum: sha1:2cf03b163b75edcaafe42925a3fcfe685843c953
+    last_write_checksum: sha1:7dbc7e788036389cf01880fd702f0b7a60ade649
   internal/provider/bitbucketcredential_resource.go:
     id: 99461a76ba60
     last_write_checksum: sha1:5bce9723362d15b5b7e0c2e3f3f10b2eafdae385
     pristine_git_object: ef48989850ba46b7641a28a14055504c1737a53c
   internal/provider/bitbucketcredential_resource_sdk.go:
     id: ea250abc2a72
-    last_write_checksum: sha1:b00c9b77de96aec0da0c8c8bba6c147aca098fed
+    last_write_checksum: sha1:20b9b139f9026d80011a6136ca4553ed2bee1f26
     pristine_git_object: 8a0bebdcdd3d64be9a83a6a75aa5bc0422f8f3ff
   internal/provider/codecommitcredential_resource.go:
     id: 22c2e9aa4b13
@@ -494,7 +494,7 @@ trackedFiles:
     pristine_git_object: 58dcb06c3f42ed4aa8f5bf250a2b70ed4ad235ed
   internal/provider/codecommitcredential_resource_sdk.go:
     id: dcc60e154878
-    last_write_checksum: sha1:d9f72dc52d3fda3b00dbfe15fea59c15ccde71fd
+    last_write_checksum: sha1:78fdb9a7650b187e6dd6dca607fe7062af7b3105
     pristine_git_object: 0c1b43d5db49b023cf3c7408c198a4d66c795d8a
   internal/provider/computeenv_resource.go:
     id: f4162f219efd
@@ -510,15 +510,15 @@ trackedFiles:
     pristine_git_object: e6a9866eacb679ff8d1567624763412dcb61f0d1
   internal/provider/containerregistrycredential_resource_sdk.go:
     id: 84a1496699d8
-    last_write_checksum: sha1:88fbb1bd9d7c68c3bdaecae6e63fe41e6a05f782
+    last_write_checksum: sha1:d7cd5a183698275ef86cc01c7b340039e2e96799
     pristine_git_object: 9cb9ad7d844c9ac4c05ed05c9fbc4351231a9c4e
   internal/provider/credential_resource.go:
     id: b17d06f08976
-    last_write_checksum: sha1:1b61acf9b79ce6a7a4526940c501b04589689b8a
+    last_write_checksum: sha1:c2c710c18b224f75ce4715eaea800a9313988635
     pristine_git_object: e695351308d33c3457984e46178c7f8eb775ae87
   internal/provider/credential_resource_sdk.go:
     id: 0a20c4488832
-    last_write_checksum: sha1:2a24069f776ffb211f3ff8b94ee39f194fb8fbf2
+    last_write_checksum: sha1:13d2731a79b33213796e715d69dc08756c51b686
     pristine_git_object: 5f30e81b72fd0a632305020694beed9efec6112c
   internal/provider/credentials_data_source.go:
     id: 44d9e7a82f76
@@ -559,18 +559,18 @@ trackedFiles:
   internal/provider/gcpbatchce_resource.go:
     last_write_checksum: sha1:db712970cb96eb0a668502065893bd427b3b2b8e
   internal/provider/gcpbatchce_resource_sdk.go:
-    last_write_checksum: sha1:51e775539dce2e1ce359466ed81b14de76f2892f
+    last_write_checksum: sha1:8ccf87f0b313e7326dfc17582b395ac0aadcc050
   internal/provider/gcpcloudce_resource.go:
     last_write_checksum: sha1:8bfd30f1d8a430efd90ada3ea14af53646fb36e1
   internal/provider/gcpcloudce_resource_sdk.go:
-    last_write_checksum: sha1:5b1d35a7ef5389f58dbe11030bbd09508c444e6d
+    last_write_checksum: sha1:5db764bec9f6692c066597f688af2efd37031152
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
     last_write_checksum: sha1:c9cd253e8540eff268f3ba8fcc0c599317120efa
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
-    last_write_checksum: sha1:8bff3a37eedb61d439b76c88d97c31243e7a03ef
+    last_write_checksum: sha1:002b5c5e8f4a426190b04e60d831321fa1ad8a70
     pristine_git_object: 71e29ff10c22205eab4418ac0b8a92152cc5b23d
   internal/provider/githubcredential_resource.go:
     id: e1f090a0cb9e
@@ -578,7 +578,7 @@ trackedFiles:
     pristine_git_object: c6a4da7de3d8a1ca06c268021bcb56ba09f3c9f1
   internal/provider/githubcredential_resource_sdk.go:
     id: bc2bee614a62
-    last_write_checksum: sha1:ae0c5546c3c1fa03896cb6ed0072e27c8378ee5c
+    last_write_checksum: sha1:73184f74d6a1ffb872b90a6912bc4628a6524dda
     pristine_git_object: 01c4b02c388b5caf56516bd71e9a2176973234b2
   internal/provider/gitlabcredential_resource.go:
     id: fcb86103d097
@@ -586,7 +586,7 @@ trackedFiles:
     pristine_git_object: 5b27290c979fb073cf156f1babc37c36cde9ab8e
   internal/provider/gitlabcredential_resource_sdk.go:
     id: a6c217015659
-    last_write_checksum: sha1:9a260ce308613dea6addc908e8036d080aa7cd47
+    last_write_checksum: sha1:05c581fa6c41c0fc8e1cd088e0e5740490d0f330
     pristine_git_object: 0f3d5604b62f838d2b0b79919f08bc65e5c9cf5b
   internal/provider/googlecredential_resource.go:
     id: 8822521a4af3
@@ -594,7 +594,7 @@ trackedFiles:
     pristine_git_object: 026226dc9ef3d464025bca768181bcaa0a4e6f7f
   internal/provider/googlecredential_resource_sdk.go:
     id: b4c881561996
-    last_write_checksum: sha1:ee72ea448a31adccf7af5bc0ce76c24d57ea43a7
+    last_write_checksum: sha1:ea2ca1600cc7f60faeeaaba0c0ffe32bc496842c
     pristine_git_object: a25a2b110b86b9bffc9496f89bf92a4e5e452bce
   internal/provider/kubernetescredential_resource.go:
     id: 9cca06635b9e
@@ -602,7 +602,7 @@ trackedFiles:
     pristine_git_object: 1be6769e629c348b8cf88a2f4898baf75b3da740
   internal/provider/kubernetescredential_resource_sdk.go:
     id: ea2832ecd302
-    last_write_checksum: sha1:50fd884953a08ca3797c4d68bef4006545c8bb1b
+    last_write_checksum: sha1:a2fafaf6a2d2cefcc913a4451ff1f349c768bbe7
     pristine_git_object: 2814ac2db68121be9482eefc7c946a8df0202a38
   internal/provider/labels_resource.go:
     id: 738bccd5f1b7
@@ -618,7 +618,7 @@ trackedFiles:
     pristine_git_object: adccfb0da743b49f39ee880f81d9b6a12b4a2e27
   internal/provider/managedcomputece_resource_sdk.go:
     id: 834a6a05996d
-    last_write_checksum: sha1:c411d45a54c40c1acd7c9985d01fc400ecb85060
+    last_write_checksum: sha1:df19dbc27d8d96787a7370586c415a3974b91bba
     pristine_git_object: 2200507ea00d48e6fa7ee4f3f2e51571f17226c3
   internal/provider/orgs_resource.go:
     id: 28df60f6d9c9
@@ -636,11 +636,11 @@ trackedFiles:
     pristine_git_object: eb186d4cf2287bf1eec7eb07d9b9c7e0386b7b26
   internal/provider/pipelinesecret_resource.go:
     id: 5319f8284106
-    last_write_checksum: sha1:1a67b1144012389658bec0107aa8023a7bd85239
+    last_write_checksum: sha1:12e942cc5686242314f402a90d2f858b8e28090d
     pristine_git_object: 89ee6378acd7e780989aac270dd11f269f152368
   internal/provider/pipelinesecret_resource_sdk.go:
     id: e5c7e3be53da
-    last_write_checksum: sha1:609cabba381a3beb0a5a4a05bf0506ad28eedd38
+    last_write_checksum: sha1:3d1d92ac9dc81e57f5c7615ac1734df172dfa81b
     pristine_git_object: e52e3b26ba7c56a91baa9636d315323ef63b37e4
   internal/provider/primarycomputeenv_resource.go:
     id: 1894ce41f7df
@@ -716,7 +716,7 @@ trackedFiles:
     pristine_git_object: 47f7c6e152f7cecdcbd982d27de12746f870a355
   internal/provider/sshcredential_resource_sdk.go:
     id: 3c25312d23ab
-    last_write_checksum: sha1:68eaa21dd1d86223bfcf4d06799ae0e7928386a7
+    last_write_checksum: sha1:4e3be40607e82d241af200ab9e93a83e00e67bf0
     pristine_git_object: a633929e19d2c86fc43fdc96a586954c0992048c
   internal/provider/studios_resource.go:
     id: d5d4f38592d9
@@ -735,16 +735,16 @@ trackedFiles:
     last_write_checksum: sha1:f4056c889f0bfbe0811324b152b39ed6290b2a15
     pristine_git_object: 26f268ef8a33992e5cedbb0dbbe25ccb26ffb14a
   internal/provider/tokens_resource.go:
-    last_write_checksum: sha1:175a120b77e6e478b8f803a28c3a557524745cfc
+    last_write_checksum: sha1:9c804921cf41b43dfb838fe06c20c2184c71e05a
   internal/provider/tokens_resource_sdk.go:
-    last_write_checksum: sha1:09b4887dfd5f9916f8a729c10ba042065dec71b0
+    last_write_checksum: sha1:3a5bd5ff815a5a7303f03e2717d509bbb220434a
   internal/provider/toweragentcredential_resource.go:
     id: 9596670e4f16
     last_write_checksum: sha1:fb2873b0705403262568fbdc2b66eced46687e40
     pristine_git_object: d91d65ea5bffdb82659601bb5f8c37780e55e998
   internal/provider/toweragentcredential_resource_sdk.go:
     id: 139ea0cf9bf1
-    last_write_checksum: sha1:38825d6f4aa8490ab583c52a979f57c572a33b74
+    last_write_checksum: sha1:86b27faf8c7370d99d5b48265466e9b6f874d8e8
     pristine_git_object: 8717142892f205e2ca6d831bbe400d59dd11f556
   internal/provider/typeconvert/date.go:
     id: dfe2bc95ad1b
@@ -2508,7 +2508,7 @@ trackedFiles:
     pristine_git_object: 521aa719cdb5f1164d4cef15352fe2a1ca481a8d
   internal/sdk/models/shared/createaccesstokenresponse.go:
     id: 047355ccd78f
-    last_write_checksum: sha1:31221385e7c999994f7e69ca115b5d7ddec3d65e
+    last_write_checksum: sha1:fd420903a2ef2a2df98d8ef166615a71274d4a9e
     pristine_git_object: e8d0f3a5a1ba367ab5d3de41c39c6fe2709b63bb
   internal/sdk/models/shared/createactionrequest.go:
     id: 3535c016c767
@@ -2516,7 +2516,7 @@ trackedFiles:
     pristine_git_object: e31748303dcf8afdd83f767b842dea31f7066eab
   internal/sdk/models/shared/createactionresponse.go:
     id: 3ac726a6a7cf
-    last_write_checksum: sha1:41a40eaeb59497ff2ade8a5f3d3ffd560f84b7af
+    last_write_checksum: sha1:362be6281783e09447f300167e14b598c5a1c9c4
     pristine_git_object: 0ad4b562fb4cdfa299454815ad03a91974264035
   internal/sdk/models/shared/createavatarresponse.go:
     id: e5dd31cc3091
@@ -2528,19 +2528,19 @@ trackedFiles:
     pristine_git_object: f960c983782e1436c47dbd0dc27d762ab6dc89f9
   internal/sdk/models/shared/createawsbatchceresponse.go:
     id: f023249375f3
-    last_write_checksum: sha1:df5863e26d1ae9f55b29c7a29c078f3743e7b336
+    last_write_checksum: sha1:f84ea22c09e87f2900b5658fb544e4f6054ec7ad
     pristine_git_object: 978fb4f7181d1428a317d3ebf6c1f46c91f21ecb
   internal/sdk/models/shared/createawscloudcerequest.go:
     last_write_checksum: sha1:3b2dc43c690e23f1a273ae7b4a56f6b6ba9f82e3
   internal/sdk/models/shared/createawscloudceresponse.go:
-    last_write_checksum: sha1:3ccc76d873c11426e6fc291da0abe29df675eea3
+    last_write_checksum: sha1:293e9c8f69b1648ffa94b69de3e6db6f056d4ea0
   internal/sdk/models/shared/createawscomputeenvrequest.go:
     id: d42fe5a6f6e3
     last_write_checksum: sha1:db8028ebf5fca1814d39b0cbfc11085e71bf4fe0
     pristine_git_object: 380ce79aa2eca108450104b0410b69ea69763e59
   internal/sdk/models/shared/createawscomputeenvresponse.go:
     id: 747401b23ff2
-    last_write_checksum: sha1:7f473f216930a3a912f8a1baada6983bd3bb2773
+    last_write_checksum: sha1:fb1a6d069b7c3ed1cfb9a549c19bbd790da6c7b0
     pristine_git_object: 3afb051f88f7525fc930cf40331f2ebc06194534
   internal/sdk/models/shared/createawscredentialsrequest.go:
     id: eaa46066eefb
@@ -2548,39 +2548,39 @@ trackedFiles:
     pristine_git_object: 1c88fd0ff37d093788ccf507c1aef3942e3d26d8
   internal/sdk/models/shared/createawscredentialsresponse.go:
     id: 0280ab4eb8b0
-    last_write_checksum: sha1:512ca8aeb14ae5f6758174e671fa041c5de8794a
+    last_write_checksum: sha1:ffb5da37c8536c24265f7dde9d20a0c9aa3a2027
     pristine_git_object: 551872b10603e98b5e127b456ac9ca391d5dbed5
   internal/sdk/models/shared/createazurebatchcerequest.go:
     last_write_checksum: sha1:fa5c84e80979d46966a150e9b04bf5396da785d9
   internal/sdk/models/shared/createazurebatchceresponse.go:
-    last_write_checksum: sha1:f80f7d26c8370875be1badc48308c5b6dcb26ab7
+    last_write_checksum: sha1:4e2323ccf99ddd4e86e436aef8c01eb75f85ec30
   internal/sdk/models/shared/createazurecloudcerequest.go:
     last_write_checksum: sha1:14a86c0c17fd34440b2c117860ba8a11b3ff59e7
   internal/sdk/models/shared/createazurecloudceresponse.go:
-    last_write_checksum: sha1:96fa0eaf6f995ffbd8304b9712b7ee14b3820bbb
+    last_write_checksum: sha1:dd308ac2c18b2ae33453ac4ebc7c894587aabc39
   internal/sdk/models/shared/createazurecloudcredentialsrequest.go:
     last_write_checksum: sha1:8937154cae152c336b18eef76607076e3d1971ba
   internal/sdk/models/shared/createazurecloudcredentialsresponse.go:
-    last_write_checksum: sha1:7a0fc53731395025229b0224f2e66a41ec13b957
+    last_write_checksum: sha1:66b5ec192a289b53616fc035075338fa97d48826
   internal/sdk/models/shared/createazurecredentialsrequest.go:
     id: eccbe7db1018
     last_write_checksum: sha1:20efdc9f7af7c3f175ece49181bad7f12fe0ff79
     pristine_git_object: 342f240047f8fc3192387ab1637a110e4bd8cefe
   internal/sdk/models/shared/createazurecredentialsresponse.go:
     id: a6633d6d1834
-    last_write_checksum: sha1:059d6501b8a64058a70f6a1d0685cc309fa65204
+    last_write_checksum: sha1:ae9ac2c69821b441df8a386398ddb75524f7200e
     pristine_git_object: a16160c0613d10da1a556b74185958df4e87a409
   internal/sdk/models/shared/createazureentracredentialsrequest.go:
     last_write_checksum: sha1:00e68eb503c3f5c5d973fdcea0f4143ced8ebde9
   internal/sdk/models/shared/createazureentracredentialsresponse.go:
-    last_write_checksum: sha1:aa08c32d4ddf60b635ca5fd110b9232b88f142be
+    last_write_checksum: sha1:afec66364aac86d5a856f9eab96ba89207dd58d4
   internal/sdk/models/shared/createbitbucketcredentialsrequest.go:
     id: b037579a80a7
     last_write_checksum: sha1:4a3a15639ce34c967bf597a2666c57e3b3b8096d
     pristine_git_object: ac37e93b6a9cb9d7577401ce26e2215272e056e0
   internal/sdk/models/shared/createbitbucketcredentialsresponse.go:
     id: 914a302aaf04
-    last_write_checksum: sha1:be8fa1423b93121798953814ad7966503637b218
+    last_write_checksum: sha1:fdec99ca624c2841910471878e5336ce49a5e2d8
     pristine_git_object: 5c8ce50d1e9f4188790add6aabc31c23d9030b5b
   internal/sdk/models/shared/createcodecommitcredentialsrequest.go:
     id: 00576402f79f
@@ -2588,7 +2588,7 @@ trackedFiles:
     pristine_git_object: 2489b7c0e88b4d18ade3a5e6706617caedf5ff7b
   internal/sdk/models/shared/createcodecommitcredentialsresponse.go:
     id: d9e015ff79ea
-    last_write_checksum: sha1:e1d780f42ef0c131c790df23c6206414e1b16afc
+    last_write_checksum: sha1:e1cb4054c7a0d0221d11ed93c99e514fadc81660
     pristine_git_object: ed9aac6786b93da93e7ff37280855b29ece8c9be
   internal/sdk/models/shared/createcomputeenvrequest.go:
     id: 5ecebb832a10
@@ -2604,7 +2604,7 @@ trackedFiles:
     pristine_git_object: d62533aeefa8dad6a7d22f50790c133236a9097a
   internal/sdk/models/shared/createcontainerregistrycredentialsresponse.go:
     id: 5eba48078ed1
-    last_write_checksum: sha1:ad9cb194c78b3d809b6b8a309a274c8e2543d122
+    last_write_checksum: sha1:6942b956a54817ad47714573c2398e49da092a67
     pristine_git_object: 6b937290635757304387e2a33067d7f6b3e4fa02
   internal/sdk/models/shared/createcredentialsrequest.go:
     id: adce3f273899
@@ -2612,7 +2612,7 @@ trackedFiles:
     pristine_git_object: 49890f63b186b3a248a125b0b91bf012917821ea
   internal/sdk/models/shared/createcredentialsresponse.go:
     id: 6a3547aa199c
-    last_write_checksum: sha1:277fd9907efa8021d69a742cf29eead5d0129100
+    last_write_checksum: sha1:8f7efdc3444603abc46787446c63d7c6aac3e3db
     pristine_git_object: e8156147182640e87f4af93cf96c13fd16ad4151
   internal/sdk/models/shared/createdatasetrequest.go:
     id: 2e7be5c6dc73
@@ -2625,18 +2625,18 @@ trackedFiles:
   internal/sdk/models/shared/creategcpbatchcerequest.go:
     last_write_checksum: sha1:db87d9b6e64c2bfadf22aeae3061d860e079a3d2
   internal/sdk/models/shared/creategcpbatchceresponse.go:
-    last_write_checksum: sha1:27195dad1a5b95a7c8b949c64e755d4780f5f42f
+    last_write_checksum: sha1:4dded06cdee0a9a1be70c18be4c21a7c77802097
   internal/sdk/models/shared/creategcpcloudcerequest.go:
     last_write_checksum: sha1:2701907bbddf6388938bcc9260e2085eec6d946e
   internal/sdk/models/shared/creategcpcloudceresponse.go:
-    last_write_checksum: sha1:a8728bfd091f138bfec36383b75abcfd97cee2ec
+    last_write_checksum: sha1:b6968d203143127a889ec2651c527df503895151
   internal/sdk/models/shared/creategiteacredentialsrequest.go:
     id: 2ae396ab7cd2
     last_write_checksum: sha1:d1c453b34900ebaf7a173fbb3260293ce75bee13
     pristine_git_object: c939f42baedccdaab1ed06535d3769a495c9c32c
   internal/sdk/models/shared/creategiteacredentialsresponse.go:
     id: 13c2c7dd7c30
-    last_write_checksum: sha1:b7ba4dfbcb829b8f4dbb8e2beb56b64f4f533732
+    last_write_checksum: sha1:2392452c8f8a9ba1280d15326202214fe149c650
     pristine_git_object: 34a8eacc222c93883d317a356c88d2e0eab8d946
   internal/sdk/models/shared/creategithubcredentialsrequest.go:
     id: c74ef2fb8373
@@ -2644,7 +2644,7 @@ trackedFiles:
     pristine_git_object: c87d980050cd6b2ca54a6c2ce255397094be9df3
   internal/sdk/models/shared/creategithubcredentialsresponse.go:
     id: "042490240e46"
-    last_write_checksum: sha1:9b403029a6a878c51199d8d5e9980a4b1034ddc9
+    last_write_checksum: sha1:0a81f8183c6e34bcd7657f8769d99488d93363db
     pristine_git_object: c15eb22681c2a4de6d491c4411e97ff34c40fa22
   internal/sdk/models/shared/creategitlabcredentialsrequest.go:
     id: 2a470091c0d3
@@ -2652,7 +2652,7 @@ trackedFiles:
     pristine_git_object: ee5d2e047102c69627ad6525a7f594ca8a351361
   internal/sdk/models/shared/creategitlabcredentialsresponse.go:
     id: 25f5b88ece0d
-    last_write_checksum: sha1:efa83b89c28944330e063d65e4fdfcf542928529
+    last_write_checksum: sha1:6d520e6fc97eeae809dafbcb46e3b69875c8bb0c
     pristine_git_object: a49c4df63dc929337b848174d763cfe0ae4aef2a
   internal/sdk/models/shared/creategooglecredentialsrequest.go:
     id: 1ae1c3d0cf5d
@@ -2660,7 +2660,7 @@ trackedFiles:
     pristine_git_object: 15ddba07239842996b9f47498c15fc918b8e440a
   internal/sdk/models/shared/creategooglecredentialsresponse.go:
     id: 65f8763a17f7
-    last_write_checksum: sha1:a49ac92e51787ce31862a053e3ef878ba43a7555
+    last_write_checksum: sha1:0e6588fba4d75294a9cf5a7815fa612cfa52e70e
     pristine_git_object: f56dc72e3f3703386b6befc4b98a5126a3005513
   internal/sdk/models/shared/createkubernetescredentialsrequest.go:
     id: 412f326904a5
@@ -2668,7 +2668,7 @@ trackedFiles:
     pristine_git_object: 5abb059ad81c04b2eb50255a50a9c022213a1894
   internal/sdk/models/shared/createkubernetescredentialsresponse.go:
     id: cd834f582ce7
-    last_write_checksum: sha1:bdb4b0e122e60b3ac2aaec95fac0847abbccc53a
+    last_write_checksum: sha1:b0a62ba4a69e437114cd784f074d3490f69ab8cd
     pristine_git_object: c44cc31f71fef5adb1e1f24bba4fa5d1c8c5670f
   internal/sdk/models/shared/createlabelrequest.go:
     id: 5493d4aad05d
@@ -2684,7 +2684,7 @@ trackedFiles:
     pristine_git_object: a016e4b2b022ca6011d9ab76a46d718626558b1a
   internal/sdk/models/shared/createmanagedcomputeceresponse.go:
     id: 0453e76c20cc
-    last_write_checksum: sha1:eb69dd3f2064e1ea1f73ec70134ab1cab067ace5
+    last_write_checksum: sha1:42b7ee9329f56b1ad66389edf19c56574438fe64
     pristine_git_object: fc5583a70660cf9b743b49b9e8c94c73d0659fdf
   internal/sdk/models/shared/createmanagedcredentialsrequest.go:
     id: ce11a3910aca
@@ -2728,7 +2728,7 @@ trackedFiles:
     pristine_git_object: f9dc449040506214193c3f986d3094e3fe3dbe5e
   internal/sdk/models/shared/createpipelinesecretresponse.go:
     id: a679795c4feb
-    last_write_checksum: sha1:f3c2c5f4662aa14d0c4619386e5097f02a413c08
+    last_write_checksum: sha1:0caeb2564d83697ae03148645075864df830e07d
     pristine_git_object: ddeb2fca966e5639ed4b3a10ad73adb162675505
   internal/sdk/models/shared/createpipelineversionrequest.go:
     last_write_checksum: sha1:f5585a1e04a309058445bdd3844c809fd21d34ed
@@ -2742,7 +2742,7 @@ trackedFiles:
     pristine_git_object: 03fd93884bf0447227de0de04345b77b76d9411b
   internal/sdk/models/shared/createsshcredentialsresponse.go:
     id: 8c43c40b534d
-    last_write_checksum: sha1:58c25e2e51e4962f288a868a9918818650ac44dc
+    last_write_checksum: sha1:e8519a395a073e5f4acba448fb6248d24eac6b38
     pristine_git_object: 341bd3ba6c6ba5eb577e3fa9f3bb094bd7d9fb4a
   internal/sdk/models/shared/createsshkeyrequest.go:
     last_write_checksum: sha1:02d63e123da34c11b06dac76c3cb55cba8ec02e4
@@ -2766,7 +2766,7 @@ trackedFiles:
     pristine_git_object: 707171ac17d36832ed3585d2052ff4c4d0975036
   internal/sdk/models/shared/createtoweragentcredentialsresponse.go:
     id: c900fc1d3471
-    last_write_checksum: sha1:41219c5e0f6d17bea4d4d05eefc42c518461c66e
+    last_write_checksum: sha1:6da9b77632b536f7e3c39bbb2a3c24c29f005ac8
     pristine_git_object: 9a36b4504082aad217f35b2423efb40757d25094
   internal/sdk/models/shared/createworkflowstarresponse.go:
     id: 09a76f25ba68
@@ -3988,7 +3988,7 @@ trackedFiles:
     last_write_checksum: sha1:4254ac7cabfdf1410c8e69888cc51a81318bbfb4
   internal/sdk/seqera.go:
     id: b1c23bc5193c
-    last_write_checksum: sha1:98410acfc0828ab1f4064ca2eaee271235efe9fa
+    last_write_checksum: sha1:665bcbe42fc104c350575db16c824433278d68a6
     pristine_git_object: 89364ed6208c4c999b317d23d7d954d63ac46bc5
   internal/sdk/serviceinfo.go:
     id: 085db9a15b34

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -32,7 +32,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 0.40.0-RC7
+  version: 0.40.0-RC8
   additionalActions: []
   additionalDataSources:
     - datasource: custom_role_data.NewDataSource

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -15935,7 +15935,15 @@ components:
           $ref: '#/components/schemas/AccessToken'
           description: Token metadata returned after creation
           x-speakeasy-param-ordering: 2
+        id:
+          type: integer
+          format: int64
+          description: Unique identifier for the token. Mirrors `token.id`.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
       x-speakeasy-entity: Tokens
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .token.id }'
     CreateActionRequest:
       type: object
       properties:
@@ -15959,6 +15967,13 @@ components:
       properties:
         actionId:
           type: string
+        id:
+          type: string
+          description: Alias of `action_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .actionId }'
     CreateAvatarResponse:
       type: object
       properties:
@@ -16015,6 +16030,13 @@ components:
       properties:
         credentialsId:
           type: string
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
     CreateDatasetRequest:
       type: object
       properties:
@@ -16203,6 +16225,14 @@ components:
         secretId:
           type: integer
           format: int64
+        id:
+          type: integer
+          format: int64
+          description: Alias of `secret_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .secretId }'
     CreatePipelineVersionRequest:
       type: object
       properties:
@@ -23207,7 +23237,14 @@ components:
             format: int64
     CreateAWSComputeEnvResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .computeEnvId }'
       properties:
+        id:
+          type: string
+          description: Alias of `compute_env_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         computeEnvId:
           type: string
     UpdateAWSComputeEnvRequest:
@@ -23319,7 +23356,14 @@ components:
             format: int64
     CreateAWSBatchCEResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .computeEnvId }'
       properties:
+        id:
+          type: string
+          description: Alias of `compute_env_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         computeEnvId:
           type: string
     UpdateAWSBatchCERequest:
@@ -23459,7 +23503,14 @@ components:
             format: int64
     CreateAwsCloudCEResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .computeEnvId }'
       properties:
+        id:
+          type: string
+          description: Alias of `compute_env_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         computeEnvId:
           type: string
     UpdateAwsCloudCERequest:
@@ -23573,7 +23624,14 @@ components:
             format: int64
     CreateAzureBatchCEResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .computeEnvId }'
       properties:
+        id:
+          type: string
+          description: Alias of `compute_env_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         computeEnvId:
           type: string
     UpdateAzureBatchCERequest:
@@ -23687,7 +23745,14 @@ components:
             format: int64
     CreateAzureCloudCEResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .computeEnvId }'
       properties:
+        id:
+          type: string
+          description: Alias of `compute_env_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         computeEnvId:
           type: string
     UpdateAzureCloudCERequest:
@@ -23800,7 +23865,14 @@ components:
             format: int64
     CreateGCPBatchCEResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .computeEnvId }'
       properties:
+        id:
+          type: string
+          description: Alias of `compute_env_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         computeEnvId:
           type: string
     UpdateGCPBatchCERequest:
@@ -23914,7 +23986,14 @@ components:
             format: int64
     CreateGCPCloudCEResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .computeEnvId }'
       properties:
+        id:
+          type: string
+          description: Alias of `compute_env_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         computeEnvId:
           type: string
     UpdateGCPCloudCERequest:
@@ -24110,7 +24189,14 @@ components:
             format: int64
     CreateManagedComputeCEResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .computeEnvId }'
       properties:
+        id:
+          type: string
+          description: Alias of `compute_env_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         computeEnvId:
           type: string
     UpdateManagedComputeCERequest:
@@ -24245,7 +24331,14 @@ components:
           $ref: '#/components/schemas/AWSCredential'
     CreateAWSCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateAWSCredentialsRequest:
@@ -24392,7 +24485,14 @@ components:
           $ref: '#/components/schemas/AzureCredential'
     CreateAzureCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateAzureCredentialsRequest:
@@ -24517,7 +24617,14 @@ components:
           $ref: '#/components/schemas/AzureEntraCredential'
     CreateAzureEntraCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateAzureEntraCredentialsRequest:
@@ -24645,7 +24752,14 @@ components:
           $ref: '#/components/schemas/AzureCloudCredential'
     CreateAzureCloudCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateAzureCloudCredentialsRequest:
@@ -24764,7 +24878,14 @@ components:
           $ref: '#/components/schemas/BitbucketCredential'
     CreateBitbucketCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateBitbucketCredentialsRequest:
@@ -24873,7 +24994,14 @@ components:
           $ref: '#/components/schemas/CodecommitCredential'
     CreateCodecommitCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateCodecommitCredentialsRequest:
@@ -24980,7 +25108,14 @@ components:
           $ref: '#/components/schemas/ContainerRegistryCredential'
     CreateContainerRegistryCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateContainerRegistryCredentialsRequest:
@@ -25098,7 +25233,14 @@ components:
           $ref: '#/components/schemas/GoogleCredential'
     CreateGoogleCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateGoogleCredentialsRequest:
@@ -25209,7 +25351,14 @@ components:
           $ref: '#/components/schemas/GiteaCredential'
     CreateGiteaCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateGiteaCredentialsRequest:
@@ -25317,7 +25466,14 @@ components:
           $ref: '#/components/schemas/GithubCredential'
     CreateGithubCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateGithubCredentialsRequest:
@@ -25425,7 +25581,14 @@ components:
           $ref: '#/components/schemas/GitlabCredential'
     CreateGitlabCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateGitlabCredentialsRequest:
@@ -25529,7 +25692,14 @@ components:
           $ref: '#/components/schemas/KubernetesCredential'
     CreateKubernetesCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateKubernetesCredentialsRequest:
@@ -25623,7 +25793,14 @@ components:
           $ref: '#/components/schemas/SSHCredential'
     CreateSSHCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateSSHCredentialsRequest:
@@ -25730,7 +25907,14 @@ components:
           $ref: "#/components/schemas/TowerAgentCredential"
     CreateTowerAgentCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateTowerAgentCredentialsRequest:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,9 +1,9 @@
-speakeasyVersion: 1.763.1
+speakeasyVersion: 1.763.5
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:8c3a3dd2dd2f5b64144576f0b0ae9749ef1e24c20a1b5e1073900e14bc2b972e
-        sourceBlobDigest: sha256:9179d8805eb60345eac56dcce285365c6f6a9a2e1c853a6f3a5775ac51e98028
+        sourceRevisionDigest: sha256:5d7ab93870574e6186b5856a4659996d7649aa19d83a583398526cccb4a0310d
+        sourceBlobDigest: sha256:c8868905cdc3668c21caa318f5ccec66656d7ac6a237f5e09aeeefe0b4a6c4d1
         tags:
             - latest
             - 1.153.0
@@ -11,8 +11,8 @@ targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:8c3a3dd2dd2f5b64144576f0b0ae9749ef1e24c20a1b5e1073900e14bc2b972e
-        sourceBlobDigest: sha256:9179d8805eb60345eac56dcce285365c6f6a9a2e1c853a6f3a5775ac51e98028
+        sourceRevisionDigest: sha256:5d7ab93870574e6186b5856a4659996d7649aa19d83a583398526cccb4a0310d
+        sourceBlobDigest: sha256:c8868905cdc3668c21caa318f5ccec66656d7ac6a237f5e09aeeefe0b4a6c4d1
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/docs/resources/credential.md
+++ b/docs/resources/credential.md
@@ -113,11 +113,11 @@ must be one of ["aws", "azure", "azure_entra", "azure-cloud", "google", "github"
 - `category` (String) Credentials category
 - `checked` (Boolean) If set credentials deletion will be blocked by running jobs that depend on them
 - `description` (String) Optional description explaining the purpose of the credential
-- `id` (String) Unique identifier for the credential (max 22 characters)
 
 ### Read-Only
 
 - `credentials_id` (String) Credentials string identifier
+- `id` (String) Unique identifier for the credential (max 22 characters)
 
 <a id="nestedatt--keys"></a>
 ### Nested Schema for `keys`

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     seqera = {
       source  = "seqeralabs/seqera"
-      version = "0.40.0-RC7"
+      version = "0.40.0-RC8"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/seqeralabs/terraform-provider-seqera
 
-go 1.25.8
+go 1.26
 
 require (
 	github.com/hashicorp/go-uuid v1.0.3

--- a/internal/provider/action_resource.go
+++ b/internal/provider/action_resource.go
@@ -187,7 +187,10 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Description: `URL endpoint for the webhook that triggers this action`,
 			},
 			"id": schema.StringAttribute{
-				Computed:    true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+				},
 				Description: `Unique identifier for the action`,
 			},
 			"launch": schema.SingleNestedAttribute{

--- a/internal/provider/action_resource_sdk.go
+++ b/internal/provider/action_resource_sdk.go
@@ -850,6 +850,7 @@ func (r *ActionResourceModel) RefreshFromSharedCreateActionResponse(ctx context.
 
 	if resp != nil {
 		r.ActionID = types.StringPointerValue(resp.ActionID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/awsbatchce_resource_sdk.go
+++ b/internal/provider/awsbatchce_resource_sdk.go
@@ -137,6 +137,7 @@ func (r *AWSBatchCEResourceModel) RefreshFromSharedCreateAWSBatchCEResponse(ctx 
 
 	if resp != nil {
 		r.ComputeEnvID = types.StringPointerValue(resp.ComputeEnvID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/awscloudce_resource_sdk.go
+++ b/internal/provider/awscloudce_resource_sdk.go
@@ -97,6 +97,7 @@ func (r *AwsCloudCEResourceModel) RefreshFromSharedCreateAwsCloudCEResponse(ctx 
 
 	if resp != nil {
 		r.ComputeEnvID = types.StringPointerValue(resp.ComputeEnvID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/awscomputeenv_resource_sdk.go
+++ b/internal/provider/awscomputeenv_resource_sdk.go
@@ -133,6 +133,7 @@ func (r *AWSComputeEnvResourceModel) RefreshFromSharedCreateAWSComputeEnvRespons
 
 	if resp != nil {
 		r.ComputeEnvID = types.StringPointerValue(resp.ComputeEnvID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/awscredential_resource_sdk.go
+++ b/internal/provider/awscredential_resource_sdk.go
@@ -45,6 +45,7 @@ func (r *AWSCredentialResourceModel) RefreshFromSharedCreateAWSCredentialsRespon
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/azurebatchce_resource_sdk.go
+++ b/internal/provider/azurebatchce_resource_sdk.go
@@ -116,6 +116,7 @@ func (r *AzureBatchCEResourceModel) RefreshFromSharedCreateAzureBatchCEResponse(
 
 	if resp != nil {
 		r.ComputeEnvID = types.StringPointerValue(resp.ComputeEnvID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/azurecloudce_resource_sdk.go
+++ b/internal/provider/azurecloudce_resource_sdk.go
@@ -71,6 +71,7 @@ func (r *AzureCloudCEResourceModel) RefreshFromSharedCreateAzureCloudCEResponse(
 
 	if resp != nil {
 		r.ComputeEnvID = types.StringPointerValue(resp.ComputeEnvID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/azurecloudcredential_resource_sdk.go
+++ b/internal/provider/azurecloudcredential_resource_sdk.go
@@ -42,6 +42,7 @@ func (r *AzureCloudCredentialResourceModel) RefreshFromSharedCreateAzureCloudCre
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/azurecredential_resource_sdk.go
+++ b/internal/provider/azurecredential_resource_sdk.go
@@ -40,6 +40,7 @@ func (r *AzureCredentialResourceModel) RefreshFromSharedCreateAzureCredentialsRe
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/azureentracredential_resource_sdk.go
+++ b/internal/provider/azureentracredential_resource_sdk.go
@@ -42,6 +42,7 @@ func (r *AzureEntraCredentialResourceModel) RefreshFromSharedCreateAzureEntraCre
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/bitbucketcredential_resource_sdk.go
+++ b/internal/provider/bitbucketcredential_resource_sdk.go
@@ -40,6 +40,7 @@ func (r *BitbucketCredentialResourceModel) RefreshFromSharedCreateBitbucketCrede
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/codecommitcredential_resource_sdk.go
+++ b/internal/provider/codecommitcredential_resource_sdk.go
@@ -40,6 +40,7 @@ func (r *CodecommitCredentialResourceModel) RefreshFromSharedCreateCodecommitCre
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/containerregistrycredential_resource_sdk.go
+++ b/internal/provider/containerregistrycredential_resource_sdk.go
@@ -40,6 +40,7 @@ func (r *ContainerRegistryCredentialResourceModel) RefreshFromSharedCreateContai
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/credential_resource.go
+++ b/internal/provider/credential_resource.go
@@ -85,14 +85,10 @@ func (r *CredentialResource) Schema(ctx context.Context, req resource.SchemaRequ
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
-				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Unique identifier for the credential (max 22 characters)`,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthAtMost(22),
-				},
 			},
 			"keys": schema.SingleNestedAttribute{
 				Required: true,

--- a/internal/provider/credential_resource_sdk.go
+++ b/internal/provider/credential_resource_sdk.go
@@ -16,6 +16,7 @@ func (r *CredentialResourceModel) RefreshFromSharedCreateCredentialsResponse(ctx
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/gcpbatchce_resource_sdk.go
+++ b/internal/provider/gcpbatchce_resource_sdk.go
@@ -19,6 +19,7 @@ func (r *GCPBatchCEResourceModel) RefreshFromSharedCreateGCPBatchCEResponse(ctx 
 
 	if resp != nil {
 		r.ComputeEnvID = types.StringPointerValue(resp.ComputeEnvID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/gcpcloudce_resource_sdk.go
+++ b/internal/provider/gcpcloudce_resource_sdk.go
@@ -18,6 +18,7 @@ func (r *GCPCloudCEResourceModel) RefreshFromSharedCreateGCPCloudCEResponse(ctx 
 
 	if resp != nil {
 		r.ComputeEnvID = types.StringPointerValue(resp.ComputeEnvID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/giteacredential_resource_sdk.go
+++ b/internal/provider/giteacredential_resource_sdk.go
@@ -21,6 +21,7 @@ func (r *GiteaCredentialResourceModel) RefreshFromSharedCreateGiteaCredentialsRe
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/githubcredential_resource_sdk.go
+++ b/internal/provider/githubcredential_resource_sdk.go
@@ -21,6 +21,7 @@ func (r *GithubCredentialResourceModel) RefreshFromSharedCreateGithubCredentials
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/gitlabcredential_resource_sdk.go
+++ b/internal/provider/gitlabcredential_resource_sdk.go
@@ -21,6 +21,7 @@ func (r *GitlabCredentialResourceModel) RefreshFromSharedCreateGitlabCredentials
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/googlecredential_resource_sdk.go
+++ b/internal/provider/googlecredential_resource_sdk.go
@@ -21,6 +21,7 @@ func (r *GoogleCredentialResourceModel) RefreshFromSharedCreateGoogleCredentials
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/kubernetescredential_resource_sdk.go
+++ b/internal/provider/kubernetescredential_resource_sdk.go
@@ -21,6 +21,7 @@ func (r *KubernetesCredentialResourceModel) RefreshFromSharedCreateKubernetesCre
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/managedcomputece_resource_sdk.go
+++ b/internal/provider/managedcomputece_resource_sdk.go
@@ -18,6 +18,7 @@ func (r *ManagedComputeCEResourceModel) RefreshFromSharedCreateManagedComputeCER
 
 	if resp != nil {
 		r.ComputeEnvID = types.StringPointerValue(resp.ComputeEnvID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/pipelinesecret_resource.go
+++ b/internal/provider/pipelinesecret_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	speakeasy_int64planmodifier "github.com/seqeralabs/terraform-provider-seqera/internal/planmodifiers/int64planmodifier"
 	speakeasy_stringplanmodifier "github.com/seqeralabs/terraform-provider-seqera/internal/planmodifiers/stringplanmodifier"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk"
 	"regexp"
@@ -60,7 +61,10 @@ func (r *PipelineSecretResource) Schema(ctx context.Context, req resource.Schema
 				Description: `Timestamp when the secret was created`,
 			},
 			"id": schema.Int64Attribute{
-				Computed:    true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					speakeasy_int64planmodifier.SuppressDiff(speakeasy_int64planmodifier.ExplicitSuppress),
+				},
 				Description: `Unique numeric identifier for the secret`,
 			},
 			"last_updated": schema.StringAttribute{

--- a/internal/provider/pipelinesecret_resource_sdk.go
+++ b/internal/provider/pipelinesecret_resource_sdk.go
@@ -15,6 +15,7 @@ func (r *PipelineSecretResourceModel) RefreshFromSharedCreatePipelineSecretRespo
 	var diags diag.Diagnostics
 
 	if resp != nil {
+		r.ID = types.Int64PointerValue(resp.ID)
 		r.SecretID = types.Int64PointerValue(resp.SecretID)
 	}
 

--- a/internal/provider/sshcredential_resource_sdk.go
+++ b/internal/provider/sshcredential_resource_sdk.go
@@ -21,6 +21,7 @@ func (r *SSHCredentialResourceModel) RefreshFromSharedCreateSSHCredentialsRespon
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/provider/tokens_resource.go
+++ b/internal/provider/tokens_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	speakeasy_int64planmodifier "github.com/seqeralabs/terraform-provider-seqera/internal/planmodifiers/int64planmodifier"
 	speakeasy_stringplanmodifier "github.com/seqeralabs/terraform-provider-seqera/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/seqeralabs/terraform-provider-seqera/internal/provider/types"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk"
@@ -62,7 +63,10 @@ func (r *TokensResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Description: `Timestamp when the token was created`,
 			},
 			"id": schema.Int64Attribute{
-				Computed:    true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					speakeasy_int64planmodifier.SuppressDiff(speakeasy_int64planmodifier.ExplicitSuppress),
+				},
 				Description: `Unique identifier for the token`,
 			},
 			"last_used": schema.StringAttribute{

--- a/internal/provider/tokens_resource_sdk.go
+++ b/internal/provider/tokens_resource_sdk.go
@@ -27,6 +27,7 @@ func (r *TokensResourceModel) RefreshFromSharedCreateAccessTokenResponse(ctx con
 
 	if resp != nil {
 		r.AccessKey = types.StringPointerValue(resp.AccessKey)
+		r.ID = types.Int64PointerValue(resp.ID)
 		if resp.Token == nil {
 			r.Token = nil
 		} else {

--- a/internal/provider/toweragentcredential_resource_sdk.go
+++ b/internal/provider/toweragentcredential_resource_sdk.go
@@ -15,6 +15,7 @@ func (r *TowerAgentCredentialResourceModel) RefreshFromSharedCreateTowerAgentCre
 
 	if resp != nil {
 		r.CredentialsID = types.StringPointerValue(resp.CredentialsID)
+		r.ID = types.StringPointerValue(resp.ID)
 	}
 
 	return diags

--- a/internal/sdk/models/shared/createaccesstokenresponse.go
+++ b/internal/sdk/models/shared/createaccesstokenresponse.go
@@ -2,6 +2,10 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAccessTokenResponse struct {
 	// The actual token value for authentication. This sensitive value is ONLY
 	// returned when the token is created and cannot be retrieved later.
@@ -12,6 +16,24 @@ type CreateAccessTokenResponse struct {
 	// Contains the token ID, name, and usage metadata.
 	//
 	Token *AccessToken `json:"token,omitempty"`
+	// Unique identifier for the token. Mirrors `token.id`.
+	ID *int64 `json:"id,omitempty"`
+}
+
+func (c CreateAccessTokenResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAccessTokenResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .token.id }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *CreateAccessTokenResponse) GetAccessKey() *string {
@@ -26,4 +48,11 @@ func (c *CreateAccessTokenResponse) GetToken() *AccessToken {
 		return nil
 	}
 	return c.Token
+}
+
+func (c *CreateAccessTokenResponse) GetID() *int64 {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }

--- a/internal/sdk/models/shared/createactionresponse.go
+++ b/internal/sdk/models/shared/createactionresponse.go
@@ -2,8 +2,30 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateActionResponse struct {
 	ActionID *string `json:"actionId,omitempty"`
+	// Alias of `action_id` for Terraform convention.
+	ID *string `json:"id,omitempty"`
+}
+
+func (c CreateActionResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateActionResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .actionId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *CreateActionResponse) GetActionID() *string {
@@ -11,4 +33,11 @@ func (c *CreateActionResponse) GetActionID() *string {
 		return nil
 	}
 	return c.ActionID
+}
+
+func (c *CreateActionResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }

--- a/internal/sdk/models/shared/createawsbatchceresponse.go
+++ b/internal/sdk/models/shared/createawsbatchceresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAWSBatchCEResponse struct {
+	// Alias of `compute_env_id` for Terraform convention.
+	ID           *string `json:"id,omitempty"`
 	ComputeEnvID *string `json:"computeEnvId,omitempty"`
+}
+
+func (c CreateAWSBatchCEResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAWSBatchCEResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .computeEnvId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAWSBatchCEResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAWSBatchCEResponse) GetComputeEnvID() *string {

--- a/internal/sdk/models/shared/createawscloudceresponse.go
+++ b/internal/sdk/models/shared/createawscloudceresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAwsCloudCEResponse struct {
+	// Alias of `compute_env_id` for Terraform convention.
+	ID           *string `json:"id,omitempty"`
 	ComputeEnvID *string `json:"computeEnvId,omitempty"`
+}
+
+func (c CreateAwsCloudCEResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAwsCloudCEResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .computeEnvId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAwsCloudCEResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAwsCloudCEResponse) GetComputeEnvID() *string {

--- a/internal/sdk/models/shared/createawscomputeenvresponse.go
+++ b/internal/sdk/models/shared/createawscomputeenvresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAWSComputeEnvResponse struct {
+	// Alias of `compute_env_id` for Terraform convention.
+	ID           *string `json:"id,omitempty"`
 	ComputeEnvID *string `json:"computeEnvId,omitempty"`
+}
+
+func (c CreateAWSComputeEnvResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAWSComputeEnvResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .computeEnvId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAWSComputeEnvResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAWSComputeEnvResponse) GetComputeEnvID() *string {

--- a/internal/sdk/models/shared/createawscredentialsresponse.go
+++ b/internal/sdk/models/shared/createawscredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAWSCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateAWSCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAWSCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAWSCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAWSCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createazurebatchceresponse.go
+++ b/internal/sdk/models/shared/createazurebatchceresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAzureBatchCEResponse struct {
+	// Alias of `compute_env_id` for Terraform convention.
+	ID           *string `json:"id,omitempty"`
 	ComputeEnvID *string `json:"computeEnvId,omitempty"`
+}
+
+func (c CreateAzureBatchCEResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAzureBatchCEResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .computeEnvId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAzureBatchCEResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAzureBatchCEResponse) GetComputeEnvID() *string {

--- a/internal/sdk/models/shared/createazurecloudceresponse.go
+++ b/internal/sdk/models/shared/createazurecloudceresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAzureCloudCEResponse struct {
+	// Alias of `compute_env_id` for Terraform convention.
+	ID           *string `json:"id,omitempty"`
 	ComputeEnvID *string `json:"computeEnvId,omitempty"`
+}
+
+func (c CreateAzureCloudCEResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAzureCloudCEResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .computeEnvId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAzureCloudCEResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAzureCloudCEResponse) GetComputeEnvID() *string {

--- a/internal/sdk/models/shared/createazurecloudcredentialsresponse.go
+++ b/internal/sdk/models/shared/createazurecloudcredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAzureCloudCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateAzureCloudCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAzureCloudCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAzureCloudCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAzureCloudCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createazurecredentialsresponse.go
+++ b/internal/sdk/models/shared/createazurecredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAzureCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateAzureCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAzureCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAzureCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAzureCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createazureentracredentialsresponse.go
+++ b/internal/sdk/models/shared/createazureentracredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateAzureEntraCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateAzureEntraCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateAzureEntraCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateAzureEntraCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateAzureEntraCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createbitbucketcredentialsresponse.go
+++ b/internal/sdk/models/shared/createbitbucketcredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateBitbucketCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateBitbucketCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateBitbucketCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateBitbucketCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateBitbucketCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createcodecommitcredentialsresponse.go
+++ b/internal/sdk/models/shared/createcodecommitcredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateCodecommitCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateCodecommitCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateCodecommitCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateCodecommitCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateCodecommitCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createcontainerregistrycredentialsresponse.go
+++ b/internal/sdk/models/shared/createcontainerregistrycredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateContainerRegistryCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateContainerRegistryCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateContainerRegistryCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateContainerRegistryCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateContainerRegistryCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createcredentialsresponse.go
+++ b/internal/sdk/models/shared/createcredentialsresponse.go
@@ -2,8 +2,30 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateCredentialsResponse struct {
 	CredentialsID *string `json:"credentialsId,omitempty"`
+	// Alias of `credentials_id` for Terraform convention.
+	ID *string `json:"id,omitempty"`
+}
+
+func (c CreateCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *CreateCredentialsResponse) GetCredentialsID() *string {
@@ -11,4 +33,11 @@ func (c *CreateCredentialsResponse) GetCredentialsID() *string {
 		return nil
 	}
 	return c.CredentialsID
+}
+
+func (c *CreateCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }

--- a/internal/sdk/models/shared/creategcpbatchceresponse.go
+++ b/internal/sdk/models/shared/creategcpbatchceresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateGCPBatchCEResponse struct {
+	// Alias of `compute_env_id` for Terraform convention.
+	ID           *string `json:"id,omitempty"`
 	ComputeEnvID *string `json:"computeEnvId,omitempty"`
+}
+
+func (c CreateGCPBatchCEResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateGCPBatchCEResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .computeEnvId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateGCPBatchCEResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateGCPBatchCEResponse) GetComputeEnvID() *string {

--- a/internal/sdk/models/shared/creategcpcloudceresponse.go
+++ b/internal/sdk/models/shared/creategcpcloudceresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateGCPCloudCEResponse struct {
+	// Alias of `compute_env_id` for Terraform convention.
+	ID           *string `json:"id,omitempty"`
 	ComputeEnvID *string `json:"computeEnvId,omitempty"`
+}
+
+func (c CreateGCPCloudCEResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateGCPCloudCEResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .computeEnvId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateGCPCloudCEResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateGCPCloudCEResponse) GetComputeEnvID() *string {

--- a/internal/sdk/models/shared/creategiteacredentialsresponse.go
+++ b/internal/sdk/models/shared/creategiteacredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateGiteaCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateGiteaCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateGiteaCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateGiteaCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateGiteaCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/creategithubcredentialsresponse.go
+++ b/internal/sdk/models/shared/creategithubcredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateGithubCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateGithubCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateGithubCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateGithubCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateGithubCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/creategitlabcredentialsresponse.go
+++ b/internal/sdk/models/shared/creategitlabcredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateGitlabCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateGitlabCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateGitlabCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateGitlabCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateGitlabCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/creategooglecredentialsresponse.go
+++ b/internal/sdk/models/shared/creategooglecredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateGoogleCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateGoogleCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateGoogleCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateGoogleCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateGoogleCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createkubernetescredentialsresponse.go
+++ b/internal/sdk/models/shared/createkubernetescredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateKubernetesCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateKubernetesCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateKubernetesCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateKubernetesCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateKubernetesCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createmanagedcomputeceresponse.go
+++ b/internal/sdk/models/shared/createmanagedcomputeceresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateManagedComputeCEResponse struct {
+	// Alias of `compute_env_id` for Terraform convention.
+	ID           *string `json:"id,omitempty"`
 	ComputeEnvID *string `json:"computeEnvId,omitempty"`
+}
+
+func (c CreateManagedComputeCEResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateManagedComputeCEResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .computeEnvId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateManagedComputeCEResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateManagedComputeCEResponse) GetComputeEnvID() *string {

--- a/internal/sdk/models/shared/createpipelinesecretresponse.go
+++ b/internal/sdk/models/shared/createpipelinesecretresponse.go
@@ -2,8 +2,30 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreatePipelineSecretResponse struct {
 	SecretID *int64 `json:"secretId,omitempty"`
+	// Alias of `secret_id` for Terraform convention.
+	ID *int64 `json:"id,omitempty"`
+}
+
+func (c CreatePipelineSecretResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreatePipelineSecretResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .secretId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *CreatePipelineSecretResponse) GetSecretID() *int64 {
@@ -11,4 +33,11 @@ func (c *CreatePipelineSecretResponse) GetSecretID() *int64 {
 		return nil
 	}
 	return c.SecretID
+}
+
+func (c *CreatePipelineSecretResponse) GetID() *int64 {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }

--- a/internal/sdk/models/shared/createsshcredentialsresponse.go
+++ b/internal/sdk/models/shared/createsshcredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateSSHCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateSSHCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateSSHCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateSSHCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateSSHCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/models/shared/createtoweragentcredentialsresponse.go
+++ b/internal/sdk/models/shared/createtoweragentcredentialsresponse.go
@@ -2,8 +2,37 @@
 
 package shared
 
+import (
+	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
+)
+
 type CreateTowerAgentCredentialsResponse struct {
+	// Alias of `credentials_id` for Terraform convention.
+	ID            *string `json:"id,omitempty"`
 	CredentialsID *string `json:"credentialsId,omitempty"`
+}
+
+func (c CreateTowerAgentCredentialsResponse) MarshalJSON() ([]byte, error) {
+	return utils.MarshalJSON(c, "", false)
+}
+
+func (c *CreateTowerAgentCredentialsResponse) UnmarshalJSON(data []byte) error {
+	if out, err := utils.RunJQBytes(data, ". + { id: .credentialsId }"); err != nil {
+		return err
+	} else {
+		data = out
+	}
+	if err := utils.UnmarshalJSON(data, &c, "", false, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *CreateTowerAgentCredentialsResponse) GetID() *string {
+	if c == nil {
+		return nil
+	}
+	return c.ID
 }
 
 func (c *CreateTowerAgentCredentialsResponse) GetCredentialsID() *string {

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.153.0 and generator version 2.884.4
+// Generated from OpenAPI doc version 1.153.0 and generator version 2.884.11
 
 import (
 	"context"
@@ -173,9 +173,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
-		SDKVersion: "0.40.0-RC7",
+		SDKVersion: "0.40.0-RC8",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC7 2.884.4 1.153.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.40.0-RC8 2.884.11 1.153.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/overlays/actions.yaml
+++ b/overlays/actions.yaml
@@ -342,3 +342,14 @@ actions:
   - target: $.components.schemas.LaunchDbDto.properties.launchContainer
     update:
       x-speakeasy-param-readonly: true
+
+  - target: $.components.schemas.CreateActionResponse
+    update:
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .actionId }'
+      properties:
+        id:
+          type: string
+          description: Alias of `action_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true

--- a/overlays/aws-compute-env.yaml
+++ b/overlays/aws-compute-env.yaml
@@ -363,7 +363,14 @@ actions:
 
       CreateAWSComputeEnvResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .computeEnvId }'
         properties:
+          id:
+            type: string
+            description: Alias of `compute_env_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           computeEnvId:
             type: string
 

--- a/overlays/compute-env-aws-batch.yaml
+++ b/overlays/compute-env-aws-batch.yaml
@@ -360,7 +360,14 @@ actions:
 
       CreateAWSBatchCEResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .computeEnvId }'
         properties:
+          id:
+            type: string
+            description: Alias of `compute_env_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           computeEnvId:
             type: string
 

--- a/overlays/compute-env-aws-cloud.yaml
+++ b/overlays/compute-env-aws-cloud.yaml
@@ -343,7 +343,14 @@ actions:
 
       CreateAwsCloudCEResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .computeEnvId }'
         properties:
+          id:
+            type: string
+            description: Alias of `compute_env_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           computeEnvId:
             type: string
 

--- a/overlays/compute-env-azure-batch.yaml
+++ b/overlays/compute-env-azure-batch.yaml
@@ -340,7 +340,14 @@ actions:
 
       CreateAzureBatchCEResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .computeEnvId }'
         properties:
+          id:
+            type: string
+            description: Alias of `compute_env_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           computeEnvId:
             type: string
 

--- a/overlays/compute-env-azure-cloud.yaml
+++ b/overlays/compute-env-azure-cloud.yaml
@@ -343,7 +343,14 @@ actions:
 
       CreateAzureCloudCEResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .computeEnvId }'
         properties:
+          id:
+            type: string
+            description: Alias of `compute_env_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           computeEnvId:
             type: string
 

--- a/overlays/compute-env-gcp-batch.yaml
+++ b/overlays/compute-env-gcp-batch.yaml
@@ -339,7 +339,14 @@ actions:
 
       CreateGCPBatchCEResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .computeEnvId }'
         properties:
+          id:
+            type: string
+            description: Alias of `compute_env_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           computeEnvId:
             type: string
 

--- a/overlays/compute-env-gcp-cloud.yaml
+++ b/overlays/compute-env-gcp-cloud.yaml
@@ -341,7 +341,14 @@ actions:
 
       CreateGCPCloudCEResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .computeEnvId }'
         properties:
+          id:
+            type: string
+            description: Alias of `compute_env_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           computeEnvId:
             type: string
 

--- a/overlays/compute-env-seqera-compute.yaml
+++ b/overlays/compute-env-seqera-compute.yaml
@@ -456,7 +456,14 @@ actions:
 
       CreateManagedComputeCEResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .computeEnvId }'
         properties:
+          id:
+            type: string
+            description: Alias of `compute_env_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           computeEnvId:
             type: string
 

--- a/overlays/credentials-aws.yaml
+++ b/overlays/credentials-aws.yaml
@@ -324,7 +324,14 @@ actions:
           $ref: '#/components/schemas/AWSCredential'
     CreateAWSCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateAWSCredentialsRequest:

--- a/overlays/credentials-azure-cloud.yaml
+++ b/overlays/credentials-azure-cloud.yaml
@@ -312,7 +312,14 @@ actions:
           $ref: '#/components/schemas/AzureCloudCredential'
     CreateAzureCloudCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateAzureCloudCredentialsRequest:

--- a/overlays/credentials-azure-entra.yaml
+++ b/overlays/credentials-azure-entra.yaml
@@ -309,7 +309,14 @@ actions:
           $ref: '#/components/schemas/AzureEntraCredential'
     CreateAzureEntraCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateAzureEntraCredentialsRequest:

--- a/overlays/credentials-azure.yaml
+++ b/overlays/credentials-azure.yaml
@@ -335,7 +335,14 @@ actions:
           $ref: '#/components/schemas/AzureCredential'
     CreateAzureCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateAzureCredentialsRequest:

--- a/overlays/credentials-bitbucket.yaml
+++ b/overlays/credentials-bitbucket.yaml
@@ -297,7 +297,14 @@ actions:
           $ref: '#/components/schemas/BitbucketCredential'
     CreateBitbucketCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateBitbucketCredentialsRequest:

--- a/overlays/credentials-codecommit.yaml
+++ b/overlays/credentials-codecommit.yaml
@@ -288,7 +288,14 @@ actions:
           $ref: '#/components/schemas/CodecommitCredential'
     CreateCodecommitCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateCodecommitCredentialsRequest:

--- a/overlays/credentials-container-registry.yaml
+++ b/overlays/credentials-container-registry.yaml
@@ -288,7 +288,14 @@ actions:
           $ref: '#/components/schemas/ContainerRegistryCredential'
     CreateContainerRegistryCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateContainerRegistryCredentialsRequest:

--- a/overlays/credentials-gcp.yaml
+++ b/overlays/credentials-gcp.yaml
@@ -308,7 +308,14 @@ actions:
           $ref: '#/components/schemas/GoogleCredential'
     CreateGoogleCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateGoogleCredentialsRequest:

--- a/overlays/credentials-gitea.yaml
+++ b/overlays/credentials-gitea.yaml
@@ -290,7 +290,14 @@ actions:
           $ref: '#/components/schemas/GiteaCredential'
     CreateGiteaCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateGiteaCredentialsRequest:

--- a/overlays/credentials-github.yaml
+++ b/overlays/credentials-github.yaml
@@ -289,7 +289,14 @@ actions:
           $ref: '#/components/schemas/GithubCredential'
     CreateGithubCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateGithubCredentialsRequest:

--- a/overlays/credentials-gitlab.yaml
+++ b/overlays/credentials-gitlab.yaml
@@ -289,7 +289,14 @@ actions:
           $ref: '#/components/schemas/GitlabCredential'
     CreateGitlabCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateGitlabCredentialsRequest:

--- a/overlays/credentials-kubernetes.yaml
+++ b/overlays/credentials-kubernetes.yaml
@@ -284,7 +284,14 @@ actions:
           $ref: '#/components/schemas/KubernetesCredential'
     CreateKubernetesCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateKubernetesCredentialsRequest:

--- a/overlays/credentials-ssh.yaml
+++ b/overlays/credentials-ssh.yaml
@@ -271,7 +271,14 @@ actions:
           $ref: '#/components/schemas/SSHCredential'
     CreateSSHCredentialsResponse:
       type: object
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
       properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true
         credentialsId:
           type: string
     UpdateSSHCredentialsRequest:

--- a/overlays/credentials-tower-agent.yaml
+++ b/overlays/credentials-tower-agent.yaml
@@ -287,7 +287,14 @@ actions:
             $ref: "#/components/schemas/TowerAgentCredential"
       CreateTowerAgentCredentialsResponse:
         type: object
+        x-speakeasy-transform-from-api:
+          jq: '. + { id: .credentialsId }'
         properties:
+          id:
+            type: string
+            description: Alias of `credentials_id` for Terraform convention.
+            x-speakeasy-param-readonly: true
+            x-speakeasy-param-suppress-computed-diff: true
           credentialsId:
             type: string
       UpdateTowerAgentCredentialsRequest:

--- a/overlays/credentials.yaml
+++ b/overlays/credentials.yaml
@@ -248,3 +248,14 @@ actions:
   - target: $.components.schemas.Credentials.properties.deleted
     update:
       description: Flag indicating if the credential has been soft-deleted
+
+  - target: $.components.schemas.CreateCredentialsResponse
+    update:
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .credentialsId }'
+      properties:
+        id:
+          type: string
+          description: Alias of `credentials_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true

--- a/overlays/pipeline-secrets.yaml
+++ b/overlays/pipeline-secrets.yaml
@@ -200,3 +200,15 @@ actions:
   - target: $.components.schemas.CreatePipelineSecretRequest.properties.value
     update:
       example: "secret_value_here"
+
+  - target: $.components.schemas.CreatePipelineSecretResponse
+    update:
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .secretId }'
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Alias of `secret_id` for Terraform convention.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true

--- a/overlays/tokens.yaml
+++ b/overlays/tokens.yaml
@@ -158,7 +158,20 @@ actions:
   ####################################################################
   ####                Schema Overrides                            ####
   ####################################################################
-  # Response schema annotations
+  # Response schema annotations. Also lift the nested `token.id` to a
+  # top-level `id` alias so the resource's Computed `id` attribute is
+  # populated after Create — without this the Create refresh leaves
+  # `seqera_tokens.foo.id` Unknown and Terraform errors with
+  # "Provider returned invalid result object after apply".
   - target: $.components.schemas.CreateAccessTokenResponse
     update:
       x-speakeasy-entity: Tokens
+      x-speakeasy-transform-from-api:
+        jq: '. + { id: .token.id }'
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Unique identifier for the token. Mirrors `token.id`.
+          x-speakeasy-param-readonly: true
+          x-speakeasy-param-suppress-computed-diff: true


### PR DESCRIPTION
The following fixes a state bug where the newly introduced `.id` alias was not known after apply for credential create responses. 