### PR TITLE
feat: support Azure Batch boot disk size

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,10 +1,10 @@
 lockVersion: 2.0.0
 id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
-  docChecksum: ca0e12ecb5f8474a4a41b67f1a91c086
-  docVersion: 1.153.0
-  speakeasyVersion: 1.777.2
-  generationVersion: 2.903.5
+  docChecksum: c797d07e4e8c42002edba90b190e8c1e
+  docVersion: 1.159.0
+  speakeasyVersion: 1.785.0
+  generationVersion: 2.912.1
   releaseVersion: 0.40.2
   configChecksum: be5287cb9bc8dbd12dec8d589bf94764
 persistentEdits:
@@ -26,7 +26,7 @@ features:
     inputOutputModels: 2.83.0
     nameOverrides: 2.81.7
     nullables: 0.0.0
-    retries: 2.81.4
+    retries: 2.81.5
     transformJq: 0.0.1
     unions: 2.82.15
 trackedFiles:
@@ -426,11 +426,11 @@ trackedFiles:
     pristine_git_object: 0ea64fbeb1fd7709d7241a8e06d34bfe9d0323d3
   internal/provider/action_resource.go:
     id: f7c19bf35b58
-    last_write_checksum: sha1:3aaf2d184814c4f1609a2fa96db43c1f6be77507
+    last_write_checksum: sha1:69176cf0daf0e241901fea820b21b00a10853115
     pristine_git_object: fc35041e2f1cf6db01d04e9e9e861df96d042782
   internal/provider/action_resource_sdk.go:
     id: 28576317893d
-    last_write_checksum: sha1:2934a75a2452d99b09153566dc113b8408a8b1d2
+    last_write_checksum: sha1:d707481fc6da1ea997caea847c0f81006ddad23d
     pristine_git_object: b987eb32b2d86ebe52fb9875e9e4b6eb9f30af6e
   internal/provider/awsbatchce_resource.go:
     id: aeeab49ad69b
@@ -461,9 +461,9 @@ trackedFiles:
     last_write_checksum: sha1:7c5985ec470f43666b2a5860949f2d8ad5b4a5a1
     pristine_git_object: fb79abddd43fc8a362ddaff379637c1def78665a
   internal/provider/azurebatchce_resource.go:
-    last_write_checksum: sha1:e452e863bd534d4d8132c78e084e109cf0e50af8
+    last_write_checksum: sha1:1ce321f12f3670cb644efcbc9827e82edebd7024
   internal/provider/azurebatchce_resource_sdk.go:
-    last_write_checksum: sha1:02a46cc8545558a1e2eabaea102115aea025e8bc
+    last_write_checksum: sha1:834fb91d5dc049549663c97046e63336382b08ca
   internal/provider/azurecloudce_resource.go:
     last_write_checksum: sha1:73f3875c6e5be74a32d273e590cd53455ac2f5cd
   internal/provider/azurecloudce_resource_sdk.go:
@@ -502,11 +502,11 @@ trackedFiles:
     pristine_git_object: 0c1b43d5db49b023cf3c7408c198a4d66c795d8a
   internal/provider/computeenv_resource.go:
     id: f4162f219efd
-    last_write_checksum: sha1:e7f3533c0944b86532fe2fc33d927255fde393cf
+    last_write_checksum: sha1:4fb3a753c6c5e3871e2b5bec594c7ae6b0b8393f
     pristine_git_object: d5550a0a3bc980d281c55531d71458e7e4968b48
   internal/provider/computeenv_resource_sdk.go:
     id: 1e29eea44332
-    last_write_checksum: sha1:3c97e7c9b9ecffda4282141b91e7a9f35ab04b68
+    last_write_checksum: sha1:3c277fb3f4710651090a42c3341e0c22de7f2256
     pristine_git_object: 2e933070714e8aa8d9ab83f2e1b81abd6f262ade
   internal/provider/containerregistrycredential_resource.go:
     id: f0a18857f2ea
@@ -637,10 +637,10 @@ trackedFiles:
     last_write_checksum: sha1:62e7d80e48a82f86cdf811dca8a8c84aa1d41f82
     pristine_git_object: fe81d09c0d5656f2f24a007997800ddfa455d8b7
   internal/provider/pipeline_resource.go:
-    last_write_checksum: sha1:44a3a60e12542ef85beaf0eab92bd2058fb33537
+    last_write_checksum: sha1:97a07a4ab351664def9bd8c0f89b49f403188cdd
   internal/provider/pipeline_resource_sdk.go:
     id: c3bca9acd758
-    last_write_checksum: sha1:50b29b72fc2088c5865c96015ece1044f3d15b07
+    last_write_checksum: sha1:0846d51763115790068024e9bdfdfb4a00a5f597
     pristine_git_object: eb186d4cf2287bf1eec7eb07d9b9c7e0386b7b26
   internal/provider/pipelinesecret_resource.go:
     id: 5319f8284106
@@ -775,7 +775,7 @@ trackedFiles:
     last_write_checksum: sha1:6f4934c3be48ebd95c2a3394bf20d66416bbf201
     pristine_git_object: 34466719915d7901b6891482d43ebdf8a82252b5
   internal/provider/types/action_launch_request.go:
-    last_write_checksum: sha1:c8db62ceaba6c73e80869964f72a4eee7846db82
+    last_write_checksum: sha1:4cdf566a35c004f3022da62ca4e1b37c392f0e6f
   internal/provider/types/action_tower_action_config.go:
     id: 0636d437cb70
     last_write_checksum: sha1:88f1aa72102b724b6169fdafab127e8f23d62790
@@ -814,10 +814,10 @@ trackedFiles:
     last_write_checksum: sha1:8bdfd8657e00d9cd09490698ec5fbaad14a71637
   internal/provider/types/az_batch_forge_config.go:
     id: 43a33efe791e
-    last_write_checksum: sha1:673d1d80d1b6a56bbbda1827521ec89b59483708
+    last_write_checksum: sha1:ecbb38344e9ad8985a73c15bb5570e5cc4b6a0a2
     pristine_git_object: 12c7bdfaa94860c8c611890dff13fd0635affd05
   internal/provider/types/az_batch_pool_config.go:
-    last_write_checksum: sha1:59ae1cf1de55768255d7c0b7f15c8b3b1abddebc
+    last_write_checksum: sha1:2f91f588a8ff393b65d1e705e934648dfe29f573
   internal/provider/types/az_cloud_config.go:
     last_write_checksum: sha1:50a6f99e1fe960d077ed0eebffaa5bf3d7597c1c
   internal/provider/types/azure_batch_configuration.go:
@@ -1006,7 +1006,7 @@ trackedFiles:
     pristine_git_object: 4103cca9f88b2e8e142ba6023efb0383d00b211a
   internal/provider/types/workflow_launch_request.go:
     id: af36165a8643
-    last_write_checksum: sha1:cd59229333c381d7582c3d171738e5c6c0b293c3
+    last_write_checksum: sha1:c4b8fc621f3d533f87e8a737e9ce81699cf39095
     pristine_git_object: 11b31ac54b41f1ff6655e5775689da9baec929f7
   internal/provider/utils.go:
     id: 312d50f148af
@@ -1014,11 +1014,11 @@ trackedFiles:
     pristine_git_object: 9cc78dd1f7684941df14144df744dad2b23885f9
   internal/provider/workflows_resource.go:
     id: efcad015245a
-    last_write_checksum: sha1:0e9af35f0cca8946c35a24878a2d8dbbdcff3f2c
+    last_write_checksum: sha1:e4222292e1137a761dec41d9eb72ecf47fec7dbc
     pristine_git_object: 2ec8cdfba570a37c74c14055a3d9ffa12fe8881c
   internal/provider/workflows_resource_sdk.go:
     id: ee2d992725aa
-    last_write_checksum: sha1:c9d2366d190263bacc49a1011444bd13afac34c7
+    last_write_checksum: sha1:07ee3d11da310bd85858ea5c1097c02ffdfc6732
     pristine_git_object: 32dd5a54a21939c3cfa3c2ada55b841cb54032f9
   internal/provider/workspace_resource.go:
     id: 4255ab3c913f
@@ -1903,7 +1903,7 @@ trackedFiles:
     last_write_checksum: sha1:64df2516cf6a72f0bad118493dbffeff328b2c80
     pristine_git_object: 0684ca2f6f1d8645975c8457f0ece0f43a305a5a
   internal/sdk/models/operations/listdatastudiocompatiblecomputeenvs.go:
-    last_write_checksum: sha1:ecc7b7d1a5f34228bb5b5d9002233601f2dc0a40
+    last_write_checksum: sha1:437e051de21bc0bf82575212e5963e6dcea1a69a
   internal/sdk/models/operations/listdatastudios.go:
     id: e12f2928c4e6
     last_write_checksum: sha1:3e53b601ec90747387961dc86fa237a02e4b0236
@@ -2321,7 +2321,7 @@ trackedFiles:
     last_write_checksum: sha1:ad02e4ee4991f38caab91983a4832a9eb47be28e
     pristine_git_object: 730a625fa6922c93c90574273666fec9cdc3b496
   internal/sdk/models/shared/actionlaunchrequest.go:
-    last_write_checksum: sha1:61d30b92f03a93e330a4ad543a6b3c32bfc6e38f
+    last_write_checksum: sha1:f7e5211d3ad1f09872f8f3460f0bb610d59eaa1e
   internal/sdk/models/shared/actionqueryattribute.go:
     id: fc49f81f9928
     last_write_checksum: sha1:4b9dd187de1586826868830da4ff5ae13fbbcef7
@@ -2424,14 +2424,14 @@ trackedFiles:
     last_write_checksum: sha1:ffb9a9a8878dd8488bbc3ee984c868be14569677
   internal/sdk/models/shared/azbatchforgeconfig.go:
     id: d13b3a409e31
-    last_write_checksum: sha1:6962a8e3f37043fd959fc4a82024400f66150d78
+    last_write_checksum: sha1:ae114fcb9a7379ddf0a15922488314803eb63b85
     pristine_git_object: dc5d7127f390fe2d4b560e69d3e2ac5ae3e97911
   internal/sdk/models/shared/azbatchplatformmetainfo.go:
     id: 26da3f95b1e5
     last_write_checksum: sha1:2c2702eceee646a8d81d8b52cbad5e62f9380258
     pristine_git_object: 92c4406321976b69060298a0bf6771e65e27838d
   internal/sdk/models/shared/azbatchpoolconfig.go:
-    last_write_checksum: sha1:ef193d583de59c4fc6792341365d8a9a48341ee3
+    last_write_checksum: sha1:b3bc917254e5acf45a5ddaebe6a1ef7defe73ccb
   internal/sdk/models/shared/azcloudconfig.go:
     last_write_checksum: sha1:ceb669a5d57f1c05986190cd321318b76622f486
   internal/sdk/models/shared/azurebatchcecomputeconfiginput.go:
@@ -2890,7 +2890,7 @@ trackedFiles:
     pristine_git_object: dbc35210f6dc126f6711385c789c854c0b259396
   internal/sdk/models/shared/datasetversiondto.go:
     id: 1f228cf15b72
-    last_write_checksum: sha1:112384f5e68eef262db0fd898210f72dc61d973d
+    last_write_checksum: sha1:705b46f57f434f39447d8fdb2466eba6f3105d7c
     pristine_git_object: 0587a5793ac51e565d25e5084d2440153d08009f
   internal/sdk/models/shared/datastudiocheckpointdto.go:
     id: 30033bf61a25
@@ -3152,7 +3152,7 @@ trackedFiles:
     pristine_git_object: 4d50a2aa4f9d347610611cd2c7dbb0c13584944a
   internal/sdk/models/shared/describeworkflowresponse.go:
     id: cb46c0306832
-    last_write_checksum: sha1:5fa2c2ab4d9d4ce261a0f01244e342e719ab1ae3
+    last_write_checksum: sha1:762650aa1b04e298f3486bbfa046ad8d5921262d
     pristine_git_object: 43bc140ba6761af9a9802c976cd34258868edbe5
   internal/sdk/models/shared/describeworkspaceresponse.go:
     id: 5b7149929e4d
@@ -3293,7 +3293,7 @@ trackedFiles:
     last_write_checksum: sha1:df630144fbe276623a0d21b4fb5771e4c829b062
     pristine_git_object: 0ac170c9ca4204d1d3cd7e2cdd67041692cd6449
   internal/sdk/models/shared/launchdbdto.go:
-    last_write_checksum: sha1:4266db95456c399435271cfe25f439063e9dad0c
+    last_write_checksum: sha1:d7d7d8dc4e674dba00a54ebd74c7130d7031db5b
   internal/sdk/models/shared/linkedsourcedto.go:
     last_write_checksum: sha1:aaca7862a2fa767873e9216ae73228ed828d3d1d
   internal/sdk/models/shared/linkversionrequest.go:
@@ -3924,7 +3924,7 @@ trackedFiles:
     last_write_checksum: sha1:16102510d016ad90544f6b4a708cc1c5d298db3a
   internal/sdk/models/shared/workflowlaunchrequest.go:
     id: 2b0df021cbad
-    last_write_checksum: sha1:71ec980aca6b037c1c0d963994bb8610d321749d
+    last_write_checksum: sha1:b8122789e52939bfbe454bac4e542b4385151582
     pristine_git_object: 610d44495458858e298def213b53372951961f8e
   internal/sdk/models/shared/workflowlaunchresponse.go:
     id: 58befbe96295
@@ -3996,13 +3996,13 @@ trackedFiles:
     pristine_git_object: d07fa87cfd1375e9b69b5bf95f4cce5884a4f4f4
   internal/sdk/retry/config.go:
     id: 7ea5fa9128b6
-    last_write_checksum: sha1:7f7d96b59a18e95bac847ae09c63bbd911ee8432
+    last_write_checksum: sha1:102d1953fbd7e9f312c4442c71ccca2eaaeaa27d
     pristine_git_object: aa809fccb3445b1e2530a979dad620512f50e70f
   internal/sdk/roles.go:
     last_write_checksum: sha1:4254ac7cabfdf1410c8e69888cc51a81318bbfb4
   internal/sdk/seqera.go:
     id: b1c23bc5193c
-    last_write_checksum: sha1:a070d59091ee9976ba711cce3457c3bd8056b550
+    last_write_checksum: sha1:e8cbfe92970cdf40aea8b0d6ac4c282b53c8b225
     pristine_git_object: 89364ed6208c4c999b317d23d7d954d63ac46bc5
   internal/sdk/serviceinfo.go:
     id: 085db9a15b34
@@ -6911,7 +6911,7 @@ examples:
         query:
           workspaceId: 407920
       requestBody:
-        application/json: {"computeEnv": {"credentialsId": "<id>", "name": "<value>", "platform": "azure-batch", "config": {"headJobCpus": 1, "headJobMemoryMb": 4096, "jobMaxWallClockTime": "7d", "region": "<value>", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet", "workDir": "az://my-container/work"}}}
+        application/json: {"computeEnv": {"credentialsId": "<id>", "name": "<value>", "platform": "azure-batch", "config": {"forge": {"bootDiskSizeGB": 100, "headPool": {"bootDiskSizeGB": 100}, "vmCount": 407920, "workerPool": {"bootDiskSizeGB": 100}}, "headJobCpus": 1, "headJobMemoryMb": 4096, "jobMaxWallClockTime": "7d", "region": "<value>", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet", "workDir": "az://my-container/work"}}}
       responses:
         "200":
           application/json: {}
@@ -6926,7 +6926,7 @@ examples:
           workspaceId: 501081
       responses:
         "200":
-          application/json: {"computeEnv": {"credentialsId": "<id>", "name": "<value>", "platform": "azure-batch", "config": {"headJobCpus": 1, "headJobMemoryMb": 4096, "jobMaxWallClockTime": "7d", "region": "<value>", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet", "workDir": "az://my-container/work"}}}
+          application/json: {"computeEnv": {"credentialsId": "<id>", "name": "<value>", "platform": "azure-batch", "config": {"forge": {"bootDiskSizeGB": 100, "headPool": {"bootDiskSizeGB": 100}, "vmCount": 501081, "workerPool": {"bootDiskSizeGB": 100}}, "headJobCpus": 1, "headJobMemoryMb": 4096, "jobMaxWallClockTime": "7d", "region": "<value>", "subnetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet", "workDir": "az://my-container/work"}}}
         "400":
           application/json: {"message": "<value>"}
   DeleteAzureBatchCE:

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -6,7 +6,7 @@ info:
   description: |
     The Seqera Platform Terraform Provider enables infrastructure-as-code management of Seqera Platform resources. This provider allows you to programmatically create, configure, and manage organizations, workspaces, compute environments, pipelines, credentials, and other Seqera Platform components using Terraform.
   title: Seqera API
-  version: 1.153.0
+  version: 1.159.0
 tags:
   - name: actions
     description: Pipeline actions
@@ -7914,6 +7914,14 @@ paths:
           schema:
             type: integer
             format: int64
+        - name: attributes
+          in: query
+          description: 'Additional attribute values to include in the response (`labels`, `resources`). Returns an empty value (ex. `labels: null`) if omitted.'
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ComputeEnvQueryAttribute'
+          explode: false
       responses:
         '200':
           description: OK
@@ -15278,6 +15286,14 @@ components:
       properties:
         autoScale:
           type: boolean
+        bootDiskSizeGB:
+          description: Boot disk size in GB for all pool nodes. When omitted, Azure uses the default disk size for the selected VM image. Per-pool values in headPool/workerPool take precedence in dual-pool mode.
+          type: integer
+          format: int32
+          example: 100
+          maximum: 4095
+          minimum: 50
+          nullable: true
         containerRegIds:
           type: array
           items:
@@ -15338,6 +15354,14 @@ components:
       properties:
         autoScale:
           type: boolean
+        bootDiskSizeGB:
+          description: Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default.
+          type: integer
+          format: int32
+          example: 100
+          maximum: 4095
+          minimum: 50
+          nullable: true
         vmCount:
           type: integer
           format: int32
@@ -17491,6 +17515,9 @@ components:
           type: boolean
         fileName:
           type: string
+        fileSize:
+          type: integer
+          format: int64
         hasHeader:
           type: boolean
         lastUpdated:
@@ -19371,6 +19398,12 @@ components:
           x-speakeasy-param-suppress-computed-diff: true
         stubRun:
           type: boolean
+        syntaxParser:
+          type: string
+          enum:
+            - v1
+            - v2
+          nullable: true
         towerConfig:
           type: string
           nullable: true
@@ -22941,6 +22974,12 @@ components:
           type: boolean
           default: false
           example: false
+        syntaxParser:
+          type: string
+          enum:
+            - v1
+            - v2
+          nullable: true
         towerConfig:
           type: string
           nullable: true
@@ -23194,10 +23233,22 @@ components:
               $ref: '#/components/schemas/WfFusionMeta'
             logFile:
               type: string
+            nextflowConfig:
+              type: string
+              nullable: true
             operationId:
               type: string
             outFile:
               type: string
+            postRunScript:
+              type: string
+              nullable: true
+            preRunScript:
+              type: string
+              nullable: true
+            towerConfig:
+              type: string
+              nullable: true
             wave:
               $ref: '#/components/schemas/WfWaveMeta'
           type: object

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,18 +1,18 @@
-speakeasyVersion: 1.777.2
+speakeasyVersion: 1.785.0
 sources:
     Seqera API:
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:df1cf07b45f3ff1fba75809101244f83ec1b981affd4299a1c58cf87176389e9
-        sourceBlobDigest: sha256:60543bc1ddc4d4ff704c74080a97e844a6ef1a9f750a5a6ecfb868617a06b489
+        sourceRevisionDigest: sha256:fd42c2400a6b9913f6179ac427fc146ef1c928c7ecda0411e98bab0bfd708e88
+        sourceBlobDigest: sha256:eefef4f345f3d91484eb0e79aa58dd3a7361aa22b2813361c6ca27822aa98f01
         tags:
             - latest
-            - 1.153.0
+            - 1.159.0
 targets:
     seqera:
         source: Seqera API
         sourceNamespace: seqera-api
-        sourceRevisionDigest: sha256:df1cf07b45f3ff1fba75809101244f83ec1b981affd4299a1c58cf87176389e9
-        sourceBlobDigest: sha256:60543bc1ddc4d4ff704c74080a97e844a6ef1a9f750a5a6ecfb868617a06b489
+        sourceRevisionDigest: sha256:fd42c2400a6b9913f6179ac427fc146ef1c928c7ecda0411e98bab0bfd708e88
+        sourceBlobDigest: sha256:eefef4f345f3d91484eb0e79aa58dd3a7361aa22b2813361c6ca27822aa98f01
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -168,6 +168,7 @@ Optional:
 - `run_name` (String) Custom run name
 - `schema_name` (String) Pipeline schema name
 - `stub_run` (Boolean) Default: false
+- `syntax_parser` (String) must be one of ["v1", "v2"]
 - `tower_config` (String) Tower-specific configuration
 - `user_secrets` (List of String) Default: []
 - `work_dir` (String) Working directory for pipeline execution. Must start with a valid cloud storage prefix (s3://, gs://, az://) or be an absolute local path (/). Do not include a trailing slash — the API strips trailing slashes at launch time, which causes plan diffs. Required for pipelines in private workspaces and personal context; optional for shared workspaces. You can reference the work_dir from your compute environment instead of duplicating the value, e.g. seqera_compute_env.my_ce.compute_env.config.aws_batch.work_dir or seqera_aws_batch_compute_env.my_ce.config.work_dir.

--- a/docs/resources/azure_batch_ce.md
+++ b/docs/resources/azure_batch_ce.md
@@ -196,6 +196,7 @@ Default: false; Requires replacement if changed.
 Optional:
 
 - `auto_scale` (Boolean) Requires replacement if changed.
+- `boot_disk_size_gb` (Number) Boot disk size in GB for all pool nodes. When omitted, Azure uses the default disk size for the selected VM image. Per-pool values in headPool/workerPool take precedence in dual-pool mode. Requires replacement if changed.
 - `container_reg_ids` (List of String) List of Azure Container Registry IDs whose images compute jobs may pull. Requires replacement if changed.
 - `dispose_on_deletion` (Boolean) Requires replacement if changed.
 - `dual_pool_config` (Boolean) Requires replacement if changed.
@@ -210,6 +211,7 @@ Optional:
 Optional:
 
 - `auto_scale` (Boolean) Requires replacement if changed.
+- `boot_disk_size_gb` (Number) Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default. Requires replacement if changed.
 - `vm_count` (Number) Requires replacement if changed.
 - `vm_type` (String) Requires replacement if changed.
 
@@ -220,6 +222,7 @@ Optional:
 Optional:
 
 - `auto_scale` (Boolean) Requires replacement if changed.
+- `boot_disk_size_gb` (Number) Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default. Requires replacement if changed.
 - `vm_count` (Number) Requires replacement if changed.
 - `vm_type` (String) Requires replacement if changed.
 

--- a/docs/resources/compute_env.md
+++ b/docs/resources/compute_env.md
@@ -556,6 +556,7 @@ Default: false; Requires replacement if changed.
 Optional:
 
 - `auto_scale` (Boolean) Requires replacement if changed.
+- `boot_disk_size_gb` (Number) Boot disk size in GB for all pool nodes. When omitted, Azure uses the default disk size for the selected VM image. Per-pool values in headPool/workerPool take precedence in dual-pool mode. Requires replacement if changed.
 - `container_reg_ids` (List of String) List of Azure Container Registry IDs whose images compute jobs may pull. Requires replacement if changed.
 - `dispose_on_deletion` (Boolean) Requires replacement if changed.
 - `dual_pool_config` (Boolean) Requires replacement if changed.
@@ -570,6 +571,7 @@ Optional:
 Optional:
 
 - `auto_scale` (Boolean) Requires replacement if changed.
+- `boot_disk_size_gb` (Number) Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default. Requires replacement if changed.
 - `vm_count` (Number) Requires replacement if changed.
 - `vm_type` (String) Requires replacement if changed.
 
@@ -580,6 +582,7 @@ Optional:
 Optional:
 
 - `auto_scale` (Boolean) Requires replacement if changed.
+- `boot_disk_size_gb` (Number) Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default. Requires replacement if changed.
 - `vm_count` (Number) Requires replacement if changed.
 - `vm_type` (String) Requires replacement if changed.
 

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -134,6 +134,7 @@ Optional:
 - `run_name` (String) Custom run name
 - `schema_name` (String) Pipeline schema name
 - `stub_run` (Boolean) Default: false
+- `syntax_parser` (String) must be one of ["v1", "v2"]
 - `tower_config` (String) Tower-specific configuration
 - `user_secrets` (List of String) Default: []
 - `work_dir` (String) Working directory for pipeline execution. Must start with a valid cloud storage prefix (s3://, gs://, az://) or be an absolute local path (/). Do not include a trailing slash — the API strips trailing slashes at launch time, which causes plan diffs. Required for pipelines in private workspaces and personal context; optional for shared workspaces. You can reference the work_dir from your compute environment instead of duplicating the value, e.g. seqera_compute_env.my_ce.compute_env.config.aws_batch.work_dir or seqera_aws_batch_compute_env.my_ce.config.work_dir.

--- a/docs/resources/workflows.md
+++ b/docs/resources/workflows.md
@@ -104,6 +104,7 @@ resource "seqera_workflows" "with_params" {
 - `schema_name` (String) Pipeline schema name. Requires replacement if changed.
 - `source_workspace_id` (Number) Source workspace numeric identifier. Requires replacement if changed.
 - `stub_run` (Boolean) Default: false; Requires replacement if changed.
+- `syntax_parser` (String) must be one of ["v1", "v2"]; Requires replacement if changed.
 - `tower_config` (String) Tower-specific configuration. Requires replacement if changed.
 - `user_secrets` (List of String) Default: []; Requires replacement if changed.
 - `work_dir` (String) Working directory for pipeline execution. Must start with a valid cloud storage prefix (s3://, gs://, az://) or be an absolute local path (/). Do not include a trailing slash — the API strips trailing slashes at launch time, which causes plan diffs. Required for pipelines in private workspaces and personal context; optional for shared workspaces. You can reference the work_dir from your compute environment instead of duplicating the value, e.g. seqera_compute_env.my_ce.compute_env.config.aws_batch.work_dir or seqera_aws_batch_compute_env.my_ce.config.work_dir. Requires replacement if changed.

--- a/examples/resources/seqera_action/resource_tower_advanced.tf
+++ b/examples/resources/seqera_action/resource_tower_advanced.tf
@@ -8,6 +8,7 @@ resource "seqera_action" "tower_advanced" {
     compute_env_id = seqera_compute_env.aws.id
     work_dir       = "s3://my-bucket/production/work"
     revision       = "master"
+    syntax_parser  = "v2"
 
     params_text = jsonencode({
       input_data  = "s3://my-bucket/input/data.csv"

--- a/examples/resources/seqera_azure_batch_ce/resource.tf
+++ b/examples/resources/seqera_azure_batch_ce/resource.tf
@@ -18,6 +18,7 @@ resource "seqera_azure_batch_ce" "minimal" {
       vm_count            = 5
       auto_scale          = true
       dispose_on_deletion = true
+      boot_disk_size_gb   = 100
     }
   }
 }

--- a/examples/resources/seqera_azure_batch_ce/resource_dual_pool.tf
+++ b/examples/resources/seqera_azure_batch_ce/resource_dual_pool.tf
@@ -13,14 +13,16 @@ resource "seqera_azure_batch_ce" "dual_pool" {
       dual_pool_config    = true
       dispose_on_deletion = true
       head_pool = {
-        vm_type    = "Standard_E8s_v3"
-        vm_count   = 1
-        auto_scale = false
+        vm_type           = "Standard_E8s_v3"
+        vm_count          = 1
+        auto_scale        = false
+        boot_disk_size_gb = 200
       }
       worker_pool = {
-        vm_type    = "Standard_D4s_v3"
-        vm_count   = 10
-        auto_scale = true
+        vm_type           = "Standard_D4s_v3"
+        vm_count          = 10
+        auto_scale        = true
+        boot_disk_size_gb = 100
       }
     }
   }

--- a/examples/resources/seqera_pipeline/resource.tf
+++ b/examples/resources/seqera_pipeline/resource.tf
@@ -13,6 +13,7 @@ resource "seqera_pipeline" "basic" {
     compute_env_id = seqera_compute_env.aws.compute_env.id
     work_dir       = "s3://my-bucket/work"
     revision       = "main"
+    syntax_parser  = "v2"
   }
 }
 

--- a/internal/provider/action_resource.go
+++ b/internal/provider/action_resource.go
@@ -332,6 +332,14 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						Default:     booldefault.StaticBool(false),
 						Description: `Default: false`,
 					},
+					"syntax_parser": schema.StringAttribute{
+						Computed:    true,
+						Optional:    true,
+						Description: `must be one of ["v1", "v2"]`,
+						Validators: []validator.String{
+							stringvalidator.OneOf("v1", "v2"),
+						},
+					},
 					"tower_config": schema.StringAttribute{
 						Optional:    true,
 						Description: `Tower-specific configuration`,

--- a/internal/provider/action_resource_sdk.go
+++ b/internal/provider/action_resource_sdk.go
@@ -81,6 +81,11 @@ func (r *ActionResourceModel) RefreshFromSharedActionResponseDto(ctx context.Con
 			r.Launch.SchemaName = types.StringPointerValue(resp.Launch.SchemaName)
 			r.Launch.SessionID = types.StringPointerValue(resp.Launch.SessionID)
 			r.Launch.StubRun = types.BoolPointerValue(resp.Launch.StubRun)
+			if resp.Launch.SyntaxParser != nil {
+				r.Launch.SyntaxParser = types.StringValue(string(*resp.Launch.SyntaxParser))
+			} else {
+				r.Launch.SyntaxParser = types.StringNull()
+			}
 			r.Launch.TowerConfig = types.StringPointerValue(resp.Launch.TowerConfig)
 			r.Launch.UserSecrets = make([]types.String, 0, len(resp.Launch.UserSecrets))
 			for _, v := range resp.Launch.UserSecrets {
@@ -403,6 +408,12 @@ func (r *ActionResourceModel) ToSharedCreateActionRequest(ctx context.Context) (
 	} else {
 		stubRun = nil
 	}
+	syntaxParser := new(shared.ActionLaunchRequestSyntaxParser)
+	if !r.Launch.SyntaxParser.IsUnknown() && !r.Launch.SyntaxParser.IsNull() {
+		*syntaxParser = shared.ActionLaunchRequestSyntaxParser(r.Launch.SyntaxParser.ValueString())
+	} else {
+		syntaxParser = nil
+	}
 	towerConfig := new(string)
 	if !r.Launch.TowerConfig.IsUnknown() && !r.Launch.TowerConfig.IsNull() {
 		*towerConfig = r.Launch.TowerConfig.ValueString()
@@ -443,6 +454,7 @@ func (r *ActionResourceModel) ToSharedCreateActionRequest(ctx context.Context) (
 		RunName:          runName,
 		SchemaName:       schemaName,
 		StubRun:          stubRun,
+		SyntaxParser:     syntaxParser,
 		TowerConfig:      towerConfig,
 		UserSecrets:      userSecrets,
 		WorkDir:          workDir,
@@ -643,6 +655,12 @@ func (r *ActionResourceModel) ToSharedUpdateActionRequest(ctx context.Context) (
 	} else {
 		stubRun = nil
 	}
+	syntaxParser := new(shared.ActionLaunchRequestSyntaxParser)
+	if !r.Launch.SyntaxParser.IsUnknown() && !r.Launch.SyntaxParser.IsNull() {
+		*syntaxParser = shared.ActionLaunchRequestSyntaxParser(r.Launch.SyntaxParser.ValueString())
+	} else {
+		syntaxParser = nil
+	}
 	towerConfig := new(string)
 	if !r.Launch.TowerConfig.IsUnknown() && !r.Launch.TowerConfig.IsNull() {
 		*towerConfig = r.Launch.TowerConfig.ValueString()
@@ -683,6 +701,7 @@ func (r *ActionResourceModel) ToSharedUpdateActionRequest(ctx context.Context) (
 		RunName:          runName,
 		SchemaName:       schemaName,
 		StubRun:          stubRun,
+		SyntaxParser:     syntaxParser,
 		TowerConfig:      towerConfig,
 		UserSecrets:      userSecrets,
 		WorkDir:          workDir,

--- a/internal/provider/azurebatchce_resource.go
+++ b/internal/provider/azurebatchce_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -263,6 +264,18 @@ func (r *AzureBatchCEResource) Schema(ctx context.Context, req resource.SchemaRe
 								},
 								Description: `Requires replacement if changed.`,
 							},
+							"boot_disk_size_gb": schema.Int32Attribute{
+								Computed: true,
+								Optional: true,
+								PlanModifiers: []planmodifier.Int32{
+									int32planmodifier.RequiresReplaceIfConfigured(),
+									speakeasy_int32planmodifier.SuppressDiff(speakeasy_int32planmodifier.ExplicitSuppress),
+								},
+								Description: `Boot disk size in GB for all pool nodes. When omitted, Azure uses the default disk size for the selected VM image. Per-pool values in headPool/workerPool take precedence in dual-pool mode. Requires replacement if changed.`,
+								Validators: []validator.Int32{
+									int32validator.Between(50, 4095),
+								},
+							},
 							"container_reg_ids": schema.ListAttribute{
 								CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
 								Computed:   true,
@@ -308,6 +321,18 @@ func (r *AzureBatchCEResource) Schema(ctx context.Context, req resource.SchemaRe
 											speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
 										},
 										Description: `Requires replacement if changed.`,
+									},
+									"boot_disk_size_gb": schema.Int32Attribute{
+										Computed: true,
+										Optional: true,
+										PlanModifiers: []planmodifier.Int32{
+											int32planmodifier.RequiresReplaceIfConfigured(),
+											speakeasy_int32planmodifier.SuppressDiff(speakeasy_int32planmodifier.ExplicitSuppress),
+										},
+										Description: `Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default. Requires replacement if changed.`,
+										Validators: []validator.Int32{
+											int32validator.Between(50, 4095),
+										},
 									},
 									"vm_count": schema.Int32Attribute{
 										Computed: true,
@@ -367,6 +392,18 @@ func (r *AzureBatchCEResource) Schema(ctx context.Context, req resource.SchemaRe
 											speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
 										},
 										Description: `Requires replacement if changed.`,
+									},
+									"boot_disk_size_gb": schema.Int32Attribute{
+										Computed: true,
+										Optional: true,
+										PlanModifiers: []planmodifier.Int32{
+											int32planmodifier.RequiresReplaceIfConfigured(),
+											speakeasy_int32planmodifier.SuppressDiff(speakeasy_int32planmodifier.ExplicitSuppress),
+										},
+										Description: `Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default. Requires replacement if changed.`,
+										Validators: []validator.Int32{
+											int32validator.Between(50, 4095),
+										},
 									},
 									"vm_count": schema.Int32Attribute{
 										Computed: true,

--- a/internal/provider/azurebatchce_resource_sdk.go
+++ b/internal/provider/azurebatchce_resource_sdk.go
@@ -47,6 +47,7 @@ func (r *AzureBatchCEResourceModel) RefreshFromSharedAzureBatchCEComputeConfig(c
 		} else {
 			r.Config.Forge = &tfTypes.AzBatchForgeConfig{}
 			r.Config.Forge.AutoScale = types.BoolPointerValue(resp.Config.Forge.AutoScale)
+			r.Config.Forge.BootDiskSizeGB = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.Forge.BootDiskSizeGB))
 			containerRegIdsValue, containerRegIdsDiags := types.ListValueFrom(ctx, types.StringType, resp.Config.Forge.ContainerRegIds)
 			diags.Append(containerRegIdsDiags...)
 			containerRegIdsValuable, containerRegIdsDiags := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, containerRegIdsValue)
@@ -59,6 +60,7 @@ func (r *AzureBatchCEResourceModel) RefreshFromSharedAzureBatchCEComputeConfig(c
 			} else {
 				r.Config.Forge.HeadPool = &tfTypes.AzBatchPoolConfig{}
 				r.Config.Forge.HeadPool.AutoScale = types.BoolPointerValue(resp.Config.Forge.HeadPool.AutoScale)
+				r.Config.Forge.HeadPool.BootDiskSizeGB = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.Forge.HeadPool.BootDiskSizeGB))
 				r.Config.Forge.HeadPool.VMCount = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.Forge.HeadPool.VMCount))
 				r.Config.Forge.HeadPool.VMType = types.StringPointerValue(resp.Config.Forge.HeadPool.VMType)
 			}
@@ -69,6 +71,7 @@ func (r *AzureBatchCEResourceModel) RefreshFromSharedAzureBatchCEComputeConfig(c
 			} else {
 				r.Config.Forge.WorkerPool = &tfTypes.AzBatchPoolConfig{}
 				r.Config.Forge.WorkerPool.AutoScale = types.BoolPointerValue(resp.Config.Forge.WorkerPool.AutoScale)
+				r.Config.Forge.WorkerPool.BootDiskSizeGB = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.Forge.WorkerPool.BootDiskSizeGB))
 				r.Config.Forge.WorkerPool.VMCount = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.Config.Forge.WorkerPool.VMCount))
 				r.Config.Forge.WorkerPool.VMType = types.StringPointerValue(resp.Config.Forge.WorkerPool.VMType)
 			}
@@ -351,6 +354,12 @@ func (r *AzureBatchCEResourceModel) ToSharedAzureBatchCEComputeConfigInput(ctx c
 		} else {
 			autoScale = nil
 		}
+		bootDiskSizeGB := new(int)
+		if !r.Config.Forge.BootDiskSizeGB.IsUnknown() && !r.Config.Forge.BootDiskSizeGB.IsNull() {
+			*bootDiskSizeGB = int(r.Config.Forge.BootDiskSizeGB.ValueInt32())
+		} else {
+			bootDiskSizeGB = nil
+		}
 		var containerRegIds []string
 		if !r.Config.Forge.ContainerRegIds.IsUnknown() && !r.Config.Forge.ContainerRegIds.IsNull() {
 			diags.Append(r.Config.Forge.ContainerRegIds.ElementsAs(ctx, &containerRegIds, true)...)
@@ -375,6 +384,12 @@ func (r *AzureBatchCEResourceModel) ToSharedAzureBatchCEComputeConfigInput(ctx c
 			} else {
 				autoScale1 = nil
 			}
+			bootDiskSizeGb1 := new(int)
+			if !r.Config.Forge.HeadPool.BootDiskSizeGB.IsUnknown() && !r.Config.Forge.HeadPool.BootDiskSizeGB.IsNull() {
+				*bootDiskSizeGb1 = int(r.Config.Forge.HeadPool.BootDiskSizeGB.ValueInt32())
+			} else {
+				bootDiskSizeGb1 = nil
+			}
 			vmCount := new(int)
 			if !r.Config.Forge.HeadPool.VMCount.IsUnknown() && !r.Config.Forge.HeadPool.VMCount.IsNull() {
 				*vmCount = int(r.Config.Forge.HeadPool.VMCount.ValueInt32())
@@ -388,9 +403,10 @@ func (r *AzureBatchCEResourceModel) ToSharedAzureBatchCEComputeConfigInput(ctx c
 				vmType = nil
 			}
 			headPool = &shared.AzBatchPoolConfig{
-				AutoScale: autoScale1,
-				VMCount:   vmCount,
-				VMType:    vmType,
+				AutoScale:      autoScale1,
+				BootDiskSizeGB: bootDiskSizeGb1,
+				VMCount:        vmCount,
+				VMType:         vmType,
 			}
 		}
 		var vmCount1 int
@@ -410,6 +426,12 @@ func (r *AzureBatchCEResourceModel) ToSharedAzureBatchCEComputeConfigInput(ctx c
 			} else {
 				autoScale2 = nil
 			}
+			bootDiskSizeGb2 := new(int)
+			if !r.Config.Forge.WorkerPool.BootDiskSizeGB.IsUnknown() && !r.Config.Forge.WorkerPool.BootDiskSizeGB.IsNull() {
+				*bootDiskSizeGb2 = int(r.Config.Forge.WorkerPool.BootDiskSizeGB.ValueInt32())
+			} else {
+				bootDiskSizeGb2 = nil
+			}
 			vmCount2 := new(int)
 			if !r.Config.Forge.WorkerPool.VMCount.IsUnknown() && !r.Config.Forge.WorkerPool.VMCount.IsNull() {
 				*vmCount2 = int(r.Config.Forge.WorkerPool.VMCount.ValueInt32())
@@ -423,13 +445,15 @@ func (r *AzureBatchCEResourceModel) ToSharedAzureBatchCEComputeConfigInput(ctx c
 				vmType2 = nil
 			}
 			workerPool = &shared.AzBatchPoolConfig{
-				AutoScale: autoScale2,
-				VMCount:   vmCount2,
-				VMType:    vmType2,
+				AutoScale:      autoScale2,
+				BootDiskSizeGB: bootDiskSizeGb2,
+				VMCount:        vmCount2,
+				VMType:         vmType2,
 			}
 		}
 		forge = &shared.AzBatchForgeConfig{
 			AutoScale:         autoScale,
+			BootDiskSizeGB:    bootDiskSizeGB,
 			ContainerRegIds:   containerRegIds,
 			DisposeOnDeletion: disposeOnDeletion,
 			DualPoolConfig:    dualPoolConfig,

--- a/internal/provider/computeenv_resource.go
+++ b/internal/provider/computeenv_resource.go
@@ -1486,6 +1486,17 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 												},
 												Description: `Requires replacement if changed.`,
 											},
+											"boot_disk_size_gb": schema.Int32Attribute{
+												Computed: true,
+												Optional: true,
+												PlanModifiers: []planmodifier.Int32{
+													int32planmodifier.RequiresReplaceIfConfigured(),
+												},
+												Description: `Boot disk size in GB for all pool nodes. When omitted, Azure uses the default disk size for the selected VM image. Per-pool values in headPool/workerPool take precedence in dual-pool mode. Requires replacement if changed.`,
+												Validators: []validator.Int32{
+													int32validator.Between(50, 4095),
+												},
+											},
 											"container_reg_ids": schema.ListAttribute{
 												CustomType: basetypes.ListType{ElemType: basetypes.StringType{}},
 												Computed:   true,
@@ -1526,6 +1537,17 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 															boolplanmodifier.RequiresReplaceIfConfigured(),
 														},
 														Description: `Requires replacement if changed.`,
+													},
+													"boot_disk_size_gb": schema.Int32Attribute{
+														Computed: true,
+														Optional: true,
+														PlanModifiers: []planmodifier.Int32{
+															int32planmodifier.RequiresReplaceIfConfigured(),
+														},
+														Description: `Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default. Requires replacement if changed.`,
+														Validators: []validator.Int32{
+															int32validator.Between(50, 4095),
+														},
 													},
 													"vm_count": schema.Int32Attribute{
 														Computed: true,
@@ -1579,6 +1601,17 @@ func (r *ComputeEnvResource) Schema(ctx context.Context, req resource.SchemaRequ
 															boolplanmodifier.RequiresReplaceIfConfigured(),
 														},
 														Description: `Requires replacement if changed.`,
+													},
+													"boot_disk_size_gb": schema.Int32Attribute{
+														Computed: true,
+														Optional: true,
+														PlanModifiers: []planmodifier.Int32{
+															int32planmodifier.RequiresReplaceIfConfigured(),
+														},
+														Description: `Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default. Requires replacement if changed.`,
+														Validators: []validator.Int32{
+															int32validator.Between(50, 4095),
+														},
 													},
 													"vm_count": schema.Int32Attribute{
 														Computed: true,

--- a/internal/provider/computeenv_resource_sdk.go
+++ b/internal/provider/computeenv_resource_sdk.go
@@ -280,6 +280,7 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 					} else {
 						r.ComputeEnv.Config.AzureBatch.Forge = &tfTypes.AzBatchForgeConfig{}
 						r.ComputeEnv.Config.AzureBatch.Forge.AutoScale = types.BoolPointerValue(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.AutoScale)
+						r.ComputeEnv.Config.AzureBatch.Forge.BootDiskSizeGB = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.BootDiskSizeGB))
 						containerRegIdsValue, containerRegIdsDiags := types.ListValueFrom(ctx, types.StringType, resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.ContainerRegIds)
 						diags.Append(containerRegIdsDiags...)
 						containerRegIdsValuable, containerRegIdsDiags := basetypes.ListType{ElemType: basetypes.StringType{}}.ValueFromList(ctx, containerRegIdsValue)
@@ -292,6 +293,7 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 						} else {
 							r.ComputeEnv.Config.AzureBatch.Forge.HeadPool = &tfTypes.AzBatchPoolConfig{}
 							r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.AutoScale = types.BoolPointerValue(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.HeadPool.AutoScale)
+							r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.BootDiskSizeGB = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.HeadPool.BootDiskSizeGB))
 							r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.VMCount = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.HeadPool.VMCount))
 							r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.VMType = types.StringPointerValue(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.HeadPool.VMType)
 						}
@@ -302,6 +304,7 @@ func (r *ComputeEnvResourceModel) RefreshFromSharedDescribeComputeEnvResponse(ct
 						} else {
 							r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool = &tfTypes.AzBatchPoolConfig{}
 							r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.AutoScale = types.BoolPointerValue(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.WorkerPool.AutoScale)
+							r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.BootDiskSizeGB = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.WorkerPool.BootDiskSizeGB))
 							r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.VMCount = types.Int32PointerValue(typeconvert.IntPointerToInt32Pointer(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.WorkerPool.VMCount))
 							r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.VMType = types.StringPointerValue(resp.ComputeEnv.Config.AzureBatchConfiguration.Forge.WorkerPool.VMType)
 						}
@@ -2004,6 +2007,12 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			} else {
 				autoScale = nil
 			}
+			bootDiskSizeGB := new(int)
+			if !r.ComputeEnv.Config.AzureBatch.Forge.BootDiskSizeGB.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.Forge.BootDiskSizeGB.IsNull() {
+				*bootDiskSizeGB = int(r.ComputeEnv.Config.AzureBatch.Forge.BootDiskSizeGB.ValueInt32())
+			} else {
+				bootDiskSizeGB = nil
+			}
 			var containerRegIds []string
 			if !r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds.IsNull() {
 				diags.Append(r.ComputeEnv.Config.AzureBatch.Forge.ContainerRegIds.ElementsAs(ctx, &containerRegIds, true)...)
@@ -2028,6 +2037,12 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				} else {
 					autoScale1 = nil
 				}
+				bootDiskSizeGb2 := new(int)
+				if !r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.BootDiskSizeGB.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.BootDiskSizeGB.IsNull() {
+					*bootDiskSizeGb2 = int(r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.BootDiskSizeGB.ValueInt32())
+				} else {
+					bootDiskSizeGb2 = nil
+				}
 				vmCount := new(int)
 				if !r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.VMCount.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.VMCount.IsNull() {
 					*vmCount = int(r.ComputeEnv.Config.AzureBatch.Forge.HeadPool.VMCount.ValueInt32())
@@ -2041,9 +2056,10 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 					vmType = nil
 				}
 				headPool = &shared.AzBatchPoolConfig{
-					AutoScale: autoScale1,
-					VMCount:   vmCount,
-					VMType:    vmType,
+					AutoScale:      autoScale1,
+					BootDiskSizeGB: bootDiskSizeGb2,
+					VMCount:        vmCount,
+					VMType:         vmType,
 				}
 			}
 			var vmCount1 int
@@ -2063,6 +2079,12 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 				} else {
 					autoScale2 = nil
 				}
+				bootDiskSizeGb3 := new(int)
+				if !r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.BootDiskSizeGB.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.BootDiskSizeGB.IsNull() {
+					*bootDiskSizeGb3 = int(r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.BootDiskSizeGB.ValueInt32())
+				} else {
+					bootDiskSizeGb3 = nil
+				}
 				vmCount2 := new(int)
 				if !r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.VMCount.IsUnknown() && !r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.VMCount.IsNull() {
 					*vmCount2 = int(r.ComputeEnv.Config.AzureBatch.Forge.WorkerPool.VMCount.ValueInt32())
@@ -2076,13 +2098,15 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 					vmType2 = nil
 				}
 				workerPool = &shared.AzBatchPoolConfig{
-					AutoScale: autoScale2,
-					VMCount:   vmCount2,
-					VMType:    vmType2,
+					AutoScale:      autoScale2,
+					BootDiskSizeGB: bootDiskSizeGb3,
+					VMCount:        vmCount2,
+					VMType:         vmType2,
 				}
 			}
 			forge1 = &shared.AzBatchForgeConfig{
 				AutoScale:         autoScale,
+				BootDiskSizeGB:    bootDiskSizeGB,
 				ContainerRegIds:   containerRegIds,
 				DisposeOnDeletion: disposeOnDeletion1,
 				DualPoolConfig:    dualPoolConfig,
@@ -3674,11 +3698,11 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 	}
 	var googleLifeSciencesConfigurationRetired *shared.GoogleLifeSciencesConfigurationRetired
 	if r.ComputeEnv.Config.GoogleLifesciences != nil {
-		bootDiskSizeGb2 := new(int)
+		bootDiskSizeGb4 := new(int)
 		if !r.ComputeEnv.Config.GoogleLifesciences.BootDiskSizeGb.IsUnknown() && !r.ComputeEnv.Config.GoogleLifesciences.BootDiskSizeGb.IsNull() {
-			*bootDiskSizeGb2 = int(r.ComputeEnv.Config.GoogleLifesciences.BootDiskSizeGb.ValueInt32())
+			*bootDiskSizeGb4 = int(r.ComputeEnv.Config.GoogleLifesciences.BootDiskSizeGb.ValueInt32())
 		} else {
-			bootDiskSizeGb2 = nil
+			bootDiskSizeGb4 = nil
 		}
 		copyImage1 := new(string)
 		if !r.ComputeEnv.Config.GoogleLifesciences.CopyImage.IsUnknown() && !r.ComputeEnv.Config.GoogleLifesciences.CopyImage.IsNull() {
@@ -3827,7 +3851,7 @@ func (r *ComputeEnvResourceModel) ToSharedCreateComputeEnvRequest(ctx context.Co
 			zones = append(zones, r.ComputeEnv.Config.GoogleLifesciences.Zones[zonesIndex].ValueString())
 		}
 		googleLifeSciencesConfigurationRetired = &shared.GoogleLifeSciencesConfigurationRetired{
-			BootDiskSizeGb:    bootDiskSizeGb2,
+			BootDiskSizeGb:    bootDiskSizeGb4,
 			CopyImage:         copyImage1,
 			DebugMode:         debugMode1,
 			Environment:       environment16,

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -223,6 +223,14 @@ func (r *PipelineResource) Schema(ctx context.Context, req resource.SchemaReques
 						Default:     booldefault.StaticBool(false),
 						Description: `Default: false`,
 					},
+					"syntax_parser": schema.StringAttribute{
+						Computed:    true,
+						Optional:    true,
+						Description: `must be one of ["v1", "v2"]`,
+						Validators: []validator.String{
+							stringvalidator.OneOf("v1", "v2"),
+						},
+					},
 					"tower_config": schema.StringAttribute{
 						Optional:    true,
 						Description: `Tower-specific configuration`,

--- a/internal/provider/pipeline_resource_sdk.go
+++ b/internal/provider/pipeline_resource_sdk.go
@@ -58,6 +58,11 @@ func (r *PipelineResourceModel) RefreshFromSharedDescribeLaunchResponse(ctx cont
 			r.Launch.SchemaName = types.StringPointerValue(resp.Launch.SchemaName)
 			r.Launch.SessionID = types.StringPointerValue(resp.Launch.SessionID)
 			r.Launch.StubRun = types.BoolPointerValue(resp.Launch.StubRun)
+			if resp.Launch.SyntaxParser != nil {
+				r.Launch.SyntaxParser = types.StringValue(string(*resp.Launch.SyntaxParser))
+			} else {
+				r.Launch.SyntaxParser = types.StringNull()
+			}
 			r.Launch.TowerConfig = types.StringPointerValue(resp.Launch.TowerConfig)
 			r.Launch.UserSecrets = make([]types.String, 0, len(resp.Launch.UserSecrets))
 			for _, v := range resp.Launch.UserSecrets {
@@ -364,6 +369,12 @@ func (r *PipelineResourceModel) ToSharedCreatePipelineRequest(ctx context.Contex
 	} else {
 		stubRun = nil
 	}
+	syntaxParser := new(shared.WorkflowLaunchRequestSyntaxParser)
+	if !r.Launch.SyntaxParser.IsUnknown() && !r.Launch.SyntaxParser.IsNull() {
+		*syntaxParser = shared.WorkflowLaunchRequestSyntaxParser(r.Launch.SyntaxParser.ValueString())
+	} else {
+		syntaxParser = nil
+	}
 	towerConfig := new(string)
 	if !r.Launch.TowerConfig.IsUnknown() && !r.Launch.TowerConfig.IsNull() {
 		*towerConfig = r.Launch.TowerConfig.ValueString()
@@ -403,6 +414,7 @@ func (r *PipelineResourceModel) ToSharedCreatePipelineRequest(ctx context.Contex
 		RunName:          runName,
 		SchemaName:       schemaName,
 		StubRun:          stubRun,
+		SyntaxParser:     syntaxParser,
 		TowerConfig:      towerConfig,
 		UserSecrets:      userSecrets,
 		WorkDir:          workDir,
@@ -556,6 +568,12 @@ func (r *PipelineResourceModel) ToSharedUpdatePipelineRequest(ctx context.Contex
 	} else {
 		stubRun = nil
 	}
+	syntaxParser := new(shared.WorkflowLaunchRequestSyntaxParser)
+	if !r.Launch.SyntaxParser.IsUnknown() && !r.Launch.SyntaxParser.IsNull() {
+		*syntaxParser = shared.WorkflowLaunchRequestSyntaxParser(r.Launch.SyntaxParser.ValueString())
+	} else {
+		syntaxParser = nil
+	}
 	towerConfig := new(string)
 	if !r.Launch.TowerConfig.IsUnknown() && !r.Launch.TowerConfig.IsNull() {
 		*towerConfig = r.Launch.TowerConfig.ValueString()
@@ -595,6 +613,7 @@ func (r *PipelineResourceModel) ToSharedUpdatePipelineRequest(ctx context.Contex
 		RunName:          runName,
 		SchemaName:       schemaName,
 		StubRun:          stubRun,
+		SyntaxParser:     syntaxParser,
 		TowerConfig:      towerConfig,
 		UserSecrets:      userSecrets,
 		WorkDir:          workDir,

--- a/internal/provider/types/action_launch_request.go
+++ b/internal/provider/types/action_launch_request.go
@@ -31,6 +31,7 @@ type ActionLaunchRequest struct {
 	SchemaName          types.String   `tfsdk:"schema_name"`
 	SessionID           types.String   `tfsdk:"session_id"`
 	StubRun             types.Bool     `tfsdk:"stub_run"`
+	SyntaxParser        types.String   `tfsdk:"syntax_parser"`
 	TowerConfig         types.String   `tfsdk:"tower_config"`
 	UserSecrets         []types.String `tfsdk:"user_secrets"`
 	WorkDir             types.String   `tfsdk:"work_dir"`

--- a/internal/provider/types/az_batch_forge_config.go
+++ b/internal/provider/types/az_batch_forge_config.go
@@ -9,6 +9,7 @@ import (
 
 type AzBatchForgeConfig struct {
 	AutoScale         types.Bool          `tfsdk:"auto_scale"`
+	BootDiskSizeGB    types.Int32         `tfsdk:"boot_disk_size_gb"`
 	ContainerRegIds   basetypes.ListValue `tfsdk:"container_reg_ids"`
 	DisposeOnDeletion types.Bool          `tfsdk:"dispose_on_deletion"`
 	DualPoolConfig    types.Bool          `tfsdk:"dual_pool_config"`

--- a/internal/provider/types/az_batch_pool_config.go
+++ b/internal/provider/types/az_batch_pool_config.go
@@ -7,7 +7,8 @@ import (
 )
 
 type AzBatchPoolConfig struct {
-	AutoScale types.Bool   `tfsdk:"auto_scale"`
-	VMCount   types.Int32  `tfsdk:"vm_count"`
-	VMType    types.String `tfsdk:"vm_type"`
+	AutoScale      types.Bool   `tfsdk:"auto_scale"`
+	BootDiskSizeGB types.Int32  `tfsdk:"boot_disk_size_gb"`
+	VMCount        types.Int32  `tfsdk:"vm_count"`
+	VMType         types.String `tfsdk:"vm_type"`
 }

--- a/internal/provider/types/workflow_launch_request.go
+++ b/internal/provider/types/workflow_launch_request.go
@@ -30,6 +30,7 @@ type WorkflowLaunchRequest struct {
 	SchemaName          types.String   `tfsdk:"schema_name"`
 	SessionID           types.String   `tfsdk:"session_id"`
 	StubRun             types.Bool     `tfsdk:"stub_run"`
+	SyntaxParser        types.String   `tfsdk:"syntax_parser"`
 	TowerConfig         types.String   `tfsdk:"tower_config"`
 	UserSecrets         []types.String `tfsdk:"user_secrets"`
 	WorkDir             types.String   `tfsdk:"work_dir"`

--- a/internal/provider/workflows_resource.go
+++ b/internal/provider/workflows_resource.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -67,6 +68,7 @@ type WorkflowsResourceModel struct {
 	SchemaName                types.String                                  `tfsdk:"schema_name"`
 	SourceWorkspaceID         types.Int64                                   `queryParam:"style=form,explode=true,name=sourceWorkspaceId" tfsdk:"source_workspace_id"`
 	StubRun                   types.Bool                                    `tfsdk:"stub_run"`
+	SyntaxParser              types.String                                  `tfsdk:"syntax_parser"`
 	TowerConfig               types.String                                  `tfsdk:"tower_config"`
 	UserSecrets               []types.String                                `tfsdk:"user_secrets"`
 	WorkDir                   types.String                                  `tfsdk:"work_dir"`
@@ -309,6 +311,16 @@ func (r *WorkflowsResource) Schema(ctx context.Context, req resource.SchemaReque
 					boolplanmodifier.RequiresReplaceIfConfigured(),
 				},
 				Description: `Default: false; Requires replacement if changed.`,
+			},
+			"syntax_parser": schema.StringAttribute{
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Description: `must be one of ["v1", "v2"]; Requires replacement if changed.`,
+				Validators: []validator.String{
+					stringvalidator.OneOf("v1", "v2"),
+				},
 			},
 			"tower_config": schema.StringAttribute{
 				Optional: true,

--- a/internal/provider/workflows_resource_sdk.go
+++ b/internal/provider/workflows_resource_sdk.go
@@ -248,6 +248,12 @@ func (r *WorkflowsResourceModel) ToSharedWorkflowLaunchRequest(ctx context.Conte
 	} else {
 		stubRun = nil
 	}
+	syntaxParser := new(shared.WorkflowLaunchRequestSyntaxParser)
+	if !r.SyntaxParser.IsUnknown() && !r.SyntaxParser.IsNull() {
+		*syntaxParser = shared.WorkflowLaunchRequestSyntaxParser(r.SyntaxParser.ValueString())
+	} else {
+		syntaxParser = nil
+	}
 	towerConfig := new(string)
 	if !r.TowerConfig.IsUnknown() && !r.TowerConfig.IsNull() {
 		*towerConfig = r.TowerConfig.ValueString()
@@ -287,6 +293,7 @@ func (r *WorkflowsResourceModel) ToSharedWorkflowLaunchRequest(ctx context.Conte
 		RunName:          runName,
 		SchemaName:       schemaName,
 		StubRun:          stubRun,
+		SyntaxParser:     syntaxParser,
 		TowerConfig:      towerConfig,
 		UserSecrets:      userSecrets,
 		WorkDir:          workDir,

--- a/internal/sdk/models/operations/listdatastudiocompatiblecomputeenvs.go
+++ b/internal/sdk/models/operations/listdatastudiocompatiblecomputeenvs.go
@@ -12,6 +12,8 @@ type ListDataStudioCompatibleComputeEnvsRequest struct {
 	SessionID string `pathParam:"style=simple,explode=false,name=sessionId"`
 	// Workspace numeric identifier
 	WorkspaceID *int64 `queryParam:"style=form,explode=true,name=workspaceId"`
+	// Additional attribute values to include in the response (`labels`, `resources`). Returns an empty value (ex. `labels: null`) if omitted.
+	Attributes []shared.ComputeEnvQueryAttribute `queryParam:"style=form,explode=false,name=attributes"`
 }
 
 func (l *ListDataStudioCompatibleComputeEnvsRequest) GetSessionID() string {
@@ -26,6 +28,13 @@ func (l *ListDataStudioCompatibleComputeEnvsRequest) GetWorkspaceID() *int64 {
 		return nil
 	}
 	return l.WorkspaceID
+}
+
+func (l *ListDataStudioCompatibleComputeEnvsRequest) GetAttributes() []shared.ComputeEnvQueryAttribute {
+	if l == nil {
+		return nil
+	}
+	return l.Attributes
 }
 
 type ListDataStudioCompatibleComputeEnvsResponse struct {

--- a/internal/sdk/models/shared/actionlaunchrequest.go
+++ b/internal/sdk/models/shared/actionlaunchrequest.go
@@ -3,8 +3,36 @@
 package shared
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
 )
+
+type ActionLaunchRequestSyntaxParser string
+
+const (
+	ActionLaunchRequestSyntaxParserV1 ActionLaunchRequestSyntaxParser = "v1"
+	ActionLaunchRequestSyntaxParserV2 ActionLaunchRequestSyntaxParser = "v2"
+)
+
+func (e ActionLaunchRequestSyntaxParser) ToPointer() *ActionLaunchRequestSyntaxParser {
+	return &e
+}
+func (e *ActionLaunchRequestSyntaxParser) UnmarshalJSON(data []byte) error {
+	var v string
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	switch v {
+	case "v1":
+		fallthrough
+	case "v2":
+		*e = ActionLaunchRequestSyntaxParser(v)
+		return nil
+	default:
+		return fmt.Errorf("invalid value for ActionLaunchRequestSyntaxParser: %v", v)
+	}
+}
 
 // ActionLaunchRequest - Launch payload for `seqera_action` Create / Update endpoints.
 type ActionLaunchRequest struct {
@@ -38,8 +66,9 @@ type ActionLaunchRequest struct {
 	// Custom run name
 	RunName *string `json:"runName,omitempty"`
 	// Pipeline schema name
-	SchemaName *string `json:"schemaName,omitempty"`
-	StubRun    *bool   `default:"false" json:"stubRun"`
+	SchemaName   *string                          `json:"schemaName,omitempty"`
+	StubRun      *bool                            `default:"false" json:"stubRun"`
+	SyntaxParser *ActionLaunchRequestSyntaxParser `json:"syntaxParser,omitempty"`
 	// Tower-specific configuration
 	TowerConfig *string  `json:"towerConfig,omitempty"`
 	UserSecrets []string `json:"userSecrets,omitempty"`
@@ -197,6 +226,13 @@ func (a *ActionLaunchRequest) GetStubRun() *bool {
 		return nil
 	}
 	return a.StubRun
+}
+
+func (a *ActionLaunchRequest) GetSyntaxParser() *ActionLaunchRequestSyntaxParser {
+	if a == nil {
+		return nil
+	}
+	return a.SyntaxParser
 }
 
 func (a *ActionLaunchRequest) GetTowerConfig() *string {

--- a/internal/sdk/models/shared/azbatchforgeconfig.go
+++ b/internal/sdk/models/shared/azbatchforgeconfig.go
@@ -8,6 +8,8 @@ import (
 
 type AzBatchForgeConfig struct {
 	AutoScale *bool `json:"autoScale,omitempty"`
+	// Boot disk size in GB for all pool nodes. When omitted, Azure uses the default disk size for the selected VM image. Per-pool values in headPool/workerPool take precedence in dual-pool mode.
+	BootDiskSizeGB *int `json:"bootDiskSizeGB,omitempty"`
 	// List of Azure Container Registry IDs whose images compute jobs may pull.
 	//
 	ContainerRegIds   []string `json:"containerRegIds,omitempty"`
@@ -37,6 +39,13 @@ func (a *AzBatchForgeConfig) GetAutoScale() *bool {
 		return nil
 	}
 	return a.AutoScale
+}
+
+func (a *AzBatchForgeConfig) GetBootDiskSizeGB() *int {
+	if a == nil {
+		return nil
+	}
+	return a.BootDiskSizeGB
 }
 
 func (a *AzBatchForgeConfig) GetContainerRegIds() []string {

--- a/internal/sdk/models/shared/azbatchpoolconfig.go
+++ b/internal/sdk/models/shared/azbatchpoolconfig.go
@@ -8,9 +8,11 @@ import (
 
 // AzBatchPoolConfig - Azure Batch pool configuration for head or worker pool
 type AzBatchPoolConfig struct {
-	AutoScale *bool   `json:"autoScale,omitempty"`
-	VMCount   *int    `json:"vmCount,omitempty"`
-	VMType    *string `json:"vmType,omitempty"`
+	AutoScale *bool `json:"autoScale,omitempty"`
+	// Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default.
+	BootDiskSizeGB *int    `json:"bootDiskSizeGB,omitempty"`
+	VMCount        *int    `json:"vmCount,omitempty"`
+	VMType         *string `json:"vmType,omitempty"`
 }
 
 func (a AzBatchPoolConfig) MarshalJSON() ([]byte, error) {
@@ -29,6 +31,13 @@ func (a *AzBatchPoolConfig) GetAutoScale() *bool {
 		return nil
 	}
 	return a.AutoScale
+}
+
+func (a *AzBatchPoolConfig) GetBootDiskSizeGB() *int {
+	if a == nil {
+		return nil
+	}
+	return a.BootDiskSizeGB
 }
 
 func (a *AzBatchPoolConfig) GetVMCount() *int {

--- a/internal/sdk/models/shared/datasetversiondto.go
+++ b/internal/sdk/models/shared/datasetversiondto.go
@@ -15,6 +15,7 @@ type DatasetVersionDto struct {
 	DateCreated        *time.Time       `json:"dateCreated,omitempty"`
 	Disabled           *bool            `json:"disabled,omitempty"`
 	FileName           *string          `json:"fileName,omitempty"`
+	FileSize           *int64           `json:"fileSize,omitempty"`
 	HasHeader          *bool            `json:"hasHeader,omitempty"`
 	LastUpdated        *time.Time       `json:"lastUpdated,omitempty"`
 	LinkedSource       *LinkedSourceDto `json:"linkedSource,omitempty"`
@@ -82,6 +83,13 @@ func (d *DatasetVersionDto) GetFileName() *string {
 		return nil
 	}
 	return d.FileName
+}
+
+func (d *DatasetVersionDto) GetFileSize() *int64 {
+	if d == nil {
+		return nil
+	}
+	return d.FileSize
 }
 
 func (d *DatasetVersionDto) GetHasHeader() *bool {

--- a/internal/sdk/models/shared/describeworkflowresponse.go
+++ b/internal/sdk/models/shared/describeworkflowresponse.go
@@ -82,12 +82,16 @@ type DescribeWorkflowResponseWorkflow struct {
 	// Timestamp when the workflow was submitted for execution
 	Submit *time.Time `json:"submit,omitempty"`
 	// Work directory
-	WorkDir     *string       `json:"workDir,omitempty"`
-	Fusion      *WfFusionMeta `json:"fusion,omitempty"`
-	LogFile     *string       `json:"logFile,omitempty"`
-	OperationID *string       `json:"operationId,omitempty"`
-	OutFile     *string       `json:"outFile,omitempty"`
-	Wave        *WfWaveMeta   `json:"wave,omitempty"`
+	WorkDir        *string       `json:"workDir,omitempty"`
+	Fusion         *WfFusionMeta `json:"fusion,omitempty"`
+	LogFile        *string       `json:"logFile,omitempty"`
+	NextflowConfig *string       `json:"nextflowConfig,omitempty"`
+	OperationID    *string       `json:"operationId,omitempty"`
+	OutFile        *string       `json:"outFile,omitempty"`
+	PostRunScript  *string       `json:"postRunScript,omitempty"`
+	PreRunScript   *string       `json:"preRunScript,omitempty"`
+	TowerConfig    *string       `json:"towerConfig,omitempty"`
+	Wave           *WfWaveMeta   `json:"wave,omitempty"`
 }
 
 func (d DescribeWorkflowResponseWorkflow) MarshalJSON() ([]byte, error) {
@@ -283,6 +287,13 @@ func (d *DescribeWorkflowResponseWorkflow) GetLogFile() *string {
 	return d.LogFile
 }
 
+func (d *DescribeWorkflowResponseWorkflow) GetNextflowConfig() *string {
+	if d == nil {
+		return nil
+	}
+	return d.NextflowConfig
+}
+
 func (d *DescribeWorkflowResponseWorkflow) GetOperationID() *string {
 	if d == nil {
 		return nil
@@ -295,6 +306,27 @@ func (d *DescribeWorkflowResponseWorkflow) GetOutFile() *string {
 		return nil
 	}
 	return d.OutFile
+}
+
+func (d *DescribeWorkflowResponseWorkflow) GetPostRunScript() *string {
+	if d == nil {
+		return nil
+	}
+	return d.PostRunScript
+}
+
+func (d *DescribeWorkflowResponseWorkflow) GetPreRunScript() *string {
+	if d == nil {
+		return nil
+	}
+	return d.PreRunScript
+}
+
+func (d *DescribeWorkflowResponseWorkflow) GetTowerConfig() *string {
+	if d == nil {
+		return nil
+	}
+	return d.TowerConfig
 }
 
 func (d *DescribeWorkflowResponseWorkflow) GetWave() *WfWaveMeta {

--- a/internal/sdk/models/shared/launchdbdto.go
+++ b/internal/sdk/models/shared/launchdbdto.go
@@ -323,6 +323,32 @@ func (c *ComputeEnv) GetWorkspaceID() *int64 {
 	return c.WorkspaceID
 }
 
+type LaunchDbDtoSyntaxParser string
+
+const (
+	LaunchDbDtoSyntaxParserV1 LaunchDbDtoSyntaxParser = "v1"
+	LaunchDbDtoSyntaxParserV2 LaunchDbDtoSyntaxParser = "v2"
+)
+
+func (e LaunchDbDtoSyntaxParser) ToPointer() *LaunchDbDtoSyntaxParser {
+	return &e
+}
+func (e *LaunchDbDtoSyntaxParser) UnmarshalJSON(data []byte) error {
+	var v string
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	switch v {
+	case "v1":
+		fallthrough
+	case "v2":
+		*e = LaunchDbDtoSyntaxParser(v)
+		return nil
+	default:
+		return fmt.Errorf("invalid value for LaunchDbDtoSyntaxParser: %v", v)
+	}
+}
+
 type LaunchDbDto struct {
 	ComputeEnv     *ComputeEnv `json:"computeEnv,omitempty"`
 	ConfigProfiles []string    `json:"configProfiles,omitempty"`
@@ -361,8 +387,9 @@ type LaunchDbDto struct {
 	// Pipeline schema name
 	SchemaName *string `json:"schemaName,omitempty"`
 	// Session ID for resuming
-	SessionID *string `json:"sessionId,omitempty"`
-	StubRun   *bool   `json:"stubRun,omitempty"`
+	SessionID    *string                  `json:"sessionId,omitempty"`
+	StubRun      *bool                    `json:"stubRun,omitempty"`
+	SyntaxParser *LaunchDbDtoSyntaxParser `json:"syntaxParser,omitempty"`
 	// Tower-specific configuration
 	TowerConfig *string  `json:"towerConfig,omitempty"`
 	UserSecrets []string `json:"userSecrets,omitempty"`
@@ -538,6 +565,13 @@ func (l *LaunchDbDto) GetStubRun() *bool {
 		return nil
 	}
 	return l.StubRun
+}
+
+func (l *LaunchDbDto) GetSyntaxParser() *LaunchDbDtoSyntaxParser {
+	if l == nil {
+		return nil
+	}
+	return l.SyntaxParser
 }
 
 func (l *LaunchDbDto) GetTowerConfig() *string {

--- a/internal/sdk/models/shared/workflowlaunchrequest.go
+++ b/internal/sdk/models/shared/workflowlaunchrequest.go
@@ -3,8 +3,36 @@
 package shared
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/seqeralabs/terraform-provider-seqera/internal/sdk/internal/utils"
 )
+
+type WorkflowLaunchRequestSyntaxParser string
+
+const (
+	WorkflowLaunchRequestSyntaxParserV1 WorkflowLaunchRequestSyntaxParser = "v1"
+	WorkflowLaunchRequestSyntaxParserV2 WorkflowLaunchRequestSyntaxParser = "v2"
+)
+
+func (e WorkflowLaunchRequestSyntaxParser) ToPointer() *WorkflowLaunchRequestSyntaxParser {
+	return &e
+}
+func (e *WorkflowLaunchRequestSyntaxParser) UnmarshalJSON(data []byte) error {
+	var v string
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	switch v {
+	case "v1":
+		fallthrough
+	case "v2":
+		*e = WorkflowLaunchRequestSyntaxParser(v)
+		return nil
+	default:
+		return fmt.Errorf("invalid value for WorkflowLaunchRequestSyntaxParser: %v", v)
+	}
+}
 
 type WorkflowLaunchRequest struct {
 	ComputeEnvID   *string  `json:"computeEnvId,omitempty"`
@@ -37,8 +65,9 @@ type WorkflowLaunchRequest struct {
 	// Custom run name
 	RunName *string `json:"runName,omitempty"`
 	// Pipeline schema name
-	SchemaName *string `json:"schemaName,omitempty"`
-	StubRun    *bool   `default:"false" json:"stubRun"`
+	SchemaName   *string                            `json:"schemaName,omitempty"`
+	StubRun      *bool                              `default:"false" json:"stubRun"`
+	SyntaxParser *WorkflowLaunchRequestSyntaxParser `json:"syntaxParser,omitempty"`
 	// Tower-specific configuration
 	TowerConfig *string  `json:"towerConfig,omitempty"`
 	UserSecrets []string `json:"userSecrets,omitempty"`
@@ -196,6 +225,13 @@ func (w *WorkflowLaunchRequest) GetStubRun() *bool {
 		return nil
 	}
 	return w.StubRun
+}
+
+func (w *WorkflowLaunchRequest) GetSyntaxParser() *WorkflowLaunchRequestSyntaxParser {
+	if w == nil {
+		return nil
+	}
+	return w.SyntaxParser
 }
 
 func (w *WorkflowLaunchRequest) GetTowerConfig() *string {

--- a/internal/sdk/retry/config.go
+++ b/internal/sdk/retry/config.go
@@ -98,6 +98,14 @@ func retryIntervalFromResponse(res *http.Response) time.Duration {
 		return 0
 	}
 
+	retryAfterMsVal := res.Header.Get("retry-after-ms")
+	if retryAfterMsVal != "" {
+		parsedMs, err := strconv.ParseInt(retryAfterMsVal, 10, 64)
+		if err == nil && parsedMs >= 0 {
+			return time.Duration(parsedMs) * time.Millisecond
+		}
+	}
+
 	retryVal := res.Header.Get("retry-after")
 	if retryVal == "" {
 		return 0

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.153.0 and generator version 2.903.5
+// Generated from OpenAPI doc version 1.159.0 and generator version 2.912.1
 
 import (
 	"context"
@@ -175,7 +175,7 @@ func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
 		SDKVersion: "0.40.2",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.40.2 2.903.5 1.153.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.40.2 2.912.1 1.159.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/overlays/forged-resources-fix.yaml
+++ b/overlays/forged-resources-fix.yaml
@@ -17,6 +17,10 @@ actions:
 
   - target: $["components"]["schemas"]["AzCloudConfig"]["properties"]["forgedResources"]
     remove: true
+  - target: $["components"]["schemas"]["AzCloudConfig"]["properties"]["deletedResources"]
+    remove: true
 
   - target: $["components"]["schemas"]["GoogleCloudConfig"]["properties"]["forgedResources"]
+    remove: true
+  - target: $["components"]["schemas"]["GoogleCloudConfig"]["properties"]["deletedResources"]
     remove: true

--- a/specs/seqera-api-cloud.yaml
+++ b/specs/seqera-api-cloud.yaml
@@ -5,7 +5,7 @@ info:
     url: https://seqera.io
   description: Seqera Platform services API
   title: Seqera API
-  version: 1.153.0
+  version: 1.159.0
 tags:
   - name: actions
     description: Pipeline actions
@@ -7695,6 +7695,14 @@ paths:
           schema:
             type: integer
             format: int64
+        - name: attributes
+          in: query
+          description: 'Additional attribute values to include in the response (`labels`, `resources`). Returns an empty value (ex. `labels: null`) if omitted.'
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ComputeEnvQueryAttribute'
+          explode: false
       responses:
         '200':
           description: OK
@@ -10335,6 +10343,14 @@ components:
       properties:
         autoScale:
           type: boolean
+        bootDiskSizeGB:
+          description: Boot disk size in GB for all pool nodes. When omitted, Azure uses the default disk size for the selected VM image. Per-pool values in headPool/workerPool take precedence in dual-pool mode.
+          type: integer
+          format: int32
+          example: 100
+          maximum: 4095
+          minimum: 50
+          nullable: true
         containerRegIds:
           type: array
           items:
@@ -10385,6 +10401,14 @@ components:
       properties:
         autoScale:
           type: boolean
+        bootDiskSizeGB:
+          description: Boot disk size in GB for this pool's nodes. Overrides the forge-level bootDiskSizeGB. When omitted, falls back to the forge-level value or Azure's default.
+          type: integer
+          format: int32
+          example: 100
+          maximum: 4095
+          minimum: 50
+          nullable: true
         vmCount:
           type: integer
           format: int32
@@ -10397,6 +10421,11 @@ components:
           type: string
         dataCollectionRuleId:
           type: string
+        deletedResources:
+          type: array
+          items:
+            $ref: '#/components/schemas/Map.Entry_String.String_'
+          readOnly: true
         discriminator:
           description: property to select the compute config platform
           type: string
@@ -12126,6 +12155,9 @@ components:
           type: boolean
         fileName:
           type: string
+        fileSize:
+          type: integer
+          format: int64
         hasHeader:
           type: boolean
         lastUpdated:
@@ -12845,6 +12877,13 @@ components:
         bootDiskSizeGb:
           type: integer
           format: int32
+        deletedResources:
+          type: array
+          items:
+            additionalProperties:
+              type: object
+            type: object
+          readOnly: true
         discriminator:
           description: property to select the compute config platform
           type: string
@@ -13353,6 +13392,12 @@ components:
           type: string
         stubRun:
           type: boolean
+        syntaxParser:
+          type: string
+          enum:
+            - v1
+            - v2
+          nullable: true
         towerConfig:
           type: string
         userSecrets:
@@ -16534,6 +16579,12 @@ components:
           type: string
         stubRun:
           type: boolean
+        syntaxParser:
+          type: string
+          enum:
+            - v1
+            - v2
+          nullable: true
         towerConfig:
           type: string
         userSecrets:
@@ -16813,10 +16864,22 @@ components:
               $ref: '#/components/schemas/WfFusionMeta'
             logFile:
               type: string
+            nextflowConfig:
+              type: string
+              nullable: true
             operationId:
               type: string
             outFile:
               type: string
+            postRunScript:
+              type: string
+              nullable: true
+            preRunScript:
+              type: string
+              nullable: true
+            towerConfig:
+              type: string
+              nullable: true
             wave:
               $ref: '#/components/schemas/WfWaveMeta'
           type: object


### PR DESCRIPTION
## Purpose

Add support for **Azure Batch boot disk size** to the provider. This exposes:

- `config.forge.boot_disk_size_gb` — boot disk size (GB) for all pool nodes; falls back to Azure's default for the VM image when omitted.
- `config.forge.head_pool.boot_disk_size_gb` / `config.forge.worker_pool.boot_disk_size_gb` — per-pool overrides for dual-pool mode; these take precedence over the forge-level value.

The change is generated by bumping the OpenAPI spec to the version that introduced boot disk support, then regenerating the provider via Speakeasy. Examples under `examples/resources/seqera_azure_batch_ce/` were updated to demonstrate both the forge-level and per-pool fields.

## Other changes pulled in

The Seqera API gained several unrelated changes between the previously-pinned spec version and the version that introduced boot disk support. Because the provider is regenerated from a single spec, they came along with this bump. **Each of these is independent of boot disk and could be pulled in separately if a more isolated change is preferred:**

- **`syntax_parser` launch field** (`v1`/`v2`) on `seqera_action`, `seqera_pipeline`, and `seqera_workflows` launch requests.
- **`describeWorkflow` response** gained additional metadata fields (`work_dir`, `fusion`, `log_file`, `nextflow_config`, `operation_id`, `out_file`, `pre_run_script`, `post_run_script`, `tower_config`, `wave`).
- **`launchDbDto`** gained `session_id`, `stub_run`, and `syntax_parser`.
- **`datasetVersionDto`** gained `file_size`.
- **`listDataStudioCompatibleComputeEnvs`** request tweak.
- **SDK retry config** and generated SDK metadata updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
