### PR TITLE
chore: migrate to StateUpgrader With PriorSchema

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -66,6 +66,7 @@ internal/stateupgraders/sshcredential_v0.go
 internal/stateupgraders/toweragentcredential_v0.go
 internal/provider/stateupgrader_schemas.go
 internal/provider/computeenv_upgrade_decode_test.go
+internal/provider/stateupgrader_all_test.go
 
 # Custom examples that should be manually maintained
 examples/resources/seqera_pipeline/resource*.tf

--- a/.genignore
+++ b/.genignore
@@ -33,11 +33,39 @@ internal/validators/objectvalidators/sched_config_consistency_validator.go
 internal/validators/boolvalidators/graviton_validator.go
 internal/validators/stringvalidators/work_dir_format_validator.go
 
-# Custom state upgraders for field renames and migrations
-internal/stateupgraders/awsbatchce_v0.go
-internal/stateupgraders/awscomputeenv_v0.go
-internal/stateupgraders/computeenv_v0.go
+# Custom state upgraders — all follow the default lenient-decode pattern
+# (docs-internal/STATE_UPGRADER_GUIDE.md); hand-maintained, not regenerated.
+internal/stateupgraders/upgrade.go
 internal/stateupgraders/action_v0.go
+internal/stateupgraders/awsbatchce_v0.go
+internal/stateupgraders/awscloudce_v0.go
+internal/stateupgraders/awscomputeenv_v0.go
+internal/stateupgraders/awscredential_v0.go
+internal/stateupgraders/azurebatchce_v0.go
+internal/stateupgraders/azurecloudce_v0.go
+internal/stateupgraders/azurecloudcredential_v0.go
+internal/stateupgraders/azurecredential_v0.go
+internal/stateupgraders/azureentracredential_v0.go
+internal/stateupgraders/bitbucketcredential_v0.go
+internal/stateupgraders/codecommitcredential_v0.go
+internal/stateupgraders/computeenv_v0.go
+internal/stateupgraders/computeenv_v1.go
+internal/stateupgraders/containerregistrycredential_v0.go
+internal/stateupgraders/credential_v0.go
+internal/stateupgraders/customrole_v0.go
+internal/stateupgraders/gcpbatchce_v0.go
+internal/stateupgraders/gcpcloudce_v0.go
+internal/stateupgraders/giteacredential_v0.go
+internal/stateupgraders/githubappcredential_v0.go
+internal/stateupgraders/githubcredential_v0.go
+internal/stateupgraders/gitlabcredential_v0.go
+internal/stateupgraders/googlecredential_v0.go
+internal/stateupgraders/kubernetescredential_v0.go
+internal/stateupgraders/managedcomputece_v0.go
+internal/stateupgraders/sshcredential_v0.go
+internal/stateupgraders/toweragentcredential_v0.go
+internal/provider/stateupgrader_schemas.go
+internal/provider/computeenv_upgrade_decode_test.go
 
 # Custom examples that should be manually maintained
 examples/resources/seqera_pipeline/resource*.tf

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,8 +3,8 @@ id: 9eba9f63-fbb7-47c2-b957-92fb58cab346
 management:
   docChecksum: c797d07e4e8c42002edba90b190e8c1e
   docVersion: 1.159.0
-  speakeasyVersion: 1.785.0
-  generationVersion: 2.912.1
+  speakeasyVersion: 1.789.0
+  generationVersion: 2.916.2
   releaseVersion: 0.40.2
   configChecksum: be5287cb9bc8dbd12dec8d589bf94764
 persistentEdits:
@@ -15,7 +15,7 @@ features:
   terraform:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.3.2
-    core: 3.47.9
+    core: 3.47.10
     deepObjectParams: 0.1.0
     deprecations: 2.82.0
     formatBinary: 0.2.0
@@ -32,4103 +32,2956 @@ features:
 trackedFiles:
   .gitattributes:
     id: 24139dae6567
-    last_write_checksum: sha1:84b0115789fc3ea52e31df701d8a27f76077e29f
     pristine_git_object: e6a994416d0f527912d2d272e2583458f4fc9bcb
   USAGE.md:
     id: 3aed33ce6e6f
-    last_write_checksum: sha1:02c32c9430f37507b3eacd41cdc36f080809e92d
     pristine_git_object: 8e707bb129af1da185ba30b4c289b0160819c437
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:a03922adeca9ee59546275c5c5ebbc2cb7c69eb9
     pristine_git_object: 7b241353e887cd10c08b0653d13c2227ce91f456
   examples/resources/seqera_action/import-by-string-id.tf:
     id: 7b9e1b28088a
-    last_write_checksum: sha1:69509c52fcabe7239f9cf9ac73d5c7029eb95ed0
     pristine_git_object: 5097519ef2bb5e9b9da0606f229c31845a408c81
   examples/resources/seqera_action/import.sh:
     id: 771fa2ccd8d1
-    last_write_checksum: sha1:06807556e5359a316749f6cae22936c3e82075b7
     pristine_git_object: 8c64813c1c33e262ff021894a61e0a6354df681f
   examples/resources/seqera_aws_batch_ce/import-by-string-id.tf:
     id: 4811e134260a
-    last_write_checksum: sha1:e2d566c61543875801c95c9935b7bf0bd859106b
     pristine_git_object: 4a52cca3c72f31414cf7695b70392a7b8e4f3649
   examples/resources/seqera_aws_batch_ce/import.sh:
     id: 45f5f3703fbe
-    last_write_checksum: sha1:108e897c27616d1a63d65694cabb42154b21823a
     pristine_git_object: d6079949f8cb6ae9974f13f89e3bf256b956b2e8
-  examples/resources/seqera_aws_cloud_ce/import-by-string-id.tf:
-    last_write_checksum: sha1:a0479971326f945570ee473b299f4a8dc77ad01b
-  examples/resources/seqera_aws_cloud_ce/import.sh:
-    last_write_checksum: sha1:cd4b1eb4e5d02a80612c97fafaf5687696b60b37
+  examples/resources/seqera_aws_cloud_ce/import-by-string-id.tf: {}
+  examples/resources/seqera_aws_cloud_ce/import.sh: {}
   examples/resources/seqera_aws_compute_env/import-by-string-id.tf:
     id: b90750c578e2
-    last_write_checksum: sha1:8f004d877b08f92ef600fe4abcd5fafd36cd9244
     pristine_git_object: a36e464cda845554ca26988f86e11437ebbac064
   examples/resources/seqera_aws_compute_env/import.sh:
     id: a9d8be886d3b
-    last_write_checksum: sha1:c559d213dd0c9cae884c07ff1de714c849b7e30f
     pristine_git_object: 83601f7153a116de5979ef74e2e4128dd16c3e8a
   examples/resources/seqera_aws_compute_env/resource.tf:
     id: b3072b89fa01
-    last_write_checksum: sha1:033f67595ea3ab758f583580d3e5656ea71bcf38
     pristine_git_object: f6cd02d2c1b98058a0e1babcbad048a6bc0d27ba
   examples/resources/seqera_aws_credential/import-by-string-id.tf:
     id: ad3bcd233d82
-    last_write_checksum: sha1:222929c7f7081990d4ff77390a826bf3960077fd
     pristine_git_object: e16169437f762b94a32848a4537f73ce82ca9c32
   examples/resources/seqera_aws_credential/import.sh:
     id: e4972b257c31
-    last_write_checksum: sha1:1c5ec602f1a51cb9e817739eb655ef892b5a2527
     pristine_git_object: 03c742164c58fdcc51c61e231038cdb09107cde5
-  examples/resources/seqera_azure_batch_ce/import-by-string-id.tf:
-    last_write_checksum: sha1:3d328f6ac3f83ecea81b5d3f0235d1ff1857c066
-  examples/resources/seqera_azure_batch_ce/import.sh:
-    last_write_checksum: sha1:80b66fd3b6f43812f278c63dba72a964a0d04e34
-  examples/resources/seqera_azure_cloud_ce/import-by-string-id.tf:
-    last_write_checksum: sha1:3f414450cbd7fa1c203b18cdbe7ba59e6a653ddb
-  examples/resources/seqera_azure_cloud_ce/import.sh:
-    last_write_checksum: sha1:d1a2365e71984f77d3f951e6ca328c0bb35e29b6
-  examples/resources/seqera_azure_cloud_credential/import-by-string-id.tf:
-    last_write_checksum: sha1:8350d9db629ab4a5183499a7b779e8577bd31931
-  examples/resources/seqera_azure_cloud_credential/import.sh:
-    last_write_checksum: sha1:af214bb6eabe25dc6acd45e2494fda36de863faa
+  examples/resources/seqera_azure_batch_ce/import-by-string-id.tf: {}
+  examples/resources/seqera_azure_batch_ce/import.sh: {}
+  examples/resources/seqera_azure_cloud_ce/import-by-string-id.tf: {}
+  examples/resources/seqera_azure_cloud_ce/import.sh: {}
+  examples/resources/seqera_azure_cloud_credential/import-by-string-id.tf: {}
+  examples/resources/seqera_azure_cloud_credential/import.sh: {}
   examples/resources/seqera_azure_credential/import-by-string-id.tf:
     id: 53558040e9ca
-    last_write_checksum: sha1:6518c53d5fed7582509fb8ebd5d70d7033dd23b1
     pristine_git_object: c4978b9c587644f1cc7f3d2e30cd179d3f7dc769
   examples/resources/seqera_azure_credential/import.sh:
     id: cbeb123214c6
-    last_write_checksum: sha1:9add37980734e6a40da57eeb3b70b25609a973c7
     pristine_git_object: dde5987defc526aa2feb51d9c682dc4192e5e5e3
-  examples/resources/seqera_azure_entra_credential/import-by-string-id.tf:
-    last_write_checksum: sha1:5380560437f97aedcaf29e6544adb12ab23f5d6d
-  examples/resources/seqera_azure_entra_credential/import.sh:
-    last_write_checksum: sha1:a5db0a4646c7b29711fd49b7deb6c5f5db442d73
+  examples/resources/seqera_azure_entra_credential/import-by-string-id.tf: {}
+  examples/resources/seqera_azure_entra_credential/import.sh: {}
   examples/resources/seqera_bitbucket_credential/import-by-string-id.tf:
     id: d6912a2080f1
-    last_write_checksum: sha1:07858bc491fd0debfea62111db86145c95b39553
     pristine_git_object: 8f22b34d9671444770b69dff6f48f06fad4acda6
   examples/resources/seqera_bitbucket_credential/import.sh:
     id: 92da17a4b326
-    last_write_checksum: sha1:0895a8675710a78abf110e7a782c757baca9f503
     pristine_git_object: 0a818666db7794b7a6e5f79bf4b26a5c0af8eb6b
   examples/resources/seqera_codecommit_credential/import-by-string-id.tf:
     id: b4d4404234f9
-    last_write_checksum: sha1:1fedad2aadfca835893b7241eb2258aef1a30e3f
     pristine_git_object: a99b6b27131c80328d6e99c591c63d2ecf48751e
   examples/resources/seqera_codecommit_credential/import.sh:
     id: 302e793461f9
-    last_write_checksum: sha1:e04c2ce8629dc0ff557fa62f161441d4f2712c47
     pristine_git_object: a20cb26841a6a1f855795e173aaae9a94d5881f5
   examples/resources/seqera_compute_env/import-by-string-id.tf:
     id: 13f60e2cb9b2
-    last_write_checksum: sha1:877b1f37af3e5139ba08b4c17e0417bf6c3915d0
     pristine_git_object: c45ae96c15ea0362a7c5f3719ae300721d46b3a9
   examples/resources/seqera_compute_env/import.sh:
     id: e6afc9aabb0c
-    last_write_checksum: sha1:6dcaed4ae16c3a9fb9d64672be3913d221a72b00
     pristine_git_object: 95bff4e89a0544480c2d3ce43a6da516d7542125
   examples/resources/seqera_compute_env/resource.tf:
     id: 281fbb9dbe05
-    last_write_checksum: sha1:434b3bee523ec67017a805f31aab56eeb3bee94f
     pristine_git_object: eb351742350d6f70ed41a265a3c499868043286d
   examples/resources/seqera_container_registry_credential/import-by-string-id.tf:
     id: 64a1256ab555
-    last_write_checksum: sha1:cf3edcff4d032e34c80f8e456705b20764332129
     pristine_git_object: 9f685febf2d507eaa7cc47d1cdf5fa5417066c7f
   examples/resources/seqera_container_registry_credential/import.sh:
     id: 05a9bb448c36
-    last_write_checksum: sha1:d1f5c76a28b2235d01ac3a27d1ec92a3d1f01e84
     pristine_git_object: e89ac47520d8662ce098f1458f3809cc53862df7
   examples/resources/seqera_credential/import-by-string-id.tf:
     id: 6933128d0881
-    last_write_checksum: sha1:3bf97f5bdf760df29b67ed4e0797d6f0c71dab15
     pristine_git_object: 39972f127b9957a7e037ff5247142593b831a426
   examples/resources/seqera_credential/import.sh:
     id: 1a35d741ac7b
-    last_write_checksum: sha1:f18cf7adaafe5f5bba6d786bb901960d5e83470a
     pristine_git_object: 12c546b32885a4203ab501c5db562909e8b00534
-  examples/resources/seqera_custom_role/import-by-string-id.tf:
-    last_write_checksum: sha1:d6669baf6959aa52ee1242df27865c26837d3a09
-  examples/resources/seqera_custom_role/import.sh:
-    last_write_checksum: sha1:f3c87442991d55f7d86acb28dc73b871c79e315f
+  examples/resources/seqera_custom_role/import-by-string-id.tf: {}
+  examples/resources/seqera_custom_role/import.sh: {}
   examples/resources/seqera_data_link/import-by-string-id.tf:
     id: ec38480385b8
-    last_write_checksum: sha1:2571aa5c57aa0e479edba8d1290d85824ee0f039
     pristine_git_object: 0292c1aa0dfa4f6e79986b7e5fb16d20f12829eb
   examples/resources/seqera_data_link/import.sh:
     id: b9beb539f9b3
-    last_write_checksum: sha1:5f5c12ab8488fe0c98db9917881877433c797b3c
     pristine_git_object: 9f05b46f07a7e0b71aa67ed2c041ca7be5ca45c3
   examples/resources/seqera_data_link/resource.tf:
     id: ff9c8bbcc1c8
-    last_write_checksum: sha1:369435b49c96426e740d9a4cc6459636d5cdf2af
     pristine_git_object: 45e98634becf704bc9c1b53859559db680ff50ba
   examples/resources/seqera_datasets/resource.tf:
     id: 0be316b4ec4e
-    last_write_checksum: sha1:53052782d84988d0ab29af37424cf1d99a3f2451
     pristine_git_object: 2f4f755594534c9f293d6f99f5cfc93dcad9948a
-  examples/resources/seqera_gcp_batch_ce/import-by-string-id.tf:
-    last_write_checksum: sha1:e2c3d6cc32cf27090d705ae046d44d75af09a771
-  examples/resources/seqera_gcp_batch_ce/import.sh:
-    last_write_checksum: sha1:c5409fbae3c8c9b22983f5e957e4af20213e608e
-  examples/resources/seqera_gcp_cloud_ce/import-by-string-id.tf:
-    last_write_checksum: sha1:29c2c018cd9a77492663d365f126d5a03ead40fb
-  examples/resources/seqera_gcp_cloud_ce/import.sh:
-    last_write_checksum: sha1:67d51ffe7bb5f78061696a27d0b58cad91d314f7
+  examples/resources/seqera_gcp_batch_ce/import-by-string-id.tf: {}
+  examples/resources/seqera_gcp_batch_ce/import.sh: {}
+  examples/resources/seqera_gcp_cloud_ce/import-by-string-id.tf: {}
+  examples/resources/seqera_gcp_cloud_ce/import.sh: {}
   examples/resources/seqera_gitea_credential/import-by-string-id.tf:
     id: 26efec7dcd49
-    last_write_checksum: sha1:db7ccd94a6c83c3281d85cdc49926361f361fa28
     pristine_git_object: e35422623aa52520f9bb8945cc1de0a2bf09ee69
   examples/resources/seqera_gitea_credential/import.sh:
     id: 8c0e614b09f4
-    last_write_checksum: sha1:4681c9452c3a5db6a2ac5eadc7f9d01cf48ef42e
     pristine_git_object: f6811dac82b57092419a4dd94f44e967bf3eaa58
-  examples/resources/seqera_github_app_credential/import-by-string-id.tf:
-    last_write_checksum: sha1:53924ca62112185d94db1c511ebf5907f84c1f33
-  examples/resources/seqera_github_app_credential/import.sh:
-    last_write_checksum: sha1:bd7143844d6ee4d5ac59e6c627536b6f90114363
+  examples/resources/seqera_github_app_credential/import-by-string-id.tf: {}
+  examples/resources/seqera_github_app_credential/import.sh: {}
   examples/resources/seqera_github_credential/import-by-string-id.tf:
     id: cec576dc44c5
-    last_write_checksum: sha1:b4cc4d7bbb39c46c5a97f5ddf5260b14fb2914c4
     pristine_git_object: 79b716aafeefc919c9612ce1ac3a1973e4bb6197
   examples/resources/seqera_github_credential/import.sh:
     id: 3949d9b6b6e9
-    last_write_checksum: sha1:1da59e162dc4ac17dc9c9f534ec52f948acadeb7
     pristine_git_object: 2ab60310623b532cc4ec625014598077eb38dc3c
   examples/resources/seqera_gitlab_credential/import-by-string-id.tf:
     id: 202d97610124
-    last_write_checksum: sha1:4cb01d790bf77c2b8fa2a0eb2399c2f6e0803fe1
     pristine_git_object: 86f02d4f51f77744cfb27d7753c7ee3e8ce8ae23
   examples/resources/seqera_gitlab_credential/import.sh:
     id: 1f454dbdee03
-    last_write_checksum: sha1:3801aaab404867fd521d968481c07b412b06c0b0
     pristine_git_object: b4d7dfacb838d9a2fcd47d30f9214606a274aa55
-  examples/resources/seqera_google_credential/import-by-string-id.tf:
-    last_write_checksum: sha1:73d1fb5353192a6885e6e7124cea8ca1568ed7e0
+  examples/resources/seqera_google_credential/import-by-string-id.tf: {}
   examples/resources/seqera_kubernetes_credential/import-by-string-id.tf:
     id: 351dcc957fb0
-    last_write_checksum: sha1:2f2517e0681e6ffe51a03b739d25623c5003b2b9
     pristine_git_object: bbf6c0f6e305976ab6b0180b67addf134a9a4de8
   examples/resources/seqera_kubernetes_credential/import.sh:
     id: f8fe469e9196
-    last_write_checksum: sha1:8485d845061616209a6fc31cd0d88767d0d795ab
     pristine_git_object: 3f3f73233c1026ed25f8fd50fd8fcdd71c107aa5
   examples/resources/seqera_managed_compute_ce/import-by-string-id.tf:
     id: 2a079c451bbd
-    last_write_checksum: sha1:11c460902a2e7c25ec3b3ffbb241be1d933fb2a0
     pristine_git_object: f540828ca83f1472495bf88c7549f8b3ecd4d66b
   examples/resources/seqera_managed_compute_ce/import.sh:
     id: 345c7266fa17
-    last_write_checksum: sha1:7c39153c91be3cd0ffadb4181b4872711d63abc0
     pristine_git_object: 97c1684a05abcc044a2cb9479f8ed106aebd9140
   examples/resources/seqera_orgs/import-by-string-id.tf:
     id: 5a507b0e72f0
-    last_write_checksum: sha1:b62969f364fff9b09c96a75b1558066577785983
     pristine_git_object: e753190eff699338fee1f38f62a00a83298835ba
   examples/resources/seqera_orgs/import.sh:
     id: 074ee29db874
-    last_write_checksum: sha1:cb4047b733821582f96eafe435e872bc63f7b87d
     pristine_git_object: 5724e635887fb97edee061d59f58007489b9b6ff
   examples/resources/seqera_pipeline/import-by-string-id.tf:
     id: 2eabffdc33aa
-    last_write_checksum: sha1:566a1bddd164cb9e8b042957dfcbda2fddb2dc95
     pristine_git_object: 63cc38ae333bfe4b1ce5569bc03e89ebe6321ba1
   examples/resources/seqera_pipeline/import.sh:
     id: e57779bdc35f
-    last_write_checksum: sha1:5700e85c31cc3c2181f8223c6d5671bd97991beb
     pristine_git_object: 12a7eb4925e4b351967b0515d9f2b509e905ec4d
   examples/resources/seqera_pipeline_secret/import-by-string-id.tf:
     id: 706fedb7e486
-    last_write_checksum: sha1:0c0a258e4441490fd4ba53c8c90b19a20f71e531
     pristine_git_object: 51d5b66abe55d7adc09669ab56300cb341879a01
   examples/resources/seqera_pipeline_secret/import.sh:
     id: aba12e768acd
-    last_write_checksum: sha1:d3f216f513b21db27ce04440c02b989413ae47ea
     pristine_git_object: 4d69188d92974da17d3f96e317dcd1fea7e8c561
   examples/resources/seqera_ssh_credential/import-by-string-id.tf:
     id: 5366e17fedde
-    last_write_checksum: sha1:717930037e6623c72161d5a98da980d84c4d6e60
     pristine_git_object: ee758781cdb46ddb1cab63a1de1d3af84e3784e1
   examples/resources/seqera_ssh_credential/import.sh:
     id: e07c6c42952d
-    last_write_checksum: sha1:945668b9be569d0ae9babdb7a90d0831defc54ce
     pristine_git_object: b8773e8e728549da151c6a6ffb7109a4a030834c
   examples/resources/seqera_studios/import-by-string-id.tf:
     id: f5422afa526c
-    last_write_checksum: sha1:b0dbc163c5196e25873b9bd19aa073f032ad147f
     pristine_git_object: e5e20b5c9b48e38866514f574ee1df81c35d4516
   examples/resources/seqera_studios/import.sh:
     id: 6ab23ce1fa33
-    last_write_checksum: sha1:5fd903f69794aad88d84770cbdcd07abc2bcb478
     pristine_git_object: bee0cb4dcc8b88a5aa7e3f7443ea87e596dba4df
   examples/resources/seqera_teams/import-by-string-id.tf:
     id: ab48b083196d
-    last_write_checksum: sha1:f19e5577f375c01c0dc0c6b59be6f3e56599dd40
     pristine_git_object: 46610c542e21a9cd79e1be283a565ce642efcc9a
   examples/resources/seqera_teams/import.sh:
     id: 9bd369f2d86f
-    last_write_checksum: sha1:d080be5e8c6ac24b30b025529a513aef8de22809
     pristine_git_object: 57f8065f27d3486eab66202c29575348da25c998
   examples/resources/seqera_teams/resource.tf:
     id: 08c184c94fdc
-    last_write_checksum: sha1:b4bc8fa2b507adae71c4dadc9c8852692ea5f7ad
     pristine_git_object: 1d1e81b647e97a166456b7cbae35c9ac05dc477f
   examples/resources/seqera_tower_agent_credential/import-by-string-id.tf:
     id: 559a9a121b1f
-    last_write_checksum: sha1:c30c932768a6e9c2b3bbb9fd20c2d9cabfab0367
     pristine_git_object: f8bc298d062a4c72a18e3e6576207709e4403f0b
   examples/resources/seqera_tower_agent_credential/import.sh:
     id: 4808258b4c68
-    last_write_checksum: sha1:39745d89aff10b62bc9a57f1513793af6557afb6
     pristine_git_object: 7bd992c9eb2db0a3eee79a9049c5a738058ee00c
   examples/resources/seqera_workflows/import-by-string-id.tf:
     id: 22bc4d0b4ded
-    last_write_checksum: sha1:39ae63fc9a04030c4853922731bd26f66ff6f969
     pristine_git_object: 17b6e306d51ecccf2deb8bce4c2296457383d2a1
   examples/resources/seqera_workflows/import.sh:
     id: d72df2a453b1
-    last_write_checksum: sha1:1dd1888af4d5c75b32ea48158075371806c131dd
     pristine_git_object: ebe5c685294e2baca949dfdf846337e51207d59d
   examples/resources/seqera_workspace/import-by-string-id.tf:
     id: c349aba83f4f
-    last_write_checksum: sha1:38ef913efe9add7d8d7219f9eb050d050e5bcef4
     pristine_git_object: 5bf153cf0cfe353c8e32320a6fa77346443e5609
   examples/resources/seqera_workspace/import.sh:
     id: b170b4db54bb
-    last_write_checksum: sha1:f276ffe76e31add18c64210ea7e5d667c6f77c9f
     pristine_git_object: fd5a27e12a4fe32fb7817dd93d51447a7d67f58d
   examples/resources/seqera_workspace/resource.tf:
     id: 0861dd715211
-    last_write_checksum: sha1:3f3a3ec874fa3912c2f1f9077e710deb6db914ad
     pristine_git_object: 6cdb08cff8d5e98c92183f577fc8fbe059d61ff7
   go.mod:
     id: c47645c391ad
-    last_write_checksum: sha1:1c577c00db60936b589c66abbafac202a0d0504b
     pristine_git_object: 0197aba33874c19d2d4a76f51d3c37929a4d811e
   internal/planmodifiers/boolplanmodifier/suppress_diff.go:
     id: 3cf85b98963e
-    last_write_checksum: sha1:49b88a4c160a1d03f4366625dc553431dbdba147
     pristine_git_object: c84c994d4c433cd376e8f75e0634c107ae132820
   internal/planmodifiers/boolplanmodifier/use_config_value.go:
     id: c0a10558e419
-    last_write_checksum: sha1:506e2cac3ec4075a8837403860ef0b07e19bc337
     pristine_git_object: 210846ca24831a6bda811d3e8a42326716d7bf97
-  internal/planmodifiers/boolplanmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:19e3f5464a0e42d125ba4690d9748365eae1b8c5
+  internal/planmodifiers/boolplanmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/float32planmodifier/suppress_diff.go:
     id: b7f3f671e479
-    last_write_checksum: sha1:ecb1675c4f66fbe56ada593ef68408552d49836a
     pristine_git_object: 227291a5e4437d4c1ceec54339d53c4de9c0e1a2
   internal/planmodifiers/float32planmodifier/use_config_value.go:
     id: e75edfe23c08
-    last_write_checksum: sha1:2683d9de3605886cb01438a9015c8e8b02b4e069
     pristine_git_object: 0aafffa779b10b01d1e9c831c3a4bda3e6d97789
-  internal/planmodifiers/float32planmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:b69eebcd523fcf4b495dbd6a2251f585df80f54d
+  internal/planmodifiers/float32planmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/float64planmodifier/suppress_diff.go:
     id: 7ae872c2243d
-    last_write_checksum: sha1:0124e3ccc8ee6d887fe0e85a259d1df513e695a7
     pristine_git_object: 25709901456db6e3e746b3a1724f078c56a5b97b
   internal/planmodifiers/float64planmodifier/use_config_value.go:
     id: 8fd8670f7434
-    last_write_checksum: sha1:cc1f1cadfd17a0b9b1e729029dccc03f17d734a5
     pristine_git_object: ecd655b8d658d84aa5cbcc3e1808b69674071325
-  internal/planmodifiers/float64planmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:781f7c8e262e4ae1874fcd97ff6b85c914eabcb4
+  internal/planmodifiers/float64planmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/int32planmodifier/suppress_diff.go:
     id: 3ee3ede7dc9d
-    last_write_checksum: sha1:ade2464f800909220afff1a5cb582dceee39029f
     pristine_git_object: 943019a67810660046cafd3675ecead4d853d8d4
   internal/planmodifiers/int32planmodifier/use_config_value.go:
     id: 40be4e07e289
-    last_write_checksum: sha1:019ba1949b00493bf1a866821f9331d50c8a1f09
     pristine_git_object: ebc98aae308008b2cda39d5f4cfa781982afa44f
-  internal/planmodifiers/int32planmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:00a834624cd43e662619ae7860aa73a8f54f9133
+  internal/planmodifiers/int32planmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/int64planmodifier/suppress_diff.go:
     id: fade0cc85582
-    last_write_checksum: sha1:a642bf33f3843a8a3f96751a396de906476dc22e
     pristine_git_object: 1a370b919ad5bc2458654b01f60507c425c80c85
   internal/planmodifiers/int64planmodifier/use_config_value.go:
     id: e38d6f43d093
-    last_write_checksum: sha1:b5a63f0c356cd72698e25e1b4f4fc3e29b35d482
     pristine_git_object: 2ec2d53d3ac13f58f64feb32b7fb07ca37b8fe99
-  internal/planmodifiers/int64planmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:73a80b39692ea3c371b8d994d71319aa147c82eb
+  internal/planmodifiers/int64planmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/listplanmodifier/suppress_diff.go:
     id: 7b93ed9460b9
-    last_write_checksum: sha1:c5e8780a945a698b6ed3d7f6da20324b7764aa77
     pristine_git_object: 8ccabf7baf6603ae3dd3fe9ee52d8aef4185456d
   internal/planmodifiers/listplanmodifier/use_config_value.go:
     id: c9b31b246860
-    last_write_checksum: sha1:c56e2d23520ac7023f800328bb7599e7eba2f202
     pristine_git_object: 7e851c7613c71921fd4ccf7ca1f95b8b22ce9745
-  internal/planmodifiers/listplanmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:0c4df3c0df83cb20473bc9b8a0a5dd78943b132c
+  internal/planmodifiers/listplanmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/mapplanmodifier/suppress_diff.go:
     id: 37bee37da583
-    last_write_checksum: sha1:08672c18bef2bd853c500a8bd802397fb55ca684
     pristine_git_object: 361ba9840c8c3af6a638d2ce26b7e6cf9dcc4c2f
   internal/planmodifiers/mapplanmodifier/use_config_value.go:
     id: 8fef370eccaa
-    last_write_checksum: sha1:7c2163c8fa4be8e8f7e7499cdb08cc5ed1924b39
     pristine_git_object: 0f2a717f45ca60218f4b8d9e81a6a5cd01494905
-  internal/planmodifiers/mapplanmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:71ed9035c032928c82d7fa6530ecf68d36aa8e80
+  internal/planmodifiers/mapplanmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/numberplanmodifier/suppress_diff.go:
     id: 0debe6a63221
-    last_write_checksum: sha1:4c244910bcba14a4216b13053eb5c69374049ad6
     pristine_git_object: ac8813093405d5d2f837e5a23fe463004c35f06f
   internal/planmodifiers/numberplanmodifier/use_config_value.go:
     id: e6b779d30d26
-    last_write_checksum: sha1:9b92d53a4a5f57e211e6f41ebb6c36cb12357ae6
     pristine_git_object: e93c117a0665121b4c43c4a0fd5faec999ad016e
-  internal/planmodifiers/numberplanmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:dbf77a4e4c215033be4ffd35e8458a63406c1287
+  internal/planmodifiers/numberplanmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/objectplanmodifier/suppress_diff.go:
     id: c5bc1c3980dd
-    last_write_checksum: sha1:a0256ab0b2fbe48414f2aa1fef0bd8ec33d518fb
     pristine_git_object: 1940b9d7155e5378c3b3725551da1a1416f86ad3
   internal/planmodifiers/objectplanmodifier/use_config_value.go:
     id: 7f103d324869
-    last_write_checksum: sha1:1f2b6727605c0b56ff2212ab2e2528046f05b157
     pristine_git_object: eaf24076aeaf233c342886079be38561b94d3856
-  internal/planmodifiers/objectplanmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:7eae241c8093cde335701b6f69b1e0d7d5c46b89
+  internal/planmodifiers/objectplanmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/setplanmodifier/suppress_diff.go:
     id: 2db9381ea39f
-    last_write_checksum: sha1:eb44d6dad9883959318ab749f20a08863a97e595
     pristine_git_object: bfc6558df4e6627e42e80e1eb587231a39dd2899
   internal/planmodifiers/setplanmodifier/use_config_value.go:
     id: 62a591230001
-    last_write_checksum: sha1:fe02165f8fd260bbce09f34adfa378376363422f
     pristine_git_object: a95de11e54a028586b41352c084de59fdc7af66c
-  internal/planmodifiers/setplanmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:a34ae50f35ef83487a6ad886c0c233b00aad4f2c
+  internal/planmodifiers/setplanmodifier/use_hoisted_value.go: {}
   internal/planmodifiers/stringplanmodifier/suppress_diff.go:
     id: 05379039a176
-    last_write_checksum: sha1:c8d4c21e2d576fe085f65a0a8d7d52ec38647a97
     pristine_git_object: a269e22e227efa540de3014ca07769fbccb31ec3
   internal/planmodifiers/stringplanmodifier/use_config_value.go:
     id: a783ed056524
-    last_write_checksum: sha1:250673402508661f9d12cfa026dc029d5e7855d9
     pristine_git_object: 8b4457aeb6b22b7f2b581434762e71f3f782897b
-  internal/planmodifiers/stringplanmodifier/use_hoisted_value.go:
-    last_write_checksum: sha1:b42f9ea7d7fd44e6f1ec3ffe6427cca765ce52fc
-  internal/planmodifiers/utils/hoisted_value.go:
-    last_write_checksum: sha1:04ccb3d58a019eb0e94efe207280974e85e5fccc
+  internal/planmodifiers/stringplanmodifier/use_hoisted_value.go: {}
+  internal/planmodifiers/utils/hoisted_value.go: {}
   internal/planmodifiers/utils/state_check.go:
     id: ead742412d0f
-    last_write_checksum: sha1:acc38ad698bf4fa8c51aa662076cf57b79024bd5
     pristine_git_object: 0ea64fbeb1fd7709d7241a8e06d34bfe9d0323d3
   internal/provider/action_resource.go:
     id: f7c19bf35b58
-    last_write_checksum: sha1:69176cf0daf0e241901fea820b21b00a10853115
     pristine_git_object: fc35041e2f1cf6db01d04e9e9e861df96d042782
   internal/provider/action_resource_sdk.go:
     id: 28576317893d
-    last_write_checksum: sha1:d707481fc6da1ea997caea847c0f81006ddad23d
     pristine_git_object: b987eb32b2d86ebe52fb9875e9e4b6eb9f30af6e
   internal/provider/awsbatchce_resource.go:
     id: aeeab49ad69b
-    last_write_checksum: sha1:85257e3303b081ec2485fd2d8aa1a764cd3c214b
     pristine_git_object: 136a1cfb3f23c1c396175224b78c790e8d4b9808
   internal/provider/awsbatchce_resource_sdk.go:
     id: acddb134f02d
-    last_write_checksum: sha1:740cf5754190349ebbc8e4c0bb03f936131f8797
     pristine_git_object: 91db6c7b9d563b0b0fa5e57c712ed1952c1d54d2
-  internal/provider/awscloudce_resource.go:
-    last_write_checksum: sha1:ab9e16853cd3011662e56a305d0e0a8919ce5b1f
-  internal/provider/awscloudce_resource_sdk.go:
-    last_write_checksum: sha1:73b7464ac299fa3bd1b2eb0804ab21e282fd973f
+  internal/provider/awscloudce_resource.go: {}
+  internal/provider/awscloudce_resource_sdk.go: {}
   internal/provider/awscomputeenv_resource.go:
     id: 788844f2d22e
-    last_write_checksum: sha1:dc043ab61d705afdd471ee6230dbae3f9c86d40e
     pristine_git_object: 251b9b34df068086a2b6c118fd0cdc7384d6fb53
   internal/provider/awscomputeenv_resource_sdk.go:
     id: 9a23d2e0f03e
-    last_write_checksum: sha1:458b3efe0e21d338579d646e6eaddbdd7b49ad13
     pristine_git_object: 4d4451329e274230a287210d496b8e03aea29724
   internal/provider/awscredential_resource.go:
     id: fd1fb9518f67
-    last_write_checksum: sha1:6aa98ca72229312eea9bb900f9ebdf352a9d7af6
     pristine_git_object: 718916f70c62d6cdeb910a896ec32723c62f9346
   internal/provider/awscredential_resource_sdk.go:
     id: 6dd3171fbbcc
-    last_write_checksum: sha1:7c5985ec470f43666b2a5860949f2d8ad5b4a5a1
     pristine_git_object: fb79abddd43fc8a362ddaff379637c1def78665a
-  internal/provider/azurebatchce_resource.go:
-    last_write_checksum: sha1:1ce321f12f3670cb644efcbc9827e82edebd7024
-  internal/provider/azurebatchce_resource_sdk.go:
-    last_write_checksum: sha1:834fb91d5dc049549663c97046e63336382b08ca
-  internal/provider/azurecloudce_resource.go:
-    last_write_checksum: sha1:73f3875c6e5be74a32d273e590cd53455ac2f5cd
-  internal/provider/azurecloudce_resource_sdk.go:
-    last_write_checksum: sha1:6c900aeec91332059ab4153de664b8dabcd784ce
-  internal/provider/azurecloudcredential_resource.go:
-    last_write_checksum: sha1:978b428562ae34f3f2002e91d703e648edb32dac
-  internal/provider/azurecloudcredential_resource_sdk.go:
-    last_write_checksum: sha1:98e6c39d90143a54f4e406d3e29fdb7b214a6baa
+  internal/provider/azurebatchce_resource.go: {}
+  internal/provider/azurebatchce_resource_sdk.go: {}
+  internal/provider/azurecloudce_resource.go: {}
+  internal/provider/azurecloudce_resource_sdk.go: {}
+  internal/provider/azurecloudcredential_resource.go: {}
+  internal/provider/azurecloudcredential_resource_sdk.go: {}
   internal/provider/azurecredential_resource.go:
     id: 4e14a60d78ce
-    last_write_checksum: sha1:d9a32f5b55b3a7d1f5f9bf88467b2bacfa2c27de
     pristine_git_object: 0eb0896ee9fe4eed104d1d66e3c5b72221a8e8c1
   internal/provider/azurecredential_resource_sdk.go:
     id: 1cff49867392
-    last_write_checksum: sha1:8aa8abd56361e0ab7058cac34733fe276d68653a
     pristine_git_object: 62f301e24df9501920ae8a9afe8ae7927b82a862
-  internal/provider/azureentracredential_resource.go:
-    last_write_checksum: sha1:7467274d28fb6c69044172ccf517da543b96f791
-  internal/provider/azureentracredential_resource_sdk.go:
-    last_write_checksum: sha1:7dbc7e788036389cf01880fd702f0b7a60ade649
+  internal/provider/azureentracredential_resource.go: {}
+  internal/provider/azureentracredential_resource_sdk.go: {}
   internal/provider/bitbucketcredential_resource.go:
     id: 99461a76ba60
-    last_write_checksum: sha1:5bce9723362d15b5b7e0c2e3f3f10b2eafdae385
     pristine_git_object: ef48989850ba46b7641a28a14055504c1737a53c
   internal/provider/bitbucketcredential_resource_sdk.go:
     id: ea250abc2a72
-    last_write_checksum: sha1:20b9b139f9026d80011a6136ca4553ed2bee1f26
     pristine_git_object: 8a0bebdcdd3d64be9a83a6a75aa5bc0422f8f3ff
   internal/provider/codecommitcredential_resource.go:
     id: 22c2e9aa4b13
-    last_write_checksum: sha1:27a2a4e7ec3e2d1f4935eacb2a57cd00f73959c7
     pristine_git_object: 58dcb06c3f42ed4aa8f5bf250a2b70ed4ad235ed
   internal/provider/codecommitcredential_resource_sdk.go:
     id: dcc60e154878
-    last_write_checksum: sha1:78fdb9a7650b187e6dd6dca607fe7062af7b3105
     pristine_git_object: 0c1b43d5db49b023cf3c7408c198a4d66c795d8a
   internal/provider/computeenv_resource.go:
     id: f4162f219efd
-    last_write_checksum: sha1:4fb3a753c6c5e3871e2b5bec594c7ae6b0b8393f
     pristine_git_object: d5550a0a3bc980d281c55531d71458e7e4968b48
   internal/provider/computeenv_resource_sdk.go:
     id: 1e29eea44332
-    last_write_checksum: sha1:3c277fb3f4710651090a42c3341e0c22de7f2256
     pristine_git_object: 2e933070714e8aa8d9ab83f2e1b81abd6f262ade
   internal/provider/containerregistrycredential_resource.go:
     id: f0a18857f2ea
-    last_write_checksum: sha1:058e2d28d8686f3f3c8229d9ae6f45a937145dde
     pristine_git_object: e6a9866eacb679ff8d1567624763412dcb61f0d1
   internal/provider/containerregistrycredential_resource_sdk.go:
     id: 84a1496699d8
-    last_write_checksum: sha1:d7cd5a183698275ef86cc01c7b340039e2e96799
     pristine_git_object: 9cb9ad7d844c9ac4c05ed05c9fbc4351231a9c4e
   internal/provider/credential_resource.go:
     id: b17d06f08976
-    last_write_checksum: sha1:c2c710c18b224f75ce4715eaea800a9313988635
     pristine_git_object: e695351308d33c3457984e46178c7f8eb775ae87
   internal/provider/credential_resource_sdk.go:
     id: 0a20c4488832
-    last_write_checksum: sha1:13d2731a79b33213796e715d69dc08756c51b686
     pristine_git_object: 5f30e81b72fd0a632305020694beed9efec6112c
   internal/provider/credentials_data_source.go:
     id: 44d9e7a82f76
-    last_write_checksum: sha1:f09705d90a6068dcaf26ef6a0741baa784735639
     pristine_git_object: c094aecdbc654b7e9aa573e2d84d1527c309e47b
   internal/provider/credentials_data_source_sdk.go:
     id: b0f72a52b626
-    last_write_checksum: sha1:e0a459c5a5607b21f3635ffd97bd73a24ecbc82a
     pristine_git_object: 807cf3f81a5f07294dd545ab9e7dbdb66c6dbe6b
-  internal/provider/customrole_resource.go:
-    last_write_checksum: sha1:b6a4a813e3a502aa2046f1255d3d8af44221ed34
-  internal/provider/customrole_resource_sdk.go:
-    last_write_checksum: sha1:8db6d4e14a6c8757f38a26f0cac77b485e6e9627
+  internal/provider/customrole_resource.go: {}
+  internal/provider/customrole_resource_sdk.go: {}
   internal/provider/datalink_resource.go:
     id: 6f886fe60227
-    last_write_checksum: sha1:872c91faee7c348aaf2747e5ac460295aa1ce4d4
     pristine_git_object: 902c444f8d5b5d7081962322c5f7b97db2feca79
   internal/provider/datalink_resource_sdk.go:
     id: 32916a33fa82
-    last_write_checksum: sha1:420d7b8ff0b51885a49d26e38b6835777c30ad6e
     pristine_git_object: 2ad07b97c9a0b94cd787c77ca0b89e7f5e92b8f1
   internal/provider/datalinks_data_source.go:
     id: b9cf30e3a6ef
-    last_write_checksum: sha1:a01d4caa40e952796f065b22cf8429be1ccda1fe
     pristine_git_object: 4b14bf36e23eee5c79dada6792e83bd085128dfb
   internal/provider/datalinks_data_source_sdk.go:
     id: c0e0f9715c6e
-    last_write_checksum: sha1:dda1f62454e208f1b6c169bf444b91d0845788fb
     pristine_git_object: a11343b74cdb3c23d8c861291edc7710e5560b70
   internal/provider/datasets_resource.go:
     id: bdf0dcdc921f
-    last_write_checksum: sha1:d8dd2a3f9d59609f1ac59596521fdc894c2ec365
     pristine_git_object: 26d50fc9986e0282f816f4607e6ef48d5ac0cba7
   internal/provider/datasets_resource_sdk.go:
     id: 648d7d53f1b6
-    last_write_checksum: sha1:2518480b1bf5983bf0d0fec9a47e654d138db587
     pristine_git_object: d3d10cadef9504a6a38441129ada6ccaf494496e
-  internal/provider/gcpbatchce_resource.go:
-    last_write_checksum: sha1:b04f32b27c0b6d6893f12bd95a22ac7989323338
-  internal/provider/gcpbatchce_resource_sdk.go:
-    last_write_checksum: sha1:8ccf87f0b313e7326dfc17582b395ac0aadcc050
-  internal/provider/gcpcloudce_resource.go:
-    last_write_checksum: sha1:8bfd30f1d8a430efd90ada3ea14af53646fb36e1
-  internal/provider/gcpcloudce_resource_sdk.go:
-    last_write_checksum: sha1:5db764bec9f6692c066597f688af2efd37031152
+  internal/provider/gcpbatchce_resource.go: {}
+  internal/provider/gcpbatchce_resource_sdk.go: {}
+  internal/provider/gcpcloudce_resource.go: {}
+  internal/provider/gcpcloudce_resource_sdk.go: {}
   internal/provider/giteacredential_resource.go:
     id: 2aeb5fb04152
-    last_write_checksum: sha1:c9cd253e8540eff268f3ba8fcc0c599317120efa
     pristine_git_object: 511473aefa420f60b1e0fdd850d0d2360c7cd1aa
   internal/provider/giteacredential_resource_sdk.go:
     id: 63ee809ee195
-    last_write_checksum: sha1:002b5c5e8f4a426190b04e60d831321fa1ad8a70
     pristine_git_object: 71e29ff10c22205eab4418ac0b8a92152cc5b23d
-  internal/provider/githubappcredential_resource.go:
-    last_write_checksum: sha1:a546edc6420a15bf815803eade73cfc3d413f000
-  internal/provider/githubappcredential_resource_sdk.go:
-    last_write_checksum: sha1:e1db7772edde1b145bbb5ac9fe01b03811a903ff
+  internal/provider/githubappcredential_resource.go: {}
+  internal/provider/githubappcredential_resource_sdk.go: {}
   internal/provider/githubcredential_resource.go:
     id: e1f090a0cb9e
-    last_write_checksum: sha1:5c99fc9cce9b283fa08d88a9ccabc8b294d7534e
     pristine_git_object: c6a4da7de3d8a1ca06c268021bcb56ba09f3c9f1
   internal/provider/githubcredential_resource_sdk.go:
     id: bc2bee614a62
-    last_write_checksum: sha1:73184f74d6a1ffb872b90a6912bc4628a6524dda
     pristine_git_object: 01c4b02c388b5caf56516bd71e9a2176973234b2
   internal/provider/gitlabcredential_resource.go:
     id: fcb86103d097
-    last_write_checksum: sha1:ec7c6deaaf2c05284ccf028ccd026e3f9e098a5d
     pristine_git_object: 5b27290c979fb073cf156f1babc37c36cde9ab8e
   internal/provider/gitlabcredential_resource_sdk.go:
     id: a6c217015659
-    last_write_checksum: sha1:05c581fa6c41c0fc8e1cd088e0e5740490d0f330
     pristine_git_object: 0f3d5604b62f838d2b0b79919f08bc65e5c9cf5b
   internal/provider/googlecredential_resource.go:
     id: 8822521a4af3
-    last_write_checksum: sha1:0005c125efc524e4dab5ea095cae2a373a1fded6
     pristine_git_object: 026226dc9ef3d464025bca768181bcaa0a4e6f7f
   internal/provider/googlecredential_resource_sdk.go:
     id: b4c881561996
-    last_write_checksum: sha1:ea2ca1600cc7f60faeeaaba0c0ffe32bc496842c
     pristine_git_object: a25a2b110b86b9bffc9496f89bf92a4e5e452bce
   internal/provider/kubernetescredential_resource.go:
     id: 9cca06635b9e
-    last_write_checksum: sha1:abe382719b9de2c5b1519544531f67386acef141
     pristine_git_object: 1be6769e629c348b8cf88a2f4898baf75b3da740
   internal/provider/kubernetescredential_resource_sdk.go:
     id: ea2832ecd302
-    last_write_checksum: sha1:a2fafaf6a2d2cefcc913a4451ff1f349c768bbe7
     pristine_git_object: 2814ac2db68121be9482eefc7c946a8df0202a38
   internal/provider/labels_resource.go:
     id: 738bccd5f1b7
-    last_write_checksum: sha1:3462659ef7c957bb5330b925fba1e40f008f5f36
     pristine_git_object: 2a111f6eaffb7ca5734357f3dd75289fa5996fd2
   internal/provider/labels_resource_sdk.go:
     id: 720ad0a834ae
-    last_write_checksum: sha1:db84bb2a9652362d2362324505fa5304b154d711
     pristine_git_object: 287907880a7125e9ffa8b77e8bbaa57d776887c4
   internal/provider/managedcomputece_resource.go:
     id: 7e0eecddbc1e
-    last_write_checksum: sha1:977b42c1f24183393d620a83c7eea5fd4fba32a3
     pristine_git_object: adccfb0da743b49f39ee880f81d9b6a12b4a2e27
   internal/provider/managedcomputece_resource_sdk.go:
     id: 834a6a05996d
-    last_write_checksum: sha1:df19dbc27d8d96787a7370586c415a3974b91bba
     pristine_git_object: 2200507ea00d48e6fa7ee4f3f2e51571f17226c3
   internal/provider/orgs_resource.go:
     id: 28df60f6d9c9
-    last_write_checksum: sha1:e5ccd09ab1738b98d205a9addbb2bfddbbb3489a
     pristine_git_object: e73b7ac164d81f97838d8b785505471601e1ccb1
   internal/provider/orgs_resource_sdk.go:
     id: 473d7fede1ee
-    last_write_checksum: sha1:62e7d80e48a82f86cdf811dca8a8c84aa1d41f82
     pristine_git_object: fe81d09c0d5656f2f24a007997800ddfa455d8b7
-  internal/provider/pipeline_resource.go:
-    last_write_checksum: sha1:97a07a4ab351664def9bd8c0f89b49f403188cdd
+  internal/provider/pipeline_resource.go: {}
   internal/provider/pipeline_resource_sdk.go:
     id: c3bca9acd758
-    last_write_checksum: sha1:0846d51763115790068024e9bdfdfb4a00a5f597
     pristine_git_object: eb186d4cf2287bf1eec7eb07d9b9c7e0386b7b26
   internal/provider/pipelinesecret_resource.go:
     id: 5319f8284106
-    last_write_checksum: sha1:12e942cc5686242314f402a90d2f858b8e28090d
     pristine_git_object: 89ee6378acd7e780989aac270dd11f269f152368
   internal/provider/pipelinesecret_resource_sdk.go:
     id: e5c7e3be53da
-    last_write_checksum: sha1:3d1d92ac9dc81e57f5c7615ac1734df172dfa81b
     pristine_git_object: e52e3b26ba7c56a91baa9636d315323ef63b37e4
   internal/provider/primarycomputeenv_resource.go:
     id: 1894ce41f7df
-    last_write_checksum: sha1:c6727db32ca1c93bdf7059fd64befad3fcada3c3
     pristine_git_object: 39eb929a225c75c6dde8f820919b2b6cc0701e05
   internal/provider/primarycomputeenv_resource_sdk.go:
     id: b617ad740e70
-    last_write_checksum: sha1:e43a63b24fb10618239383745fe6b9260d15ca59
     pristine_git_object: 8271b7fae7ec72fa236df95b6cb1c021ff466b99
   internal/provider/provider.go:
     id: 1e7e86841cf3
-    last_write_checksum: sha1:95c8cc0ac53445f8a9d6b8d7111f24c14dbfe09b
     pristine_git_object: 6c768261d1bb7b8f84d2db80197389871642d002
   internal/provider/reflect/diags.go:
     id: 35b6b44972e2
-    last_write_checksum: sha1:ace8bc53054bb1d8ee8689acf3e4323de75a6297
     pristine_git_object: 50c50c8c2ee48a2e0bd9f7e01e9de02489c887d8
   internal/provider/reflect/doc.go:
     id: cbfb54ee320b
-    last_write_checksum: sha1:67814656717ff0d0ff38fd9db09872e28666642b
     pristine_git_object: e384126d4201af70574ce3a9fb8102edaa3b932e
   internal/provider/reflect/generic_attr_value.go:
     id: e422f9e35e9e
-    last_write_checksum: sha1:33300f91738c9b79e41ea4d8f3581d6800ac06ef
     pristine_git_object: 48824d543386df6c125ed86da32d85d24659454c
   internal/provider/reflect/helpers.go:
     id: 3c19b91a8408
-    last_write_checksum: sha1:3a2083aa9f84f5a54638803f2225daf86408d360
     pristine_git_object: 8085789a770637a76b1728b0f89b30c564696ca6
   internal/provider/reflect/interfaces.go:
     id: d1096171c6f2
-    last_write_checksum: sha1:e03017ee98ee8d1bd64fde7a025975638bcfaed7
     pristine_git_object: ff4416e40b7dd139a553979327b0dac70aff37c5
   internal/provider/reflect/into.go:
     id: 50e3644442fc
-    last_write_checksum: sha1:7a29c6e2fd31069faddc441132ff04a92a6198be
     pristine_git_object: 29a437fe2bdb30a956b8c7668d11032962962472
   internal/provider/reflect/map.go:
     id: 0d8232fb373f
-    last_write_checksum: sha1:803a218b09d4d9de46d27a5c0227ed3fc6617f62
     pristine_git_object: 91e27a6c1d51441d6091752a0e199c300c1f09dc
   internal/provider/reflect/number.go:
     id: f7e5eb196c35
-    last_write_checksum: sha1:ff756986a30b648c423b9af8996584ffc5983514
     pristine_git_object: 53673b8476a3115f39f7ed03921221243bbe29a3
   internal/provider/reflect/options.go:
     id: ae46de5fdb32
-    last_write_checksum: sha1:735603671bc13388dca9edeb7fefc0b229196793
     pristine_git_object: 002addd9ab508962b4dc80b0b1f788c738cb8382
   internal/provider/reflect/outof.go:
     id: 2b83f83dde82
-    last_write_checksum: sha1:46f09acf317888545161fc1cd288113bd3836ead
     pristine_git_object: 215406a5867a4b5b6e0978a1664492049cc3738a
   internal/provider/reflect/pointer.go:
     id: b758e7c3bf1c
-    last_write_checksum: sha1:92cc23f30396e1a9204f70ac68ebfe7d58cbb967
     pristine_git_object: 215653e7c5d5ba9863ef5053d9084c9d69eba5ca
   internal/provider/reflect/primitive.go:
     id: c302568a3411
-    last_write_checksum: sha1:8b7708414f8be915065952b31986869feaa2fae6
     pristine_git_object: adf648e88b61a8234951db180e4c25bbb7c1b353
   internal/provider/reflect/slice.go:
     id: cd2dec5ab676
-    last_write_checksum: sha1:70ce36709e204b74e3ded36c4683df7e48df294f
     pristine_git_object: 79ad6b80c2a9492522820c3060a89f2de1131e92
   internal/provider/reflect/struct.go:
     id: 973d7dbf96c1
-    last_write_checksum: sha1:504fa0ca7711df0887f8c265c7acb3774e89afe7
     pristine_git_object: c588f768bd7b39be33962188f97d81e1c4c25f4b
   internal/provider/sshcredential_resource.go:
     id: 7eb281c9649c
-    last_write_checksum: sha1:6b00e516b93af140bb7322ac1c031e8a604c4e7c
     pristine_git_object: 47f7c6e152f7cecdcbd982d27de12746f870a355
   internal/provider/sshcredential_resource_sdk.go:
     id: 3c25312d23ab
-    last_write_checksum: sha1:4e3be40607e82d241af200ab9e93a83e00e67bf0
     pristine_git_object: a633929e19d2c86fc43fdc96a586954c0992048c
   internal/provider/studios_resource.go:
     id: d5d4f38592d9
-    last_write_checksum: sha1:5989705fd2c1e5f57ec1079625287f14bb29cc20
     pristine_git_object: b69af57c1f895efdf781dd1ccf3aa900a68744e2
   internal/provider/studios_resource_sdk.go:
     id: 3f2ecca255e3
-    last_write_checksum: sha1:2d282b32efe0659162b902683c7badb5de3decaa
     pristine_git_object: 5bfc8970d75b9bf9e6a0729b69f9a3cd9ad0eaeb
   internal/provider/teams_resource.go:
     id: 6e0e94a85c68
-    last_write_checksum: sha1:0c3bab34929b39c5243c9e4efa52ab927ac75ea8
     pristine_git_object: 5d8d2ee60c142b7c8d7b5fd44dc886e4bfee5df7
   internal/provider/teams_resource_sdk.go:
     id: 7638a674c722
-    last_write_checksum: sha1:f4056c889f0bfbe0811324b152b39ed6290b2a15
     pristine_git_object: 26f268ef8a33992e5cedbb0dbbe25ccb26ffb14a
-  internal/provider/tokens_resource.go:
-    last_write_checksum: sha1:9c804921cf41b43dfb838fe06c20c2184c71e05a
-  internal/provider/tokens_resource_sdk.go:
-    last_write_checksum: sha1:3a5bd5ff815a5a7303f03e2717d509bbb220434a
+  internal/provider/tokens_resource.go: {}
+  internal/provider/tokens_resource_sdk.go: {}
   internal/provider/toweragentcredential_resource.go:
     id: 9596670e4f16
-    last_write_checksum: sha1:fb2873b0705403262568fbdc2b66eced46687e40
     pristine_git_object: d91d65ea5bffdb82659601bb5f8c37780e55e998
   internal/provider/toweragentcredential_resource_sdk.go:
     id: 139ea0cf9bf1
-    last_write_checksum: sha1:86b27faf8c7370d99d5b48265466e9b6f874d8e8
     pristine_git_object: 8717142892f205e2ca6d831bbe400d59dd11f556
   internal/provider/typeconvert/date.go:
     id: dfe2bc95ad1b
-    last_write_checksum: sha1:6fb1aec1dfb728ea10e8318efc3ea42b4691d80d
     pristine_git_object: d8f63834d7980386b9a680ae7365fd7a7aa06c46
   internal/provider/typeconvert/datetime.go:
     id: d2fb73d4f01c
-    last_write_checksum: sha1:a2a20e6785f1e12c3f94c016cbc106e54942e981
     pristine_git_object: 7bfdc553a393a1db69a25574998eb6cc5df79566
   internal/provider/typeconvert/int.go:
     id: c44fcd78fccc
-    last_write_checksum: sha1:c28123f17006dc96a233f916a17c38408e37b71f
     pristine_git_object: 54763e7a7555fae6d8bf51c4590220ff610202aa
   internal/provider/types/access_token.go:
     id: d799677ac003
-    last_write_checksum: sha1:5d98ae9b33385660b2f38940471bf086f8910015
     pristine_git_object: 880e7ad38477659d09a2d21e42b664e78cdf8a06
   internal/provider/types/action_config_type.go:
     id: c403b8e4a1d7
-    last_write_checksum: sha1:6f4934c3be48ebd95c2a3394bf20d66416bbf201
     pristine_git_object: 34466719915d7901b6891482d43ebdf8a82252b5
-  internal/provider/types/action_launch_request.go:
-    last_write_checksum: sha1:4cdf566a35c004f3022da62ca4e1b37c392f0e6f
+  internal/provider/types/action_launch_request.go: {}
   internal/provider/types/action_tower_action_config.go:
     id: 0636d437cb70
-    last_write_checksum: sha1:88f1aa72102b724b6169fdafab127e8f23d62790
     pristine_git_object: d18c50fb459a6e8d700bd9345eb4a96584eb0a89
   internal/provider/types/altair_pbs_configuration.go:
     id: 18ab08d57a44
-    last_write_checksum: sha1:68364ee4431297b6b52f6414f99546a0c6b1aa1a
     pristine_git_object: 623a5ee4c19452cb4a167a68975847f273281e71
   internal/provider/types/amazon_eks_cluster_configuration.go:
     id: 7936e8a5dc0b
-    last_write_checksum: sha1:1d1dc511aefbe6bf9d2aab36dacfc35efdb0d41c
     pristine_git_object: 976221f26c4f0222c2d5945be36da82a9afff191
   internal/provider/types/aws_batch_config.go:
     id: 75b92191a3bd
-    last_write_checksum: sha1:51f3c31aa970200603bc7a10391fbac18939bdd1
     pristine_git_object: 555d5f732c12cfc2b22d4fb1acaa75a30f7ec604
   internal/provider/types/aws_batch_configuration.go:
     id: f48dc5af48a6
-    last_write_checksum: sha1:ad52fa89d1919b5897b10da7a4025a7b9d02c8ac
     pristine_git_object: 7db3202471193f93826bdf67c90bd74b9dab4c88
-  internal/provider/types/aws_cloud_config.go:
-    last_write_checksum: sha1:2e5b6470024757b7ccff0882b57ee4d5a9fc5e10
+  internal/provider/types/aws_cloud_config.go: {}
   internal/provider/types/aws_cloud_configuration.go:
     id: db2f67953459
-    last_write_checksum: sha1:a71cd884dc4177bc0634a518d065f560115ae1af
     pristine_git_object: 62842b6d7f36077a795bcfce869fcaff8d351e2d
   internal/provider/types/aws_code_commit_credentials.go:
     id: 78d63242bf3a
-    last_write_checksum: sha1:dbd7153b198e7dbc3cd679d91b366d7e25364752
     pristine_git_object: c1ddba8e421a8a27956d63f7fd120dbf7b32687a
   internal/provider/types/aws_credentials.go:
     id: 090cc24ec81b
-    last_write_checksum: sha1:8b053d6bbc2585de921f5167b1291e906acc6e29
     pristine_git_object: 8eafc98a13defa43b365abf90cda705df57349bc
-  internal/provider/types/az_batch_config.go:
-    last_write_checksum: sha1:8bdfd8657e00d9cd09490698ec5fbaad14a71637
+  internal/provider/types/az_batch_config.go: {}
   internal/provider/types/az_batch_forge_config.go:
     id: 43a33efe791e
-    last_write_checksum: sha1:ecbb38344e9ad8985a73c15bb5570e5cc4b6a0a2
     pristine_git_object: 12c7bdfaa94860c8c611890dff13fd0635affd05
-  internal/provider/types/az_batch_pool_config.go:
-    last_write_checksum: sha1:2f91f588a8ff393b65d1e705e934648dfe29f573
-  internal/provider/types/az_cloud_config.go:
-    last_write_checksum: sha1:50a6f99e1fe960d077ed0eebffaa5bf3d7597c1c
+  internal/provider/types/az_batch_pool_config.go: {}
+  internal/provider/types/az_cloud_config.go: {}
   internal/provider/types/azure_batch_configuration.go:
     id: c880ec503280
-    last_write_checksum: sha1:d26040afc87f4c3e77983990dbfbd54610258343
     pristine_git_object: cb480f8f017e553bf3999b583fe1ba3dc0e2ca4b
   internal/provider/types/azure_cloud_configuration.go:
     id: 82511ba85861
-    last_write_checksum: sha1:87b0a76a64bb938034d60ed672185c2be7799321
     pristine_git_object: 8f6837bd0be5614d5c706b97dbfc0bf5f8ec80ac
   internal/provider/types/azure_cloud_credentials.go:
     id: af7c8a543af9
-    last_write_checksum: sha1:97b5e8a2c6e2e4c1609f51ced06783bba5dc7c25
     pristine_git_object: 192eb21d5b59be7f9ab0d63ffb15751acbd01cb7
   internal/provider/types/azure_credentials.go:
     id: 99ba83246d99
-    last_write_checksum: sha1:2472e440139e8f240bec92f07589fff985e23bbd
     pristine_git_object: 06861aa0312e8b9b84ab16bb33f21f814291ba47
   internal/provider/types/azure_entra_credentials.go:
     id: e43293e40fd3
-    last_write_checksum: sha1:803a8a628d721f41e548a48e9afba8a67d4d133a
     pristine_git_object: a48580a0f85c738ff1ba1f9ca7c53443d30c0586
   internal/provider/types/azure_repos_credentials.go:
     id: 2f12352aeeaf
-    last_write_checksum: sha1:fee710970ee29945c894a4cad7e1be005cf7da97
     pristine_git_object: cc0c429f3506dac1057c3dff94cb4c16b239879f
   internal/provider/types/bit_bucket_credentials.go:
     id: c9a20017c822
-    last_write_checksum: sha1:582213fbed55b531b09844459506cd54d946e651
     pristine_git_object: c54b0bbc1db7eb7c002b3971a12a3065b0225719
-  internal/provider/types/bucket_action_config.go:
-    last_write_checksum: sha1:37de290d689f99bb768c7588b01b71eacfc4b6c6
-  internal/provider/types/bucket_action_request.go:
-    last_write_checksum: sha1:a6c493761b5382f818c542ea3383d88fdf48e84c
-  internal/provider/types/compute_config.go:
-    last_write_checksum: sha1:0b3635eda86d3d0c0356c383f8bc38d5bef63d41
+  internal/provider/types/bucket_action_config.go: {}
+  internal/provider/types/bucket_action_request.go: {}
+  internal/provider/types/compute_config.go: {}
   internal/provider/types/compute_env_compute_config.go:
     id: 6553ec9a03cb
-    last_write_checksum: sha1:c85553d2d0342a805e8e52ce6f43910da261b4a0
     pristine_git_object: 4e2b91d1eb0b29699d4a1d4e6603011abd8a7418
   internal/provider/types/compute_env_response_dto_resources.go:
     id: 3bca39bd37e3
-    last_write_checksum: sha1:7a1754b0c9d14a5b1c9bd9668b219a56176ecfef
     pristine_git_object: e7a3bdf6fb37323bca66c24a75566fde13fa2753
   internal/provider/types/config_env_variable.go:
     id: da2357163332
-    last_write_checksum: sha1:b8ee9c62af1fb5260c5f2111ba6eb25477b1a055
     pristine_git_object: a9c05333b9889715519de0ad6c57e0f98d35ebf1
   internal/provider/types/container_registry_credentials.go:
     id: c687a79ae869
-    last_write_checksum: sha1:0b7f0ebf8d0989bdb86aa7d52c8340346831cdbb
     pristine_git_object: 99203bf83ec24cc39d1ae20e7ec654bf899f016c
-  internal/provider/types/create_pipeline_version_request.go:
-    last_write_checksum: sha1:870b727f1c2dc238554a6bae532cd3ff2364210a
+  internal/provider/types/create_pipeline_version_request.go: {}
   internal/provider/types/credential.go:
     id: b7725d71bf9e
-    last_write_checksum: sha1:71093b68ac0ba714032a31471ec6542ca4bb68aa
     pristine_git_object: 300f141b80661c8d502f9ed91c02826e0e72a0c5
-  internal/provider/types/cron_action_config.go:
-    last_write_checksum: sha1:49afa810a77612dd43c45e13ef3e067cebe4bae0
-  internal/provider/types/cron_action_request.go:
-    last_write_checksum: sha1:d6210759a1800aec6fe19daf896a7b709bbb71ef
+  internal/provider/types/cron_action_config.go: {}
+  internal/provider/types/cron_action_request.go: {}
   internal/provider/types/data_link.go:
     id: 2535727cf0f1
-    last_write_checksum: sha1:1086c0d782ae4c4c952fbea765545146447f46fa
     pristine_git_object: 041d41bca83e819fb1c5d58c3c9f42c36c369348
   internal/provider/types/data_link_credentials.go:
     id: c71e463bdba6
-    last_write_checksum: sha1:41b0275d1d9ffa3cb1f8cb06fa149419a49b2606
     pristine_git_object: 9e07cf4824e7bd929522b3c0d2eda2ebf76d3391
   internal/provider/types/data_studio_configuration.go:
     id: 25a48f67c4fb
-    last_write_checksum: sha1:4aa6c7d0c1dd711fb5de49dc4b8c39d409fad4a8
     pristine_git_object: 5d2f7ae2dd4a0505cb1dbb535e1e664771fcc9ed
-  internal/provider/types/describe_workflow_response_pipeline_info.go:
-    last_write_checksum: sha1:4161b63feea1f9acc06db69b6e1256b0700ebadb
+  internal/provider/types/describe_workflow_response_pipeline_info.go: {}
   internal/provider/types/forge_config.go:
     id: 59cc8ac25831
-    last_write_checksum: sha1:1e0e577a94fb9505a2ef91ab9e7856143d920ab4
     pristine_git_object: dc0e42b289943cf567e2051339104d135b119aec
-  internal/provider/types/git_hub_app_security_keys.go:
-    last_write_checksum: sha1:e1c600f33168edaee11407a9061d5099f41ad63a
+  internal/provider/types/git_hub_app_security_keys.go: {}
   internal/provider/types/git_hub_credentials.go:
     id: a6d4944159d4
-    last_write_checksum: sha1:ae0df1db959fcf0c5ddc3c47d1a3e94572a422d0
     pristine_git_object: 71972be9ca7b86d65aacfef501a3f3e16da80c5e
   internal/provider/types/git_lab_credentials.go:
     id: 71e42461f65a
-    last_write_checksum: sha1:d088f4373735355a7b614f0261170420b6f6578c
     pristine_git_object: 802340f7b6933362f0dc6464b8ed36a33b85fa84
   internal/provider/types/gitea_credentials.go:
     id: 287e7775ee3a
-    last_write_checksum: sha1:9492defc4cd35fce5b4b0ac2e424dafc17cbeb6f
     pristine_git_object: eb14e43dfe95fc9660e24a5b4322cca3e2472d69
   internal/provider/types/github_action_config.go:
     id: f49ee3b89983
-    last_write_checksum: sha1:ff6b49342a436ca0e535a9fe804eaa7aefb4d522
     pristine_git_object: fee4f8219d9a79b52671130f3318f6aabdf28f25
-  internal/provider/types/google_batch_config.go:
-    last_write_checksum: sha1:2ea12c8796c60aef5282c4abaf10b92260fa1873
+  internal/provider/types/google_batch_config.go: {}
   internal/provider/types/google_batch_service_configuration.go:
     id: 5a581f1c4635
-    last_write_checksum: sha1:9468b518adc8e95315d52acc6d5df43935d287c3
     pristine_git_object: 3b1d18b5efc8fd5120b4d3f2f7a9a56feafa342c
-  internal/provider/types/google_cloud_config.go:
-    last_write_checksum: sha1:9c0bf7121f7c5699a63c0644927e9f4fcfdfb617
+  internal/provider/types/google_cloud_config.go: {}
   internal/provider/types/google_cloud_configuration.go:
     id: 4eb43152509e
-    last_write_checksum: sha1:500773395b84b5e44b7ec5079f8c545f438ff16a
     pristine_git_object: 60248593c3c3ece07a86cbc3e309b545cd5672db
   internal/provider/types/google_credentials.go:
     id: 8ea55670d7b3
-    last_write_checksum: sha1:c4a6a34874b48a0997c52bdda62b9a947247484c
     pristine_git_object: c16ad2a4da463a9e38d539019bdee713a89d6db8
   internal/provider/types/google_gke_cluster_configuration.go:
     id: d670e605e603
-    last_write_checksum: sha1:4e5ee0e22543aebebef80ac957f2141ed567bf59
     pristine_git_object: 1314ce36e4cb0dfd552031415264b763974c34cc
-  internal/provider/types/google_life_sciences_configuration_retired.go:
-    last_write_checksum: sha1:aa810f198e04fa3090d4d7017db9e95df5143650
+  internal/provider/types/google_life_sciences_configuration_retired.go: {}
   internal/provider/types/ibmlsf_configuration.go:
     id: 601a3c320ae8
-    last_write_checksum: sha1:98c23e932b6aec2cd918743d45a09eb0d786e11f
     pristine_git_object: 4e4a371ba53ef46e2b8d5a86c0c40b5670d3f0c6
   internal/provider/types/kubernetes_compute_configuration.go:
     id: 3f7cae74ea07
-    last_write_checksum: sha1:1edd1ef70eba3939bdd6145d94f66b18b13de6fa
     pristine_git_object: 492ce0bc240845be30fb49a4468fee7c2765d98c
   internal/provider/types/kubernetes_credentials.go:
     id: 78c716326a54
-    last_write_checksum: sha1:97d24e5c82fe2f3a47ee6b6247c45a2b81e072a2
     pristine_git_object: dab87f916d68fd3903277d62c81db79052b0c224
   internal/provider/types/label_db_dto.go:
     id: 7fe2f9d9c53c
-    last_write_checksum: sha1:68cb7e7586e62cd6f11fd900f9d3e2322e62c82e
     pristine_git_object: 57a30b21ca693cde4f2e4d6dd6d128505280451a
-  internal/provider/types/local_execution_configuration.go:
-    last_write_checksum: sha1:db33b4ea67883dfc99edec292ed8243e864ceabe
+  internal/provider/types/local_execution_configuration.go: {}
   internal/provider/types/local_security_keys.go:
     id: 9d6f76c965ee
-    last_write_checksum: sha1:74916914478277178628509bd7afb7bdaf23f5eb
     pristine_git_object: befa8633ddb6d5d30c603e77f65ff0f22dd3c292
   internal/provider/types/moab_configuration.go:
     id: 339ce0dd7aca
-    last_write_checksum: sha1:0e98c71261fd33017ccca620992cab590c9704f3
     pristine_git_object: eb84f2d23ae2970348690f068e599fb67cc3f359
-  internal/provider/types/mount_data.go:
-    last_write_checksum: sha1:6439db35cbcddc245d8e0a590878d02639f4f221
-  internal/provider/types/pipeline_min_info_response_pipeline_version_min_info_response.go:
-    last_write_checksum: sha1:d149cbaa16b13ea7d9034623bbcb8d0a6666c666
+  internal/provider/types/mount_data.go: {}
+  internal/provider/types/pipeline_min_info_response_pipeline_version_min_info_response.go: {}
   internal/provider/types/s3_compatible_credentials.go:
     id: 94157ae642fe
-    last_write_checksum: sha1:c710f072890b547c4d361089ee8d9d6a598d4e12
     pristine_git_object: f79e0fa2b63cf39d5acad38ff304d48fbbfb3474
-  internal/provider/types/sched_config.go:
-    last_write_checksum: sha1:b0ccd3744ab529015e80c3f92292de6fc97fca15
+  internal/provider/types/sched_config.go: {}
   internal/provider/types/security_keys.go:
     id: 1a1c24c21233
-    last_write_checksum: sha1:70ce1cdbcbdaca5a03599dd06e1d458fb5de63a2
     pristine_git_object: 74d3a8fbffd1853a8c5bc5b4f41b775b322ecf79
   internal/provider/types/seqera_compute_configuration.go:
     id: 60600ba28c1c
-    last_write_checksum: sha1:a2d9599a171cfad178e99465c82de603bdbdd125
     pristine_git_object: 6be055a610d9da430ce64a4e925deeb2cb009314
   internal/provider/types/seqera_compute_credentials.go:
     id: 6333241c47ee
-    last_write_checksum: sha1:5b888ffbe2dd246cfb27492baa3dca5bc8bd1ec3
     pristine_git_object: 8f1da48ea70ace845b878a3f0208ebc55616e17f
   internal/provider/types/slurm_configuration.go:
     id: 3b58450d7952
-    last_write_checksum: sha1:4c7fd497300065c81bc8b83b3146cbd60bfa0251
     pristine_git_object: 6fd36f99ad70d5125b8732d65be715e23773cc8b
   internal/provider/types/ssh_credentials.go:
     id: 1f4f9de1e711
-    last_write_checksum: sha1:4ba667b2cc5144b2c19c3ed0e30db3592c0316e8
     pristine_git_object: e304e804365ad9c8c0de1fdf5e6247299eba8a2b
-  internal/provider/types/ssh_details.go:
-    last_write_checksum: sha1:674e551608c5d0a59f30f170b32565b57ebb6ff5
+  internal/provider/types/ssh_details.go: {}
   internal/provider/types/tower_agent_credentials.go:
     id: 0e460efd9daf
-    last_write_checksum: sha1:94f361b9318b35eaac17f027a696632a1beba299
     pristine_git_object: c4b5b95ceca949cc41a87c0134151d29168cfe19
   internal/provider/types/univa_grid_engine_configuration.go:
     id: 1bff7795c6ea
-    last_write_checksum: sha1:64d058d21c656d6f0fcc84c9551a5d09f4c1bc30
     pristine_git_object: 4103cca9f88b2e8e142ba6023efb0383d00b211a
   internal/provider/types/workflow_launch_request.go:
     id: af36165a8643
-    last_write_checksum: sha1:c4b8fc621f3d533f87e8a737e9ce81699cf39095
     pristine_git_object: 11b31ac54b41f1ff6655e5775689da9baec929f7
   internal/provider/utils.go:
     id: 312d50f148af
-    last_write_checksum: sha1:ebb9748832af8f468cc80deac9ce582a4dddd690
     pristine_git_object: 9cc78dd1f7684941df14144df744dad2b23885f9
   internal/provider/workflows_resource.go:
     id: efcad015245a
-    last_write_checksum: sha1:e4222292e1137a761dec41d9eb72ecf47fec7dbc
     pristine_git_object: 2ec8cdfba570a37c74c14055a3d9ffa12fe8881c
   internal/provider/workflows_resource_sdk.go:
     id: ee2d992725aa
-    last_write_checksum: sha1:07ee3d11da310bd85858ea5c1097c02ffdfc6732
     pristine_git_object: 32dd5a54a21939c3cfa3c2ada55b841cb54032f9
   internal/provider/workspace_resource.go:
     id: 4255ab3c913f
-    last_write_checksum: sha1:1eab3b4395cbc6ae2907a9bbb47fe6d9152cfddc
     pristine_git_object: 3a254498bdb26fe0a1be5e3afd3452978bba12da
   internal/provider/workspace_resource_sdk.go:
     id: 6b7b5772bf74
-    last_write_checksum: sha1:00025465234d8842e2e42ada52cc5638d88dadd3
     pristine_git_object: ef08f3fe5d664b406cd4c6ef11d883cb611dfdb7
   internal/sdk/.gitattributes:
     id: 1ea4c4e0a39d
-    last_write_checksum: sha1:84b0115789fc3ea52e31df701d8a27f76077e29f
     pristine_git_object: e6a994416d0f527912d2d272e2583458f4fc9bcb
   internal/sdk/actions.go:
     id: 15acb90274d1
-    last_write_checksum: sha1:b648ef7dc44c45eb17e2d1539a12ebb60e09e81b
     pristine_git_object: ce8f740635e7b222a384f4f94ede6619d7d26c24
   internal/sdk/avatars.go:
     id: 295feb914135
-    last_write_checksum: sha1:1ca4be4ceb8e3efece6151a3497accf9124c282b
     pristine_git_object: eeb2138186ead7a043a4156ca999876ae1ef98ad
   internal/sdk/computeenvs.go:
     id: 966f951685a1
-    last_write_checksum: sha1:9a979c1b6a98e6b01bca895fb662ad95248bb935
     pristine_git_object: 2088635cf294256f64e87885c0426517fb230861
   internal/sdk/credentials.go:
     id: 67c2f2d273f9
-    last_write_checksum: sha1:e34dfd5e7d4e5bd015463032ac7c45696f520c4a
     pristine_git_object: 47bd93d33a5187778e37e15f28a86920d700bb6d
   internal/sdk/datalinks.go:
     id: ef6966e16293
-    last_write_checksum: sha1:8d4c5e882df58f6b72c8d7a2439d212efe10b2f9
     pristine_git_object: b1e44827a51863975f9f474fb86fdd9633d9f363
   internal/sdk/datasets.go:
     id: c03fc9a88bfc
-    last_write_checksum: sha1:24c9297161d8e4721b0126793ae2cca28556fdf9
     pristine_git_object: 6d697a222027e0ff47a1c606cab4da12b0602bd5
   internal/sdk/docs/models/operations/option.md:
     id: a35737eb2e35
-    last_write_checksum: sha1:f45321582662c187a12e797364a9b5c9f187311d
     pristine_git_object: 35d8a1e2ad48a64702c6a654ac8880dabec053b0
   internal/sdk/ga4gh.go:
     id: 42dfc548ccdc
-    last_write_checksum: sha1:5b27a4b8afc102ece78611aea006dd3d0afe6044
     pristine_git_object: e8ffa8ceba5dcac2a4d3d4527451748343a17f85
   internal/sdk/identities.go:
     id: a724fedb400f
-    last_write_checksum: sha1:5ff3be47c4be2320992468e7a578ee6b0851a2ba
     pristine_git_object: bcd9d3ceb520f4ab43ea996f714ecf630474fbd1
   internal/sdk/internal/config/sdkconfiguration.go:
     id: 6af0bc8635d9
-    last_write_checksum: sha1:16a80dcc03bb8d8a79826528299568e37ee5b24a
     pristine_git_object: 2d5adcb96f90399884d1b3bb127a92c0ef8dc470
   internal/sdk/internal/hooks/hooks.go:
     id: 4e88208e997f
-    last_write_checksum: sha1:9816c3fa08fccc6c85799e158ad4fef766033cf5
     pristine_git_object: 7f5895d3e8519d2320ac8f04f67fd94780760fcf
   internal/sdk/internal/utils/contenttype.go:
     id: b767d5c02609
-    last_write_checksum: sha1:ab5cfd860d02c6e6a37f89e2b5649a9859947fb1
     pristine_git_object: f6487e01eb987c0aa49e7aa50b5ff24830314c63
   internal/sdk/internal/utils/env.go:
     id: 4b4be1422b75
-    last_write_checksum: sha1:1e0bcb2d2caed9f3657f1dbc99b55811bed0298c
     pristine_git_object: 110d464eacf2387b347bad1cb903666354a339e9
   internal/sdk/internal/utils/form.go:
     id: a29055426367
-    last_write_checksum: sha1:04bd9bb8ade586c51eac840e79112e6bc1a06bd8
     pristine_git_object: 8fdd2aafcbc87fe8877818254fbaaa4b3022f85e
   internal/sdk/internal/utils/headers.go:
     id: f035883ac0ff
-    last_write_checksum: sha1:8b6f3dd49ed711c8cb30463e99346557d0316f1c
     pristine_git_object: c4537b353994c4844d7c32d5a4c6ae017088ea96
-  internal/sdk/internal/utils/jq.go:
-    last_write_checksum: sha1:2e75ed7a7db1f91e97dac1ac4ca7801b2beb69b5
+  internal/sdk/internal/utils/jq.go: {}
   internal/sdk/internal/utils/json.go:
     id: 2231afac3add
-    last_write_checksum: sha1:0fcd2a51bc0cb02631e72233801356354efdf92a
     pristine_git_object: 892eb1b4ad3c029cddbd9aa0e63f639e1b24d6c5
   internal/sdk/internal/utils/pathparams.go:
     id: e7fec2afe4a6
-    last_write_checksum: sha1:aa29bcdfdeeb3abf9eb4613a5e008283889c751e
     pristine_git_object: cef345d4cfe71dc6185f457cc2a03ba16e1c9730
   internal/sdk/internal/utils/queryparams.go:
     id: fb88ad971185
-    last_write_checksum: sha1:0eee13f4c77dc0b11d28a39a2b99a1627d72ad55
     pristine_git_object: 85d978e1be77b19400abf28446ff4103f69d046a
   internal/sdk/internal/utils/requestbody.go:
     id: c971a8b3bbf5
-    last_write_checksum: sha1:09c4d4a8dc3d339a7c2514b4342749c15973c2ac
     pristine_git_object: d6ee6e871294814f826da36454d69187afd95093
   internal/sdk/internal/utils/retries.go:
     id: 6832c2142453
-    last_write_checksum: sha1:750d46f9d6ce4e2504a7069301923a09eda56325
     pristine_git_object: c2d013e48ce1fb1f7ea7148bf8d78a599f825a24
   internal/sdk/internal/utils/security.go:
     id: 6ebe9eaeb99b
-    last_write_checksum: sha1:49fee4e9252239953611e6de36f4682851499ab5
     pristine_git_object: 19dfa6f4607dea64b1dd61c211e072212e7a3cb2
   internal/sdk/internal/utils/union.go:
     id: 183142835cfe
-    last_write_checksum: sha1:4b2b50599edbd825a0feba9d2ee277aaccf3cb98
     pristine_git_object: 0a7f0d88a4a23d4a53742ec848d380ee97ee853d
   internal/sdk/internal/utils/union_test.go:
     id: 4c885192f6f0
-    last_write_checksum: sha1:bd5c7506e1d6238117c1ac4e340314a5a41401b5
     pristine_git_object: f66814c73ace94d8e71d785fd6161fb405745754
   internal/sdk/internal/utils/utils.go:
     id: feefcdf75dbd
-    last_write_checksum: sha1:c03378176a107205b8938606faef3fd8fb8f91a0
     pristine_git_object: 0415b536598baa76c5d1a8fc32816ed1b83f9137
   internal/sdk/labels.go:
     id: a35e05b0247d
-    last_write_checksum: sha1:0e7ed1197416b5f666b1139be112705e9bdde869
     pristine_git_object: b7356bf00c840d897e8af0f600a0050b3b0e4749
   internal/sdk/launch.go:
     id: 8999bce1dfb3
-    last_write_checksum: sha1:0a23e032285ddf69f9fca2344c9782bf265617b1
     pristine_git_object: e9528a4551a305698e1510eab30ffd9d25a0d2a3
   internal/sdk/models/errors/apierror.go:
     id: bf281d768352
-    last_write_checksum: sha1:f8493be1606361ffba9bf77d77ede209acc0f562
     pristine_git_object: d7a75360fe11b02f7de84c07135dfa4004a82b44
   internal/sdk/models/operations/addlabelstoactions.go:
     id: 54ea176819e0
-    last_write_checksum: sha1:28c365fa4e7197d4f02f4af76615741227abbcb9
     pristine_git_object: 131334b27a31000604d836f6931aa1bb9a6dd7d7
   internal/sdk/models/operations/addlabelstodatasets.go:
     id: 94d89a6e23a1
-    last_write_checksum: sha1:24c7320e9fb05ec86df072fb47a4a91db39e952a
     pristine_git_object: 58aff95000900eb14b19eeb46d6090c0c5e47d73
   internal/sdk/models/operations/addlabelstopipelines.go:
     id: 325db8924b6b
-    last_write_checksum: sha1:930ffd86cf34da940479fe57c86f9b0323f034d2
     pristine_git_object: 849710e51a5d4fcdeeb77bd92efdbdea2c93aba4
   internal/sdk/models/operations/addlabelstoworkflows.go:
     id: db852d801a10
-    last_write_checksum: sha1:6b76f7a0779d461e17fb71319eb019db6449ee31
     pristine_git_object: 5ba7fbb2940f2573038489e3d47d3a856218b931
   internal/sdk/models/operations/applylabelstoactions.go:
     id: a2dfa08b4c2c
-    last_write_checksum: sha1:0e3ef8df4fddfb662ab467e9e90bda22c852095d
     pristine_git_object: 7d44c4852dce9c665d24d2b53685803d5d3c3f56
   internal/sdk/models/operations/applylabelstodatasets.go:
     id: bd42c015a6bb
-    last_write_checksum: sha1:360fda0bc4ae3db80283ae732a9fb701bacb3bd2
     pristine_git_object: 8eea91375f910e0eab1a4006de97ebf15f077d9b
   internal/sdk/models/operations/applylabelstopipelines.go:
     id: 292fe6276c44
-    last_write_checksum: sha1:13c5526864ca4c4ffc118ad0abf5154d6b682d5e
     pristine_git_object: 81cf5495d95d2c90be46b99381b88dd0b6252ea8
   internal/sdk/models/operations/applylabelstoworkflows.go:
     id: 70715bef5c56
-    last_write_checksum: sha1:4b3e7d37fe737e530701c9991283e008721a6a88
     pristine_git_object: 9ef6c67e93751748cae86d9ba5daa4a626ee2e43
   internal/sdk/models/operations/cancelworkflow.go:
     id: 3122cc8c6341
-    last_write_checksum: sha1:30ab09150f480b0c036d8f3ab2b0e1cf525abc17
     pristine_git_object: 7fb7ee717a5f510ca30338e8858159e10ffecb3d
   internal/sdk/models/operations/createaction.go:
     id: 2870d06facbf
-    last_write_checksum: sha1:8ad6aebbb6fc2121e0e6c71011104539ab65336c
     pristine_git_object: 1540dad80f38e0ea55c7f11e454cfbc0903fefcd
   internal/sdk/models/operations/createavatar.go:
     id: fd854a337de9
-    last_write_checksum: sha1:a5b20b4e77c7e5a09114c3dddf84162924c8eac2
     pristine_git_object: d908afce83a42b7579f6e76e87e659e49af8a43e
   internal/sdk/models/operations/createawsbatchce.go:
     id: 6430e979b884
-    last_write_checksum: sha1:80aab73baacac7381eec582e015905a0bd8c5ed7
     pristine_git_object: f42e5ee6ed9deff7185b359fd1482e83b3a52870
-  internal/sdk/models/operations/createawscloudce.go:
-    last_write_checksum: sha1:87f57651afebd02be5e41f362869012bcf851c89
+  internal/sdk/models/operations/createawscloudce.go: {}
   internal/sdk/models/operations/createawscomputeenv.go:
     id: 1f5f70d062d9
-    last_write_checksum: sha1:c214d69ae6e1ff68ba5453e6931dce4e50b3dba5
     pristine_git_object: e667041d614b37d4b3ea9a33a94b15ea030d712b
   internal/sdk/models/operations/createawscredentials.go:
     id: 85e477ba68bb
-    last_write_checksum: sha1:b42a673fd11a45d71be0efc7e405e40830fd1a3f
     pristine_git_object: 4c0921a031743a7d4ece3b437638330c7d9a83c5
-  internal/sdk/models/operations/createazurebatchce.go:
-    last_write_checksum: sha1:163f4badfdc0a26ab855bd213f0f389410dfba47
-  internal/sdk/models/operations/createazurecloudce.go:
-    last_write_checksum: sha1:8d339605a2c09ed61586c8dc62ed0ec70198c144
-  internal/sdk/models/operations/createazurecloudcredentials.go:
-    last_write_checksum: sha1:7abab312ca916b02c91658a827f3581a15e1623f
+  internal/sdk/models/operations/createazurebatchce.go: {}
+  internal/sdk/models/operations/createazurecloudce.go: {}
+  internal/sdk/models/operations/createazurecloudcredentials.go: {}
   internal/sdk/models/operations/createazurecredentials.go:
     id: b45aead99e48
-    last_write_checksum: sha1:e31742293bba67f5a03e35098382a865a504bd1b
     pristine_git_object: 8c8c437be0b99b0523781c39c0f5bd825d356b9c
-  internal/sdk/models/operations/createazureentracredentials.go:
-    last_write_checksum: sha1:8601a0c2d5316786e90e6ad0468c9580c543857d
+  internal/sdk/models/operations/createazureentracredentials.go: {}
   internal/sdk/models/operations/createbitbucketcredentials.go:
     id: 7072954ccf52
-    last_write_checksum: sha1:4af8a2b6e5dd276ab5f127b3f235f48f7b67cf2d
     pristine_git_object: 49de2ff278a72a52aec85f764365a10bf8e792ad
   internal/sdk/models/operations/createcodecommitcredentials.go:
     id: ecaa34a538f3
-    last_write_checksum: sha1:43307aef2e36b2ca7bfd0b0471c44712287128f4
     pristine_git_object: 52243185937b1eb97ee96251d7ea8958722c28d4
   internal/sdk/models/operations/createcomputeenv.go:
     id: f63e480778ad
-    last_write_checksum: sha1:1edad826f6fe3ed32ec1acc20cb5ea361fab0e9c
     pristine_git_object: b609f21982a4d2b7720d64e620f57d43f0605d24
   internal/sdk/models/operations/createcontainerregistrycredentials.go:
     id: 6e7e3171d890
-    last_write_checksum: sha1:370c47b1abf6207cd9adac943ead9e896862e0bb
     pristine_git_object: cd5b6ddf2eefe13cb0952affa91b283937cd8829
   internal/sdk/models/operations/createcredentials.go:
     id: 48e2f75c1c5a
-    last_write_checksum: sha1:dbfb21161f28f1db88f607a098156c477fb2c409
     pristine_git_object: c394092f3fa837c2d1ae2e748732971f8fa6b38b
   internal/sdk/models/operations/createcustomdatalink.go:
     id: 813b0db514bf
-    last_write_checksum: sha1:008b309f219aab568ba9d732cc74ac77f4957929
     pristine_git_object: 318791acec50191f33c3ebe519825e5b856e7acc
   internal/sdk/models/operations/createdataset.go:
     id: 50e691a2dd23
-    last_write_checksum: sha1:6da47d4fe567c7c4d9182e5298613be5dd1319fa
     pristine_git_object: 3320f7853008313a78441546409fb3016ea03ebb
   internal/sdk/models/operations/createdatasetv2.go:
     id: 175e771d3c27
-    last_write_checksum: sha1:2bed6c7b5435106515eda6a1ffbe9b57061cf97e
     pristine_git_object: 7753ab19b2ceb238ed99e9017d40d8137517a876
   internal/sdk/models/operations/createdatastudio.go:
     id: 5bfda9b411cf
-    last_write_checksum: sha1:0dacdfefd75ea97077909ca20e8aa33a74f037f2
     pristine_git_object: 11a74d7bd66a5a4b6c02447518d4c0a93b68a610
-  internal/sdk/models/operations/creategcpbatchce.go:
-    last_write_checksum: sha1:ea9c3e440d36a5accf35ba99f99fe8808d229916
-  internal/sdk/models/operations/creategcpcloudce.go:
-    last_write_checksum: sha1:00625719e44b5446c90a7c31f933e48fdd019d5b
+  internal/sdk/models/operations/creategcpbatchce.go: {}
+  internal/sdk/models/operations/creategcpcloudce.go: {}
   internal/sdk/models/operations/creategiteacredentials.go:
     id: 5cb205a6f6b9
-    last_write_checksum: sha1:2df21b7fb233923546241013571a40f229dcd03a
     pristine_git_object: f51216c5031cb68f6624ce740783103247cebdc9
-  internal/sdk/models/operations/creategithubappcredentials.go:
-    last_write_checksum: sha1:e4e5978201822141dbbbdff0d341ccb525e63c87
+  internal/sdk/models/operations/creategithubappcredentials.go: {}
   internal/sdk/models/operations/creategithubcredentials.go:
     id: 920ae55ba490
-    last_write_checksum: sha1:0863a8a1d903173cac41401cce4c6f998f754765
     pristine_git_object: fb9869a6b082c0a84999c77f585bbe09b4d908ca
   internal/sdk/models/operations/creategitlabcredentials.go:
     id: 8d75213feee2
-    last_write_checksum: sha1:537f7956863b08dfc08665eccb34e38955aa514d
     pristine_git_object: d32ed699ef803226c8790d1a98e7a57fa182888e
   internal/sdk/models/operations/creategooglecredentials.go:
     id: f89e2e92500f
-    last_write_checksum: sha1:a6781873542464838ae4636667f11be90bf3a1cb
     pristine_git_object: 31e4f1133d8dedafcdb117289f9623b65b8c1708
   internal/sdk/models/operations/createkubernetescredentials.go:
     id: 23c166e2c5d1
-    last_write_checksum: sha1:40c3d091e55f40224a894702a05c827777694ac3
     pristine_git_object: d963d30197b8492c0e4c6c2ec0be20e0ea7b10a5
   internal/sdk/models/operations/createlabel.go:
     id: f04470a238d7
-    last_write_checksum: sha1:6fcb77bd1c5eb231fb7d5b08b39567ba5b2125bf
     pristine_git_object: a6e5043a03672264b74ad36910cff26e6ae6d377
   internal/sdk/models/operations/createmanagedcomputece.go:
     id: 86580a360920
-    last_write_checksum: sha1:380a594652c22526b873404c4accd541fe4959c4
     pristine_git_object: 51a35fd9bcad1e9f060ff62b40fc12ddff6dfb81
   internal/sdk/models/operations/createmanagedcredentials.go:
     id: 20465813e0ae
-    last_write_checksum: sha1:f24c0187d90fcdb871634bb9f23e7c54ceaaeed2
     pristine_git_object: 711eb55532a2838036a65ad945e793ac3f5e0731
   internal/sdk/models/operations/createmanagedidentity.go:
     id: b80f6213d37f
-    last_write_checksum: sha1:7634a79547382c38567d5c61aef8df12a9f70f0f
     pristine_git_object: 50a67d2180875491859ea29f2136f730cfd4d490
   internal/sdk/models/operations/createorganization.go:
     id: 825b4d4a4d70
-    last_write_checksum: sha1:e517a9e4e00bd8621ad0873bcd0d7e2aba67f8b1
     pristine_git_object: 85d7b8cbe3c6abffdba45c0cb992b0cc47f172a1
   internal/sdk/models/operations/createorganizationmember.go:
     id: f3177c385909
-    last_write_checksum: sha1:a43ca87f97f3ca15b86fda8a14718f732f726824
     pristine_git_object: e3f37208f04fe6b5067aa740fb422d2e05b78a76
   internal/sdk/models/operations/createorganizationteam.go:
     id: 02c1ae32b49d
-    last_write_checksum: sha1:6ec163bf8192dc772ee73c4bb67f3b83806ff48c
     pristine_git_object: 8630317b2e93441e613dec9b2b55dc44483dfc2b
   internal/sdk/models/operations/createorganizationteammember.go:
     id: 2abfc4409ba6
-    last_write_checksum: sha1:4b7b4b978be1930381964d44314de0afbe6cab59
     pristine_git_object: 6e11e27172ef8ba4a86bb24c17ab698fd70fea3d
   internal/sdk/models/operations/createpipeline.go:
     id: 5f5e9c21ee88
-    last_write_checksum: sha1:7ee4a2111ecd103b4d6b812013b92c07f125d595
     pristine_git_object: 21a5e651df02c095eef1f45bd94e5a79fe3b0107
-  internal/sdk/models/operations/createpipelineschema.go:
-    last_write_checksum: sha1:90beb3d898b4d148201fbd0d2ed3f9405fae7422
+  internal/sdk/models/operations/createpipelineschema.go: {}
   internal/sdk/models/operations/createpipelinesecret.go:
     id: dc4aa186bbf0
-    last_write_checksum: sha1:7dbedcc004c3240ab9817b88bb7e9f266b43c349
     pristine_git_object: 81824dc902542ca5df67fd3e8471d0cdcfbec4f0
-  internal/sdk/models/operations/createrole.go:
-    last_write_checksum: sha1:0d9fc6823a2fcd850b4a6448cab7800cf3bba236
+  internal/sdk/models/operations/createrole.go: {}
   internal/sdk/models/operations/createsshcredentials.go:
     id: bb07e307e98d
-    last_write_checksum: sha1:d38799758f6349e1e156df277979027b70005b14
     pristine_git_object: 6c563cdf9cdb0bb367bd75af33519abd3df2322b
-  internal/sdk/models/operations/createsshkey.go:
-    last_write_checksum: sha1:d70df7266880670ca42881258f80ecf791250496
+  internal/sdk/models/operations/createsshkey.go: {}
   internal/sdk/models/operations/createtoken.go:
     id: 8141776c74e7
-    last_write_checksum: sha1:16f9bd5780e1fd5503d1ba1e7106f0e05ce2e461
     pristine_git_object: f6038612d0da288341b12acccd39c59e9ca13a58
   internal/sdk/models/operations/createtoweragentcredentials.go:
     id: 6535f97c26dc
-    last_write_checksum: sha1:041566c77611f3e5fb1bfcdce46d0897f67c419a
     pristine_git_object: 91ab7ede38f00ad6e9a18463f06f9ebe39f12c9c
   internal/sdk/models/operations/createtrace.go:
     id: 338ab9a3f7f7
-    last_write_checksum: sha1:508db670bd922af93453d13f248338e29b302b2b
     pristine_git_object: 4cd37ee80a180d62835723196500d0a4d5730054
   internal/sdk/models/operations/createworkflowlaunch.go:
     id: 0b05866d8daf
-    last_write_checksum: sha1:87c87af706d02b8f0df6474fb55853ef031398bc
     pristine_git_object: 5884464fd32a9c30d9267a3a0d30c7411b0091cd
   internal/sdk/models/operations/createworkflowstar.go:
     id: 07e3a3d82ebe
-    last_write_checksum: sha1:91a5bd69acd194e4adfe6e599a517fa153e47cec
     pristine_git_object: 8896c12783dd3dd4ced876f0300d21882eed1169
   internal/sdk/models/operations/createworkspace.go:
     id: 0dfb68c3ac15
-    last_write_checksum: sha1:ec518a4c8260bef38035c3d464791e54188d70ec
     pristine_git_object: a8f42d1df466904a300357c5b1f3d84f50ac3f90
   internal/sdk/models/operations/createworkspaceparticipant.go:
     id: 3ae82933a7c0
-    last_write_checksum: sha1:025281e31f3752e7806a0931d6e9b4e0c8bbb4f0
     pristine_git_object: 94aacab3ac018126161ce8183079f2934efd9062
   internal/sdk/models/operations/deleteaction.go:
     id: d25a658ba75b
-    last_write_checksum: sha1:7e3173eb59082e39806f54f7d34fb02e6af6d1e5
     pristine_git_object: cc216042359192c2d7b43420cf2d3f2aaadad1ca
   internal/sdk/models/operations/deletealltokens.go:
     id: b3b3b0ca1a0c
-    last_write_checksum: sha1:a69cce970ed449fba90563e14b7aa1d71d620f43
     pristine_git_object: ee54df9ae99761e53f0a574715da352da48557c3
   internal/sdk/models/operations/deleteawsbatchce.go:
     id: 031f54f4fa94
-    last_write_checksum: sha1:68632f53897ea67758a5469f1b8a880a32012c6b
     pristine_git_object: 628cb69f1ae9645b4e6edec71501f9fd0cccd9f9
-  internal/sdk/models/operations/deleteawscloudce.go:
-    last_write_checksum: sha1:406dffbb502e97c5b98455d6b3cc628bcd725f04
+  internal/sdk/models/operations/deleteawscloudce.go: {}
   internal/sdk/models/operations/deleteawscomputeenv.go:
     id: f912665db62a
-    last_write_checksum: sha1:2c640c432f4c971a70cef5d1cee0064c92bdb7d6
     pristine_git_object: 3fb022a3634717d90c779ea2cc6bf0d87c8895c7
   internal/sdk/models/operations/deleteawscredentials.go:
     id: 497f3e55cf6c
-    last_write_checksum: sha1:9da4140cd5a8b792eef923748d72a65ba04d3430
     pristine_git_object: ad55bac4a5b44dd03bcd140368de3f235e827707
-  internal/sdk/models/operations/deleteazurebatchce.go:
-    last_write_checksum: sha1:8afbfcc75974c6003b9dc37fbc17432f78393ddf
-  internal/sdk/models/operations/deleteazurecloudce.go:
-    last_write_checksum: sha1:590a0d2b5b27cb1187915954b17ad97e7f4b4073
-  internal/sdk/models/operations/deleteazurecloudcredentials.go:
-    last_write_checksum: sha1:e586c30b12d087e3f403e0eb4fa4f6d5a970321c
+  internal/sdk/models/operations/deleteazurebatchce.go: {}
+  internal/sdk/models/operations/deleteazurecloudce.go: {}
+  internal/sdk/models/operations/deleteazurecloudcredentials.go: {}
   internal/sdk/models/operations/deleteazurecredentials.go:
     id: 98db9ee4a026
-    last_write_checksum: sha1:71e8027b419da768bc7392312c992139b35f4e5c
     pristine_git_object: b6ce8c054ac35b95a366cbd1c19f3c6360ad393c
-  internal/sdk/models/operations/deleteazureentracredentials.go:
-    last_write_checksum: sha1:af528c2b61948455089def391d28a35a09ed948e
+  internal/sdk/models/operations/deleteazureentracredentials.go: {}
   internal/sdk/models/operations/deletebitbucketcredentials.go:
     id: a1b3a94f9112
-    last_write_checksum: sha1:dab242c5a691b1cbd5b11ef3bf1271b8dafcde7d
     pristine_git_object: 02ae6e51d7069dcbee644305133a3446b4c295af
   internal/sdk/models/operations/deletecodecommitcredentials.go:
     id: 7f9073809f39
-    last_write_checksum: sha1:8080135a96524b40d7a1f36e6a48e4d5430a9e9b
     pristine_git_object: 81d4445e4509a117ccb87912b4e0ea73e7bb6dab
   internal/sdk/models/operations/deletecomputeenv.go:
     id: 155a98555053
-    last_write_checksum: sha1:2134010fbfd83752bf4882e54d469ea69f52412e
     pristine_git_object: 92261e0b83be06da9a3c80d722474b1a14cd0bb9
   internal/sdk/models/operations/deletecontainerregistrycredentials.go:
     id: 446e6f2ec9ba
-    last_write_checksum: sha1:6b1992e9847cd148ddfd38557539711d91c23843
     pristine_git_object: c6bdd4a1f222ec705bf4f519052345b3260ae79f
   internal/sdk/models/operations/deletecredentials.go:
     id: aead969f17e4
-    last_write_checksum: sha1:ab1b64556171006367f91675ecbbe044c93846d7
     pristine_git_object: 53f1665f342dde1192c2ea0ee5c6a693a891e378
   internal/sdk/models/operations/deletecustomdatalink.go:
     id: eafb7582968c
-    last_write_checksum: sha1:ebdac6c1c17198928e21a1e06d5ff931463cbc31
     pristine_git_object: 838e2f16a73cb087ee4e609896fab09682ab9d2a
   internal/sdk/models/operations/deletedatalinkitem.go:
     id: 2a3179e8656f
-    last_write_checksum: sha1:37a8a674a9c967e9958dcfc518be25b89677a2a1
     pristine_git_object: 422dff7905d9609e12612ccd6a3d669188648c37
   internal/sdk/models/operations/deletedataset.go:
     id: 36c39eee9c86
-    last_write_checksum: sha1:0b12cd9a046adafce02a7a121b4904d90689a962
     pristine_git_object: a7a57dbb88a633a2c227234c1cf9a4c4ab40f261
   internal/sdk/models/operations/deletedatasets.go:
     id: ad4fe0bc8a88
-    last_write_checksum: sha1:4dc15f04849eb9639910f2fcf4500a917b167d70
     pristine_git_object: 0d3ca62dea2e0835a554089d8a6ea2d5cd30f6d3
   internal/sdk/models/operations/deletedatasetv2.go:
     id: 6155c593e3fa
-    last_write_checksum: sha1:b802145cbaf06346a429b85f4f6bd11697b405d2
     pristine_git_object: 6a95dc4be92510d6809489430600f4b309405ccb
   internal/sdk/models/operations/deletedatastudio.go:
     id: 3670f403a62d
-    last_write_checksum: sha1:4ca0ca415c372113b3f2696afffe9f9e1bc44329
     pristine_git_object: 30fb257520f564ba8e31216ed5800c840d759d0e
-  internal/sdk/models/operations/deletegcpbatchce.go:
-    last_write_checksum: sha1:d52532a4f930d94367992982631534eb22ed1e08
-  internal/sdk/models/operations/deletegcpcloudce.go:
-    last_write_checksum: sha1:29fc98a22cab78c698abfedf476d662eeb6e9bf3
+  internal/sdk/models/operations/deletegcpbatchce.go: {}
+  internal/sdk/models/operations/deletegcpcloudce.go: {}
   internal/sdk/models/operations/deletegiteacredentials.go:
     id: 3b2e3ae86aae
-    last_write_checksum: sha1:bff908119cf35a9c9def60e03a8766dda3fbd7da
     pristine_git_object: 4a9730804454571d9716d29a55526e98c20727ed
-  internal/sdk/models/operations/deletegithubappcredentials.go:
-    last_write_checksum: sha1:0179dac4788bd946b56e81f9708a1822b67ca535
+  internal/sdk/models/operations/deletegithubappcredentials.go: {}
   internal/sdk/models/operations/deletegithubcredentials.go:
     id: 1b45e72d2ff4
-    last_write_checksum: sha1:99402cca559be01d06b83c0b67d6a441b82eb0ff
     pristine_git_object: ed56501232d31f5286dc21ad626aace589d1e605
   internal/sdk/models/operations/deletegitlabcredentials.go:
     id: f86b9735ebe3
-    last_write_checksum: sha1:ac43526b32bc68d4e2b01b324954efa64ea12867
     pristine_git_object: b7a101a2168b70a445e55ee8c4063529be28020f
   internal/sdk/models/operations/deletegooglecredentials.go:
     id: c0892504d7df
-    last_write_checksum: sha1:50da5ee44ff2dd788907f79ee31e2a0d0e222394
     pristine_git_object: e9c759e108d957dee27b3038f8c8ec21db866540
   internal/sdk/models/operations/deletekubernetescredentials.go:
     id: e0e506cba235
-    last_write_checksum: sha1:945b47d8f2ed308947dd812bd0e44e223149c5d9
     pristine_git_object: 6d6e5880acf0177278eb241c179609832a52c4c7
   internal/sdk/models/operations/deletelabel.go:
     id: 0137e86b7026
-    last_write_checksum: sha1:e8a662f6b672c166d459b925eef86decd3e7ee09
     pristine_git_object: 3cc227b504c8fa30d7aa9b5516b4f90bbf901290
   internal/sdk/models/operations/deletemanagedcomputece.go:
     id: b2c3256dc4f8
-    last_write_checksum: sha1:27e1d3f236a864b2a8d5f9512255e0cb4690ecfb
     pristine_git_object: a11e5411457641157666703ec6c6dec40c3d864c
   internal/sdk/models/operations/deletemanagedcredentials.go:
     id: 23349038a2a7
-    last_write_checksum: sha1:9fa58203842419b47bd5cd4ffad0059f1f208703
     pristine_git_object: 2d6c76f6215f3da937114cdad9b398271a1badb7
   internal/sdk/models/operations/deletemanagedidentity.go:
     id: eb6a131f9a3b
-    last_write_checksum: sha1:6349b49a4b23ec9c72225c0c1f24ea3843276de6
     pristine_git_object: 8ab6522e34df5adbaa8c93d0d4b5cae426bd5774
   internal/sdk/models/operations/deleteorganization.go:
     id: 1c8ebe14d0fa
-    last_write_checksum: sha1:9ef553f4d3d8c048b73f8eaa4382ec9665eb7527
     pristine_git_object: 460a1c318e311309486a62cb56e74d4b46b4b202
   internal/sdk/models/operations/deleteorganizationmember.go:
     id: 8d9c0bab1fdf
-    last_write_checksum: sha1:7e8a2583ec086c36fbb02c85ba5635b511928cee
     pristine_git_object: 4c994e680d12e40dd27fcef8c1fea7ce4494ca27
   internal/sdk/models/operations/deleteorganizationteam.go:
     id: dba77d7e72ed
-    last_write_checksum: sha1:9f4fd1030b3e43d11666c14019ba3576d80c6df8
     pristine_git_object: b783a3aee7686446460314bcc5eb84fb9486399d
   internal/sdk/models/operations/deleteorganizationteammember.go:
     id: b3255a38b8db
-    last_write_checksum: sha1:1c4efec587d9a8be05c44218200c340b1c0ac573
     pristine_git_object: 99f09d4386b3d0155d90d46e28a292774f78079d
   internal/sdk/models/operations/deletepipeline.go:
     id: ca2013f50ad4
-    last_write_checksum: sha1:6333f4c3b773f28bf1bb66dccb686f1174a66357
     pristine_git_object: 23d011468759edc58e9a0023bcaf7c819ddc1edc
   internal/sdk/models/operations/deletepipelinesecret.go:
     id: 1d3d8285b502
-    last_write_checksum: sha1:f2033356665231f4e13a70b4a8749a1dfcd5315d
     pristine_git_object: 8171786108b1cd0aae18b59bf45ba2f54b097f6c
-  internal/sdk/models/operations/deleterole.go:
-    last_write_checksum: sha1:86915383fff5d9c9b5b2324a8a8b038611849c61
+  internal/sdk/models/operations/deleterole.go: {}
   internal/sdk/models/operations/deletesshcredentials.go:
     id: 0e155693ad42
-    last_write_checksum: sha1:cbcd6d6bf19ef32dd3882a6c7304c32a9c29fc0f
     pristine_git_object: 7204e26899e962331a230cdc9c8dcd4c2d383b21
-  internal/sdk/models/operations/deletesshkey.go:
-    last_write_checksum: sha1:7e82e9781edd9e27626e534c1cc117dee79cb021
+  internal/sdk/models/operations/deletesshkey.go: {}
   internal/sdk/models/operations/deletetoken.go:
     id: 545d4e57e89a
-    last_write_checksum: sha1:fcc41997582b29d062a62323474041f021f5ac0d
     pristine_git_object: 24dad3176c1c2e274c0b39c8eac9dc419d8c85c7
   internal/sdk/models/operations/deletetoweragentcredentials.go:
     id: 4b876ff5e5e2
-    last_write_checksum: sha1:cd9106ad6e1f8b30bdbc415e78a8341f0f2ae865
     pristine_git_object: 7bb03385601959fe2dcbabb371b3422be668c4b0
   internal/sdk/models/operations/deleteuser.go:
     id: 3bebaf90a8a6
-    last_write_checksum: sha1:f4932ae704e63d57aba4a22795bec320b6037537
     pristine_git_object: acdccca7c217caa948149782143106b003833e60
   internal/sdk/models/operations/deleteworkflow.go:
     id: 8a08f6881c4f
-    last_write_checksum: sha1:272575e3ee3a15ce1d7fe1de5842c9e280330f37
     pristine_git_object: 5c75eb7e3a6180db80f7777564479ea20baa04a6
   internal/sdk/models/operations/deleteworkflowmany.go:
     id: eadc88e6e52b
-    last_write_checksum: sha1:c33e2d5eeaccc99e3a1e37c0d42aba633d024f16
     pristine_git_object: 66f7c26cdf7e11e046733c23ef7563c8513a90cf
   internal/sdk/models/operations/deleteworkflowstar.go:
     id: fa2d42cadd91
-    last_write_checksum: sha1:660bf39f051e797c11a84d587e7bc35a73c42a8b
     pristine_git_object: f6f6c6af0cd4519fbfdb16a800396ea5bc6f008c
   internal/sdk/models/operations/deleteworkspace.go:
     id: 1193e004e5cc
-    last_write_checksum: sha1:c54199b8c9a42e3eba2b592978c27fe3edb9b879
     pristine_git_object: 4fdd2d2f5990e5203f980ee1f38c2b28f3792359
   internal/sdk/models/operations/deleteworkspaceparticipant.go:
     id: 8a369744c243
-    last_write_checksum: sha1:af1ace4846973ca219e42748dd77f27da62b8177
     pristine_git_object: 7aea3817aa23df2000ef397f5d73835c943ba8a2
-  internal/sdk/models/operations/deleteworkspaceuser.go:
-    last_write_checksum: sha1:ff70b1986bd64a74e46d1c03c46806b54b86b3cf
+  internal/sdk/models/operations/deleteworkspaceuser.go: {}
   internal/sdk/models/operations/describeaction.go:
     id: "966976712e46"
-    last_write_checksum: sha1:2aef8e465f64c513f9f73a4fa527b5588541240c
     pristine_git_object: 4bbac8dfa1e6d46989a94a26416fce1c6e020583
   internal/sdk/models/operations/describeawsbatchce.go:
     id: 6e9f36a95fe0
-    last_write_checksum: sha1:f30142cbdff1f0112f2fd93578a4f92874796212
     pristine_git_object: c3a6766d07c56e5a37ba01e4aa9c23194bef6378
-  internal/sdk/models/operations/describeawscloudce.go:
-    last_write_checksum: sha1:145a4d383f7609b84e4baed9d0f8032c542ee9ed
+  internal/sdk/models/operations/describeawscloudce.go: {}
   internal/sdk/models/operations/describeawscomputeenv.go:
     id: 976e456ad7ff
-    last_write_checksum: sha1:345778866dc0f4d8222db002c27c972f260261ba
     pristine_git_object: 8800203d7cdbb9fb3564fa6a3afecdd8e7c57795
   internal/sdk/models/operations/describeawscredentials.go:
     id: b6c81dbe2d53
-    last_write_checksum: sha1:c0f480a92e581b7e82a8bc287541dcbc4208c4a6
     pristine_git_object: f875abef9cc844ab77a400da7fbd60143556368e
-  internal/sdk/models/operations/describeazurebatchce.go:
-    last_write_checksum: sha1:75a8d5438d0cd571f1c11a2745039993edd2c3ef
-  internal/sdk/models/operations/describeazurecloudce.go:
-    last_write_checksum: sha1:62d82ac90fbb55b677f0371834d216dbf3926c3c
-  internal/sdk/models/operations/describeazurecloudcredentials.go:
-    last_write_checksum: sha1:4b507bb6f150f0eb0a71fb47770e6fb22f50ec19
+  internal/sdk/models/operations/describeazurebatchce.go: {}
+  internal/sdk/models/operations/describeazurecloudce.go: {}
+  internal/sdk/models/operations/describeazurecloudcredentials.go: {}
   internal/sdk/models/operations/describeazurecredentials.go:
     id: 24476858a911
-    last_write_checksum: sha1:ba58cbfbc82a33c85e6dcb04e04de2fcd6a314a7
     pristine_git_object: 29385ab2a7f9b2617446b7e640ac9351c466ee33
-  internal/sdk/models/operations/describeazureentracredentials.go:
-    last_write_checksum: sha1:3d63c0e99d01d8c50ec264a773c667d29a7532c1
+  internal/sdk/models/operations/describeazureentracredentials.go: {}
   internal/sdk/models/operations/describebitbucketcredentials.go:
     id: b6ca37cb8056
-    last_write_checksum: sha1:f86c5e1619290a1b8075de91f6aafced35c5b96a
     pristine_git_object: 5bda8d5504eda6ef49612fe4053c48aaccae4a74
   internal/sdk/models/operations/describecodecommitcredentials.go:
     id: b31aa295e1a7
-    last_write_checksum: sha1:a50d4db47d3659f549cdc5057f422623a138ed84
     pristine_git_object: 28c1cc130948bc5beacb09cd1c4c14ba5dbcbd7b
   internal/sdk/models/operations/describecomputeenv.go:
     id: aac3d7006c79
-    last_write_checksum: sha1:40dff9f54807b77f4c6cfe4423e6b67820cfe401
     pristine_git_object: 398dcc69ce552ac86530380bbdef6527eed55d68
   internal/sdk/models/operations/describecontainerregistrycredentials.go:
     id: 96e8211a8e67
-    last_write_checksum: sha1:f43af19af2d746d2e207addc26dc849fedd40f87
     pristine_git_object: 1b0090c8b4f5b40d4324d470aad00e411d7c8b56
   internal/sdk/models/operations/describecredentials.go:
     id: 48bfbf511a8b
-    last_write_checksum: sha1:105c18e7e37eecf2a408267b1d1efd908e891120
     pristine_git_object: 4a5f3a19436a7e6495ce78f0e9917466d323f699
   internal/sdk/models/operations/describedatalink.go:
     id: 5624756d312b
-    last_write_checksum: sha1:7cf37c5459d561a566e2dbf2594295b0585c3975
     pristine_git_object: 74fa8d865241dcdb7d5c85b47f019ed2f4f12d2f
   internal/sdk/models/operations/describedataset.go:
     id: aa67e56521df
-    last_write_checksum: sha1:53d7e70026cad336a6fe4ae5aaab825968ed9a4d
     pristine_git_object: ff093819f74f1d3987d56910b6ec6a6e392e225f
   internal/sdk/models/operations/describedatasetv2.go:
     id: 3e0f274c03b9
-    last_write_checksum: sha1:b92814c39e859dbd36cb3d7ab5a7d0b97099a5ae
     pristine_git_object: ceb808b9c11c1fb42e394aada52c343f636c3be0
   internal/sdk/models/operations/describedatastudio.go:
     id: 1280c695eb1f
-    last_write_checksum: sha1:1d05b153967fafa20852a2110f3c4e4c880665c1
     pristine_git_object: 7f617c7d7f58db1ce100482e0c053a763d2328e5
-  internal/sdk/models/operations/describegcpbatchce.go:
-    last_write_checksum: sha1:d7ac0a864992ea499d86a709f4e06e585fb92f5a
-  internal/sdk/models/operations/describegcpcloudce.go:
-    last_write_checksum: sha1:175e01f42fab0dcac607a33564af486355cf6722
+  internal/sdk/models/operations/describegcpbatchce.go: {}
+  internal/sdk/models/operations/describegcpcloudce.go: {}
   internal/sdk/models/operations/describegiteacredentials.go:
     id: 37766e51b23b
-    last_write_checksum: sha1:b25a1cf11e00202dff364881770e54922b7466df
     pristine_git_object: eed1e5430625595f6216e7f8ffc2e5f55516fc6f
-  internal/sdk/models/operations/describegithubappcredentials.go:
-    last_write_checksum: sha1:e431aed86f5e7d0c473ea0108e2a5ee0fd09118d
+  internal/sdk/models/operations/describegithubappcredentials.go: {}
   internal/sdk/models/operations/describegithubcredentials.go:
     id: e3220a54e087
-    last_write_checksum: sha1:026d32046738383ed337fe521a5bc94d8524dec2
     pristine_git_object: 29c030008f8baef0f3f6944172a56a0bf596278e
   internal/sdk/models/operations/describegitlabcredentials.go:
     id: ddc3638df429
-    last_write_checksum: sha1:79e8a5fb33586c0aba43084519f00a7432d4c75d
     pristine_git_object: 8c65a74b0190d5fd7778dd7623836de5a5bb9548
   internal/sdk/models/operations/describegooglecredentials.go:
     id: 6431e37b27c2
-    last_write_checksum: sha1:4ec220d70dfdfe92cd5b31be11c7b163890e379d
     pristine_git_object: 3143077b2ea8b6537ab6631d5d7614edea9e5ac6
   internal/sdk/models/operations/describekubernetescredentials.go:
     id: d12bcff46246
-    last_write_checksum: sha1:43a30c171f17b1cb22f3ec0cb7e49da02058fb73
     pristine_git_object: 6a588a9be6c399e95ce0f1a82210610fbe2a374a
   internal/sdk/models/operations/describelaunch.go:
     id: c45eb8993de2
-    last_write_checksum: sha1:2befbce0362a7c231d60e7aa869b26fa03ca5727
     pristine_git_object: 254c3f91754533cb29a9387f133a03d51cee12cf
   internal/sdk/models/operations/describemanagedcomputece.go:
     id: fcf1a41bcd96
-    last_write_checksum: sha1:b15c12826e6f98f7081b6e70b1c28d30d1a5bbbc
     pristine_git_object: a148d9ca12698ac1d111a134e259f2693944e72f
   internal/sdk/models/operations/describemanagedidentity.go:
     id: df3cc8ceaf9e
-    last_write_checksum: sha1:ae63c845ecd9c856e8fcc5daebe94d0eeae65783
     pristine_git_object: 45b1f9237f44c20aa68ed115740fc966c9b08d4e
   internal/sdk/models/operations/describeorganization.go:
     id: 73b03e639b2d
-    last_write_checksum: sha1:a0cca6e1e0d3b955dbbfb0303c3f36610328f20e
     pristine_git_object: 6ce9d006062d2f075d8e506b1a6b7eeec7f719ca
   internal/sdk/models/operations/describeorganizationquotas.go:
     id: fafa5bf003f1
-    last_write_checksum: sha1:a7d90d26f1fc401f1d5adb8177f788f6d785d931
     pristine_git_object: 25e4d0459ea620a2b6158cd04ad64c8410575874
   internal/sdk/models/operations/describeorganizationteam.go:
     id: b90bdc7fb591
-    last_write_checksum: sha1:3faaf2f60d4044e2a5de6bb132f3a78ee3983168
     pristine_git_object: 1509a5f8183f5aea78d6c7bbbf4fb8adbf03e91c
   internal/sdk/models/operations/describepipeline.go:
     id: 19855696ec0b
-    last_write_checksum: sha1:010cc3ae5c45298f8f159e3bb75e52de1db04002
     pristine_git_object: cbaae92b2d2a259b1d8e8a0df3088f4c2c9526e5
   internal/sdk/models/operations/describepipelinelaunch.go:
     id: 1708099c377e
-    last_write_checksum: sha1:511d1069b070c18eee379d53898e82becb2ee635
     pristine_git_object: e670cb4d864ad3d0873a7d3f40f3e3c32e92aaa0
   internal/sdk/models/operations/describepipelinerepository.go:
     id: 8801e116f3ba
-    last_write_checksum: sha1:c4de6363bd3dc59112189dad8f504744a0cfab1b
     pristine_git_object: 5bb2722ae06ec3bfe227e125ea7bc4f458c46e27
   internal/sdk/models/operations/describepipelineschema.go:
     id: 4b928f34d06a
-    last_write_checksum: sha1:b17c1c64ff275fb36559c3411843f4ad28416d46
     pristine_git_object: d1b5806abfb010cde682c6cb0026941614659cf1
   internal/sdk/models/operations/describepipelinesecret.go:
     id: 3f99ed28bc48
-    last_write_checksum: sha1:9e2f53eee9b8321b1916d2d4c4e021869984f254
     pristine_git_object: 59abab08d7ca6a53a13aa834ebd4886479190d93
   internal/sdk/models/operations/describeplatform.go:
     id: b9d79baea717
-    last_write_checksum: sha1:db36e5f0495e37f16027516616b1d20baf7f9c67
     pristine_git_object: aa8639c7f649618febf4911e27d6e88b47376523
-  internal/sdk/models/operations/describerole.go:
-    last_write_checksum: sha1:f41c57bb992e27b815560ebefa71389278542d0e
+  internal/sdk/models/operations/describerole.go: {}
   internal/sdk/models/operations/describesshcredentials.go:
     id: a85ddc2ebbb2
-    last_write_checksum: sha1:4b48c159209cda718c28b0ad1525775b0c6257de
     pristine_git_object: 269951ab0f95723155436b936287eb6e117bd89b
-  internal/sdk/models/operations/describesshkey.go:
-    last_write_checksum: sha1:0dc11d3435677a4c9def6e24d3d160fefd538eb1
+  internal/sdk/models/operations/describesshkey.go: {}
   internal/sdk/models/operations/describetoweragentcredentials.go:
     id: 3230404bb7bc
-    last_write_checksum: sha1:4d185bb39beba42ee2e5c47653b0df52d0be112f
     pristine_git_object: 3152138c00fbc854b6d110e69820240e8614f8d6
   internal/sdk/models/operations/describeuser.go:
     id: d70d71349869
-    last_write_checksum: sha1:878ece741d17a832f8229eadfbfa2efcaa42e28d
     pristine_git_object: 5673954723fc7f2c6495f04936d2dbe7e45c2bbc
   internal/sdk/models/operations/describeworkflow.go:
     id: 2122efae3cc6
-    last_write_checksum: sha1:72d68f3c62a0ba203083443337fbfa1f39a6e9ed
     pristine_git_object: 0ab984a3b1928896fa96a3f6e30cc79b05e19fa0
   internal/sdk/models/operations/describeworkflowlaunch.go:
     id: 9b3314997f23
-    last_write_checksum: sha1:64f6d6b62cc7d86368b5d45cd01729d6cc5cdcf1
     pristine_git_object: 8d1d8000b8159d5e3102c90857b2c72f30aecf21
   internal/sdk/models/operations/describeworkflowmetrics.go:
     id: 8b918dbddbb6
-    last_write_checksum: sha1:19db1e3865d8ae8e5c0e479c4a7c5b88ab375204
     pristine_git_object: 8b4d6c98ca498d36cb69d2260aa26f064c598698
   internal/sdk/models/operations/describeworkflowprogress.go:
     id: 0288323aa36b
-    last_write_checksum: sha1:a09c785a3291cf5fe724c3cd34662a4fe92231fb
     pristine_git_object: 465ca5130b59d6d22ad5aa310222c23945f810a6
   internal/sdk/models/operations/describeworkflowstar.go:
     id: 339eeae078a1
-    last_write_checksum: sha1:6f7ee0f8a2fb043f0556ca67ffce949a4886d064
     pristine_git_object: 87cf683348b742aeb5b1602dcaad9bd1439f3f18
   internal/sdk/models/operations/describeworkflowtask.go:
     id: 27354b1f0eb7
-    last_write_checksum: sha1:1ab778aff407b54621cb807c6d21e3380424f10e
     pristine_git_object: 9fd6dbffab25843f519902712eb1df916f2ee109
   internal/sdk/models/operations/describeworkspace.go:
     id: 721aa79558e3
-    last_write_checksum: sha1:51d694311a265b990114c72473c06cd5954b5b45
     pristine_git_object: 80bd3e16ceb0cfa21143f9e6d1279a6b86341870
   internal/sdk/models/operations/disablecomputeenv.go:
     id: bb6f84efa11f
-    last_write_checksum: sha1:5a1a86983f297ca229aa961087d83c9e30dd8eb5
     pristine_git_object: 24f2d6cb8e35d3c41dadd1e798ce13ea30c990bc
   internal/sdk/models/operations/disabledatasetversion.go:
     id: 2f1de6cbb551
-    last_write_checksum: sha1:2b60a68bcb6b2be2969b46c984b69e4d466a720c
     pristine_git_object: 5000c99eea4c9eb274cc22ea56119c3a604e0bba
   internal/sdk/models/operations/downloadavatar.go:
     id: 56b3ccbb2d66
-    last_write_checksum: sha1:859bf3e9dd4218e6ac64c53db31b3159b9b66195
     pristine_git_object: 0791064339e7bfc07aaf7481798e17e7d4b3e0e8
   internal/sdk/models/operations/downloaddatalink.go:
     id: 5220465275c9
-    last_write_checksum: sha1:470facd6c1c14b3c0e830802300cce2d15d19e63
     pristine_git_object: 4cebbd6224ea39ad53f4525d09ff89be7d0205ed
   internal/sdk/models/operations/downloaddatasetv2.go:
     id: 7fd9d48350fe
-    last_write_checksum: sha1:b209a66a90b424cceb0ce9493e82a2bf29b150ff
     pristine_git_object: 8f9a9fa2cc980faeaf9bb7efadd93d530e776ec7
   internal/sdk/models/operations/downloadworkflowlog.go:
     id: 98a53dd20063
-    last_write_checksum: sha1:572cfb0e72014ca68db330cbf907cb04abe3ddbe
     pristine_git_object: 9cb7ba3e523ec11448eb215c1a9765fd35f5527b
   internal/sdk/models/operations/downloadworkflowtasklog.go:
     id: a5dcbcd7bebe
-    last_write_checksum: sha1:95fb38976c6b3982d2ab244b9f6f01a361eb4a01
     pristine_git_object: da32d7de352f58aa451f41c2cc310bdac0d442bb
   internal/sdk/models/operations/enablecomputeenv.go:
     id: c4edc6e1a538
-    last_write_checksum: sha1:e7312143534ff962b8f12e8da030551791ecc2c2
     pristine_git_object: fea4d961ad73170803043ab33864a831063df9e1
   internal/sdk/models/operations/exploredatalink.go:
     id: 74fb668fffd8
-    last_write_checksum: sha1:f49d5d546f34afe41799e86b512e3ab483ac0cf9
     pristine_git_object: 6921554a430a0f74d8088fe35761ae247fb47584
   internal/sdk/models/operations/exploredatalinktree.go:
     id: 0602b94ffded
-    last_write_checksum: sha1:80676019ecf8f7ffb7b96b6c8c94f985da987db7
     pristine_git_object: 09c40105fd21e098a581eaf63cd9a73a4922508b
   internal/sdk/models/operations/exploredatalinkwithpath.go:
     id: 5d3d94a9ad3e
-    last_write_checksum: sha1:64a584f36606ef8ac765ab3acebcbdb7016df0ef
     pristine_git_object: 238bfbb3261e5ab71b4cb261cd3784a540a0b5db
   internal/sdk/models/operations/extenddatastudiolifespan.go:
     id: eea4d9a5ff32
-    last_write_checksum: sha1:0dbcfff499472d26d5f74a1fb9deae67268d4485
     pristine_git_object: 5523a8aa7e22be8790ad9f2f830a626d2179122e
   internal/sdk/models/operations/finddatastudiosworkspacesettings.go:
     id: 5400cef769e3
-    last_write_checksum: sha1:35a59c617b49572ae4d6e0e75655ea25fc85ca63
     pristine_git_object: 80444f4a7f33b00f072dc855493db6500f595be5
   internal/sdk/models/operations/finishdatalinkupload.go:
     id: c1d9f29c30c2
-    last_write_checksum: sha1:509d13e67eda5436618d7afdcac612b68ca44e9c
     pristine_git_object: f48ffc038c6a22cb1f92aac76d8b82b4da805c66
   internal/sdk/models/operations/finishdatalinkuploadwithpath.go:
     id: 26723b5870b7
-    last_write_checksum: sha1:5f53d8fa4bf94d9135d24652f66b58abc0beae27
     pristine_git_object: 0b6c63128dd565861d8d738843a5ab07db26d1ee
   internal/sdk/models/operations/ga4ghruncancel.go:
     id: 5c70933abdb8
-    last_write_checksum: sha1:c246f188d7a93f588d5d88ba970cdd1c0e05d7f9
     pristine_git_object: 16c186eb7376b19dc42e243554012363b86a2c8f
   internal/sdk/models/operations/ga4ghruncreate.go:
     id: 591da5570848
-    last_write_checksum: sha1:43fc232a9ed502bfa3445249d72789d9655f5b4f
     pristine_git_object: 0b3a4ef52f5f2a31adadec8ce02b5d5e4bd62ed4
   internal/sdk/models/operations/ga4ghrundescribe.go:
     id: e0406f497d82
-    last_write_checksum: sha1:47030a1175ee2df6502008c45c443f11c74eb3de
     pristine_git_object: 3ea2cc1863a99d23db1faa33bb510e5f6018b222
   internal/sdk/models/operations/ga4ghrunlist.go:
     id: 29c46bc76f36
-    last_write_checksum: sha1:0b35dad54e276a238791e6be2e3790ff317caca8
     pristine_git_object: 66dd3d7852ecc17c6b851b3c7bd23eb3f80453b2
   internal/sdk/models/operations/ga4ghrunstatus.go:
     id: 8bf25cfbddf6
-    last_write_checksum: sha1:482487250149db83127bf796bd7dc8c64242186f
     pristine_git_object: 87286afb4a14f25371ada7fa6f30585fb55bb9c5
   internal/sdk/models/operations/ga4ghserviceinfo.go:
     id: a18217dcdd73
-    last_write_checksum: sha1:3b7a993617919352f6c111e962937f7f2333a4de
     pristine_git_object: 9b2d7e9ba0ac7ab7a8322920863e3b168e087ecf
   internal/sdk/models/operations/generatedatalinkuploadurl.go:
     id: 2ce7b2c8acb2
-    last_write_checksum: sha1:ae39e52b19a6c8211834c19e02541978446d249a
     pristine_git_object: 4042b08769bd731c245e9744facf70fe850ce656
   internal/sdk/models/operations/generatedatalinkuploadurlwithpath.go:
     id: 76060c261442
-    last_write_checksum: sha1:b8817dbd22b5a49afc988cf2f46f9663915c9eb8
     pristine_git_object: 72c0415804107a49b974151be9384f441c003e3b
   internal/sdk/models/operations/generatedownloadscript.go:
     id: 10b0432ed728
-    last_write_checksum: sha1:590d0c32e66be7283e8306f3ea8fd935e3cbf158
     pristine_git_object: d5709a4447922f287531257feb7d96118e35c125
   internal/sdk/models/operations/generatedownloadurldatalink.go:
     id: a867914ee0bb
-    last_write_checksum: sha1:abe6a78c7b47deb4731e47792fc8d4dea54972d0
     pristine_git_object: 43852df50afbc4fb2b9c725781d3cc2cae57f2ac
   internal/sdk/models/operations/generaterandomworkflowname.go:
     id: 77ece758efa9
-    last_write_checksum: sha1:84cc84aa9003ef379a3f68075773a2bbe109d4de
     pristine_git_object: b0bbe02ce8332022412255119d83604c2ba77122
   internal/sdk/models/operations/getdatastudiocheckpoint.go:
     id: 8d308399adb7
-    last_write_checksum: sha1:c03882ee43c9c90d4206f65103c5a5c57886dd24
     pristine_git_object: f40e51b30bd25fd566cc33a1297cc7acac6b66ef
-  internal/sdk/models/operations/getencryptedcredentials.go:
-    last_write_checksum: sha1:ef9ddd2f175d0f0286fa88a393cac3ee7b7af3cb
+  internal/sdk/models/operations/getencryptedcredentials.go: {}
   internal/sdk/models/operations/getworkflowlog.go:
     id: a2007af19121
-    last_write_checksum: sha1:acaba5d61683878e702ccea314e6e38197ab0699
     pristine_git_object: 54d18db66664a3080ee174a63a62e5ada5ba682a
   internal/sdk/models/operations/getworkflowtasklog.go:
     id: 88934741ea4a
-    last_write_checksum: sha1:0fa346f9bc693b150aa694febb91124be3f057eb
     pristine_git_object: a7c5351de42325cc801db14234df30ea6b619621
   internal/sdk/models/operations/hidedatasets.go:
     id: 5b5c9d9d5d81
-    last_write_checksum: sha1:3cd58ab87cf2339d3ff46e7f2186c38227e30296
     pristine_git_object: 14d5dd4f68ffd8fee128b646d7b89dd7c7874ade
   internal/sdk/models/operations/info.go:
     id: e2a6ef8e19d1
-    last_write_checksum: sha1:b4636b83d4ee1b9b25c143f7d9482b652750f8c5
     pristine_git_object: 869cd320ac836e4f9c978e48597de7d5c60bdfb7
   internal/sdk/models/operations/launchaction.go:
     id: 4cc69c1add55
-    last_write_checksum: sha1:10af718a3a77a738f021194a1faf062540336de4
     pristine_git_object: 62bd65a9985f8bc27fa2598b7e1fa1eb4930d2e3
   internal/sdk/models/operations/leaveorganization.go:
     id: cf34758d6c84
-    last_write_checksum: sha1:67389bfe95b8149c9768c5e0e44beb9ed393584b
     pristine_git_object: 29376465bcd741800534b12e956e438422dfcd7d
   internal/sdk/models/operations/leaveworkspaceparticipant.go:
     id: 049f1100fae7
-    last_write_checksum: sha1:d686be18f51c75689066a370f87d75f7f1b44109
     pristine_git_object: e2e06679fe0988da6fdae2a247064ecc45709738
-  internal/sdk/models/operations/linkdatasetversion.go:
-    last_write_checksum: sha1:d1676631cef659fba4722a58d89944eb01832b66
+  internal/sdk/models/operations/linkdatasetversion.go: {}
   internal/sdk/models/operations/listactions.go:
     id: 13c7253f41df
-    last_write_checksum: sha1:5cb46c03734f0ac15b855e7f1b3d0d74975c279e
     pristine_git_object: f4a08d7ae481739f7be85a04ba74d350a74c8fd3
   internal/sdk/models/operations/listactiontypes.go:
     id: 60aadb6c866f
-    last_write_checksum: sha1:432a67aa5e13e5f4a422dc854d247d02c06eb937
     pristine_git_object: 4335756b42ed9e719d60da8a7439fde6b12e8327
   internal/sdk/models/operations/listcomputeenvs.go:
     id: bb3de0d7ec07
-    last_write_checksum: sha1:fbd00732d82ae0fa6b16c7f4e2843616b992d2bf
     pristine_git_object: 8c8183faf35349d880e3cdfd68897592e3e7c86d
   internal/sdk/models/operations/listcredentialsdatasource.go:
     id: cc33a2d98eda
-    last_write_checksum: sha1:6266c3a7540e006f18395526d6c4b3694b6e2222
     pristine_git_object: de2e50d92b9f65b38648ff521646d7dcf94de6dc
   internal/sdk/models/operations/listdatalinksdatasource.go:
     id: 59e212ab8212
-    last_write_checksum: sha1:1dbcfaf5ea94907ed37f5ec63f3e6e674351dca9
     pristine_git_object: 9439c0b7f3db19bd0cccabda3f78344a9565d863
   internal/sdk/models/operations/listdatasets.go:
     id: eb286234d68f
-    last_write_checksum: sha1:fc434dd5e1334d9baa48add344f7a836a0f28ebc
     pristine_git_object: a36621fbcac6eaff613f9770dd121e8aa840f354
   internal/sdk/models/operations/listdatasetsv2.go:
     id: 89841f856a75
-    last_write_checksum: sha1:b9848cc85309da456fbe1098202ead8c47212427
     pristine_git_object: aeaf53bfed587409be7b468150b8baf1c1d1873e
   internal/sdk/models/operations/listdatasetversions.go:
     id: b98e6aa7fb4e
-    last_write_checksum: sha1:bdbac8b01636b8fa251a1efffc2dd89482a0db72
     pristine_git_object: a50169cbfc76e455e3c9b45ab9533c128c776797
   internal/sdk/models/operations/listdatasetversionsv2.go:
     id: 3b28710e0c7c
-    last_write_checksum: sha1:296b6afaabb4fb79ceb810dfd8ccd92171df7067
     pristine_git_object: 85ef82577e6008fdbebfae2fbbef9201fad309a2
   internal/sdk/models/operations/listdatastudiocheckpoints.go:
     id: 72992e5afa62
-    last_write_checksum: sha1:64df2516cf6a72f0bad118493dbffeff328b2c80
     pristine_git_object: 0684ca2f6f1d8645975c8457f0ece0f43a305a5a
-  internal/sdk/models/operations/listdatastudiocompatiblecomputeenvs.go:
-    last_write_checksum: sha1:437e051de21bc0bf82575212e5963e6dcea1a69a
+  internal/sdk/models/operations/listdatastudiocompatiblecomputeenvs.go: {}
   internal/sdk/models/operations/listdatastudios.go:
     id: e12f2928c4e6
-    last_write_checksum: sha1:3e53b601ec90747387961dc86fa237a02e4b0236
     pristine_git_object: 7141d4cea687af606c76a9ed5b6d983bb92405db
   internal/sdk/models/operations/listdatastudiotemplates.go:
     id: 6a9827780c82
-    last_write_checksum: sha1:0c5c9508f8a7934115632285bb0926a8d80fd554
     pristine_git_object: 791a70e3a33a9d4e2765923848d75227e9e99128
   internal/sdk/models/operations/listlabels.go:
     id: 3a8e187b93b0
-    last_write_checksum: sha1:1fe9e21f080e8330033d21195887323e77124e89
     pristine_git_object: 4d72dcfee6a13b4e95767858eaeeccbde25eda54
   internal/sdk/models/operations/listlatestdatasetversionsv2.go:
     id: 74aa5592b6cb
-    last_write_checksum: sha1:6bc6669ba7c1399f81f80cebf5281a4b3e277e9a
     pristine_git_object: 568f09a7fb30fe250997fede35bfe20da038e694
   internal/sdk/models/operations/listlaunchdatasetversions.go:
     id: b6d7242b9e92
-    last_write_checksum: sha1:dffeb6abeac3efff1a48e72fbd63c894c887b463
     pristine_git_object: c682a71a3ab9dd241996d8cb4aca0d74aa718f88
   internal/sdk/models/operations/listmanagedcredentials.go:
     id: dec8bf663695
-    last_write_checksum: sha1:aad7776f043ff103efe79ed0f048ab2b2cf99a1e
     pristine_git_object: 1a14f2c1d1922874eb9e2c504d850cb23902f6aa
   internal/sdk/models/operations/listmanagedidentities.go:
     id: 723065d1a1b6
-    last_write_checksum: sha1:a6625ffa001b4baf68359f38b92d9a9253ad4bf6
     pristine_git_object: cda60c2dd60dae2293d162a52b4e4e875e528887
   internal/sdk/models/operations/listmounteddatalinkids.go:
     id: d5cfbc0564a2
-    last_write_checksum: sha1:cf46ced1d59193734d25c66b21511464bb7ba2ed
     pristine_git_object: 2fbc15f876b3096e7713df46e069a48fbf018b4f
   internal/sdk/models/operations/listorganizationcollaborators.go:
     id: 9550d4123121
-    last_write_checksum: sha1:51ad7f30f38eb20a75e3e91f5bd5a2584b10d90d
     pristine_git_object: 8278c0d8ee80d9592f60b9d8e3fcb1104186bb8b
   internal/sdk/models/operations/listorganizationmembers.go:
     id: b7da3df5652a
-    last_write_checksum: sha1:6084aa0ec0fe56446c7bb4296b0ac02412603f25
     pristine_git_object: b891c8f30cb1a88a32c17eae483412e51986107d
   internal/sdk/models/operations/listorganizations.go:
     id: 4fe6c8fc6771
-    last_write_checksum: sha1:05950a489c69dda6662d585d25f104daf95c5716
     pristine_git_object: b57000376e0d529ebc0864f97165479eab2560b2
   internal/sdk/models/operations/listorganizationteammembers.go:
     id: 5977cfe85567
-    last_write_checksum: sha1:04df4ca8e82ffc6c3f6096981c43566dcea6e064
     pristine_git_object: dbd0c549f010c5d59c7d51b39c80dc980815fa5b
   internal/sdk/models/operations/listorganizationteams.go:
     id: b4f8e240dbb1
-    last_write_checksum: sha1:f31267e80c547a909f23794d53675da9333d1a01
     pristine_git_object: f171731df3d5c408944ba63974ed64563d1468e8
   internal/sdk/models/operations/listpipelinerepositories.go:
     id: 29e2832c49ca
-    last_write_checksum: sha1:73d01f99b0271892e55cba8686f8a07306e8f477
     pristine_git_object: 654854e9a5eb6045129fa8ca1eef423a7ce26407
   internal/sdk/models/operations/listpipelines.go:
     id: 8596c1d5a5da
-    last_write_checksum: sha1:f87bec28829dd795e05aeee26af58e8522aec795
     pristine_git_object: 0e1c73b6eae4065367ed81708d21a6a5fca2580f
   internal/sdk/models/operations/listpipelinesecrets.go:
     id: fc7e7f9663f3
-    last_write_checksum: sha1:c34f8f99f4eb2ab26e13264290d2a386b87824b2
     pristine_git_object: 5842659e9f6e19a6cc60688ea72b47933b3371e8
-  internal/sdk/models/operations/listpipelineversions.go:
-    last_write_checksum: sha1:c45d1ceb134a036acb262aa55b9192d6182bed1e
+  internal/sdk/models/operations/listpipelineversions.go: {}
   internal/sdk/models/operations/listplatformregions.go:
     id: 37482440181a
-    last_write_checksum: sha1:21b52e7b689453410a38dd043eece1548c52751a
     pristine_git_object: 6c440b0b876198f68cc47e345a39acbd77ca2954
   internal/sdk/models/operations/listplatforms.go:
     id: f0ad34b83c59
-    last_write_checksum: sha1:af369f53cf5d39f1f58bf549c82e6cf8830195a1
     pristine_git_object: 57a00e8fcd754a368e7c0f7b7bf2104387af584e
-  internal/sdk/models/operations/listrolepermissions.go:
-    last_write_checksum: sha1:9ceabff726a11dae67b4c27a1b96b9debce005d5
-  internal/sdk/models/operations/listroles.go:
-    last_write_checksum: sha1:9ef5016da8d0c7967845b70281b79b7d137bd194
-  internal/sdk/models/operations/listsshkeys.go:
-    last_write_checksum: sha1:00284e49fb924ad7106763fa64871ed1eda6ba6f
-  internal/sdk/models/operations/listuserrolesinorganization.go:
-    last_write_checksum: sha1:ca9623898b4c84f8d802edbda5faeb4f65fc9eaf
+  internal/sdk/models/operations/listrolepermissions.go: {}
+  internal/sdk/models/operations/listroles.go: {}
+  internal/sdk/models/operations/listsshkeys.go: {}
+  internal/sdk/models/operations/listuserrolesinorganization.go: {}
   internal/sdk/models/operations/listworkflows.go:
     id: 5ccab7404dd3
-    last_write_checksum: sha1:bf32f7802a5fbf3c238bc49ecadca1bd26105172
     pristine_git_object: 7b9ac7ceddea0fdc3be5da7055ae70433337cef1
   internal/sdk/models/operations/listworkflowtasks.go:
     id: 990e67093549
-    last_write_checksum: sha1:4511d520e38eec51248f1a8cac7472412164332c
     pristine_git_object: 003f6ca7790c753343d0ead7201b723778b7b553
   internal/sdk/models/operations/listworkspacedatasetversions.go:
     id: 2a52c2573798
-    last_write_checksum: sha1:a62ac138019607a0cdc5050b048f7b285c04d43f
     pristine_git_object: ac9ca64ba03323c5255f0649e63eaefae294b08a
   internal/sdk/models/operations/listworkspaceparticipants.go:
     id: dd1fca5e40c2
-    last_write_checksum: sha1:fa3967519238bba165463be8697445554b0fffd0
     pristine_git_object: 1c748a8ab19c7c5b5018b90db7ae4b56bb49bd9f
   internal/sdk/models/operations/listworkspaces.go:
     id: 86a1257e623f
-    last_write_checksum: sha1:39b04e0da78c5ccdb042d034e77dbd32218f22d8
     pristine_git_object: 88ca88d8704f898c3dae7adeb765c279a0362ca6
   internal/sdk/models/operations/listworkspacesbyteam.go:
     id: bd0a95813906
-    last_write_checksum: sha1:ead43a94e9ca5246190f5b0c54f774ac6f8e28a3
     pristine_git_object: d62219613df18d4e11a33fa32150cffbae015f88
   internal/sdk/models/operations/listworkspacesuser.go:
     id: 9e7813d6986a
-    last_write_checksum: sha1:9a79a1d79222411002596595a7584bf66a5f9e10
     pristine_git_object: f6f5b63c38d835976e6f785c0aade5a8eaf54001
-  internal/sdk/models/operations/managepipelineversion.go:
-    last_write_checksum: sha1:69034e7cc9008caadec96dfae19754d749f72922
+  internal/sdk/models/operations/managepipelineversion.go: {}
   internal/sdk/models/operations/options.go:
     id: 6d0d29414e00
-    last_write_checksum: sha1:ca61f85e80bde8486c36ac7697a68086665d4062
     pristine_git_object: d3a402f2e7c2c26a3ff02929a9aa228650364045
   internal/sdk/models/operations/pauseaction.go:
     id: 9eab8632f446
-    last_write_checksum: sha1:f047b47121fc57cb965691b561ee13785cc096b5
     pristine_git_object: d4edf6d8df286f6c314cab6d3453ff496ee9594b
-  internal/sdk/models/operations/previewdataseturl.go:
-    last_write_checksum: sha1:1a3f24ca921bbb91234fbd9f041b2bcf7d83153a
-  internal/sdk/models/operations/previewdatasetversion.go:
-    last_write_checksum: sha1:2024470845d2c9673b6fb3cad0e0da85857bb6c1
+  internal/sdk/models/operations/previewdataseturl.go: {}
+  internal/sdk/models/operations/previewdatasetversion.go: {}
   internal/sdk/models/operations/refreshdatalinkcache.go:
     id: e2f0dd1e535d
-    last_write_checksum: sha1:b3fd9e68cb4e520370317320cd7f6fe2588f455b
     pristine_git_object: 5cf52ad86ca4262832f08f29635b8b52cb01ca72
   internal/sdk/models/operations/removelabelsfromactions.go:
     id: b6fa2cfbfd96
-    last_write_checksum: sha1:f61feb94aa620b5bfbb6b20e1945deabf60b46db
     pristine_git_object: f83d76fe467607b0d96d716f1ca411bb06fb19cf
   internal/sdk/models/operations/removelabelsfromdatasets.go:
     id: 6a5dd0ff8bf0
-    last_write_checksum: sha1:47442ac17d1ec395a7b4352d6d6d97821ff07781
     pristine_git_object: 51dba9c916eea41b6d573c502630c3a68c9ed587
   internal/sdk/models/operations/removelabelsfrompipelines.go:
     id: 13d2156786eb
-    last_write_checksum: sha1:d210c2f31b646b13d3031ca5aff678ab2caa02c9
     pristine_git_object: 60877d66113f50395bf997e4dc0a947c63a3e0cf
   internal/sdk/models/operations/removelabelsfromworkflows.go:
     id: 0881d3fbb54c
-    last_write_checksum: sha1:34c6f67e8bbca90d2b8cb53a4c56a197ad51c33a
     pristine_git_object: 2821276f9c80af8b6de0127c78c1eefccab887d7
-  internal/sdk/models/operations/resolvecronexpression.go:
-    last_write_checksum: sha1:74bb694165c53c165ca2ee49e03cc3ae1ea95363
+  internal/sdk/models/operations/resolvecronexpression.go: {}
   internal/sdk/models/operations/showdatasets.go:
     id: ee0c46e5ae8b
-    last_write_checksum: sha1:ceb633595218415dc6ead6c3efab67d4336626ab
     pristine_git_object: 7f0c5c16f3609c34266b53bf57d7b3be34d3d245
   internal/sdk/models/operations/startdatastudio.go:
     id: 7b2c6a27f855
-    last_write_checksum: sha1:43c6620045f940398c4cfb927ed089d87d4bcb2f
     pristine_git_object: 42a738be5b8f232d233ce701ff11b4219bef68f8
   internal/sdk/models/operations/stopdatastudio.go:
     id: 16ff4a88b1cb
-    last_write_checksum: sha1:23237344d8f3953c69245a7be2b3b1161e044591
     pristine_git_object: 1ee10611ece5d3b2f7b480819fcc993cba6c33ca
   internal/sdk/models/operations/tokenlist.go:
     id: d24e9829641f
-    last_write_checksum: sha1:d51e857a27715affbb025b769507f1dd1e1bd8db
     pristine_git_object: 98bc4a9c648d7dc10828e2e8d947304e0a3dcccc
   internal/sdk/models/operations/updateaction.go:
     id: fa6cffd64c4c
-    last_write_checksum: sha1:bba70cfd8942122760264619f67fb72772b0e1d5
     pristine_git_object: ccdb6e36db8c9db4a5ab14e083ea970b5ae7a07a
-  internal/sdk/models/operations/updateawsbatchce.go:
-    last_write_checksum: sha1:8f36f26ef71c678264bf30509e012903e9410b79
-  internal/sdk/models/operations/updateawscloudce.go:
-    last_write_checksum: sha1:5b93fb2e3dcbde09b7b7caf357cebaa1ec0b7405
-  internal/sdk/models/operations/updateawscomputeenv.go:
-    last_write_checksum: sha1:95bc4574aa754432544eaec4232cf495cd6af1cc
+  internal/sdk/models/operations/updateawsbatchce.go: {}
+  internal/sdk/models/operations/updateawscloudce.go: {}
+  internal/sdk/models/operations/updateawscomputeenv.go: {}
   internal/sdk/models/operations/updateawscredentials.go:
     id: e8911e4f76af
-    last_write_checksum: sha1:150772a2b3263175fad51346ced94d913018a458
     pristine_git_object: 3e2391c515076b6d3c87c79685bf5d033d1b7833
-  internal/sdk/models/operations/updateazurebatchce.go:
-    last_write_checksum: sha1:70c91d6f6f278da09c20cae37c558c6fbebd59c6
-  internal/sdk/models/operations/updateazurecloudce.go:
-    last_write_checksum: sha1:4ae77314a211e47aefe08defaabcbfd05d9a13c0
-  internal/sdk/models/operations/updateazurecloudcredentials.go:
-    last_write_checksum: sha1:c3f8e7da5d9155e72fa2087125a18c3470ebcbf0
+  internal/sdk/models/operations/updateazurebatchce.go: {}
+  internal/sdk/models/operations/updateazurecloudce.go: {}
+  internal/sdk/models/operations/updateazurecloudcredentials.go: {}
   internal/sdk/models/operations/updateazurecredentials.go:
     id: 7fc8fe4e2314
-    last_write_checksum: sha1:2d4b799253838a1ae8afec5d6b7359617848b587
     pristine_git_object: 22a37c95728f4bbde6ff951ec24bbbb79af584c1
-  internal/sdk/models/operations/updateazureentracredentials.go:
-    last_write_checksum: sha1:b832e3b101b3f955732da8224a1a74d5e28fdc40
+  internal/sdk/models/operations/updateazureentracredentials.go: {}
   internal/sdk/models/operations/updatebitbucketcredentials.go:
     id: 7340f33636df
-    last_write_checksum: sha1:80e9f9845ebfc63623ca1a722e3cfdeda54e5a63
     pristine_git_object: a0f66d9178a0944c66eb975ba7d4e02f1876ce01
   internal/sdk/models/operations/updatecodecommitcredentials.go:
     id: d0c02d121772
-    last_write_checksum: sha1:fa97482a6c77d2fa67ca2524a5d97b9ef4cfc7ff
     pristine_git_object: f091c38b2179fa8986e0460aedb286a8ecc7c4ad
   internal/sdk/models/operations/updatecomputeenv.go:
     id: ebb8f432b60c
-    last_write_checksum: sha1:27b29d835326bfbfd8e5fd539bfe1aea4f59b1f3
     pristine_git_object: 75f25af4de242adea98f6b5b2402da515cfde76c
   internal/sdk/models/operations/updatecomputeenvprimary.go:
     id: 17b49ea522cc
-    last_write_checksum: sha1:43223e7e87df274021b8025b6528714150ed06fa
     pristine_git_object: e968f65b898d55f5536e44547e8c9b6a3e113092
   internal/sdk/models/operations/updatecontainerregistrycredentials.go:
     id: 47f9c4fb44a8
-    last_write_checksum: sha1:5a50db932d2983e315f0de82421669983fec3fe0
     pristine_git_object: 0f08d02f3afe6e1636f94edf477da479af890556
   internal/sdk/models/operations/updatecredentials.go:
     id: 29b246e8eb7c
-    last_write_checksum: sha1:bedc7af521b0d5d3ca7490dd47bc9f8993570a07
     pristine_git_object: 1a7aeeddb60c9c20474e60dbd4dee6cbff8894c6
   internal/sdk/models/operations/updatecustomdatalink.go:
     id: 3d0503761f94
-    last_write_checksum: sha1:d440ee2985122214ce8bdd6d013d55fef06d50a8
     pristine_git_object: 5cf580867a57061c33e9098d3e380cd6aa070eeb
   internal/sdk/models/operations/updatedataset.go:
     id: 3b7938bcf412
-    last_write_checksum: sha1:27157602223e3e1878d6b4f8d525b3cba074d102
     pristine_git_object: 56b50a523aa2bb708537137a8ed05180617e57f9
   internal/sdk/models/operations/updatedatasetv2.go:
     id: dd71f26b995a
-    last_write_checksum: sha1:952d9cbf3303b34142126ebdf5442104e6b94373
     pristine_git_object: 18e4c3d8395cde5c452c6827bac48a9db74f7b5d
-  internal/sdk/models/operations/updatedatastudio.go:
-    last_write_checksum: sha1:be2b09d81ad63f3246465161d1c87e8befaff655
+  internal/sdk/models/operations/updatedatastudio.go: {}
   internal/sdk/models/operations/updatedatastudiocheckpoint.go:
     id: 6a29dc1e143b
-    last_write_checksum: sha1:87026c4f80d97103bfb23c3db1b42c4f0de663dc
     pristine_git_object: 4f9f1151c87215baecab33272bbb39a7d953c72f
   internal/sdk/models/operations/updatedatastudiosworkspacesettings.go:
     id: 4b4d6754cd64
-    last_write_checksum: sha1:291da8255dd5fc25ba2f4ebb56fc8890e87afbd4
     pristine_git_object: 8e81d37d107dc0cb14ed0ba599bbc9b3ddbcfb9e
-  internal/sdk/models/operations/updategcpbatchce.go:
-    last_write_checksum: sha1:1d5a30e02136104d139111e5d29f0cbedc69885d
-  internal/sdk/models/operations/updategcpcloudce.go:
-    last_write_checksum: sha1:79eae38fd45fbf2bdc92eff2d054a36b76d16bfb
+  internal/sdk/models/operations/updategcpbatchce.go: {}
+  internal/sdk/models/operations/updategcpcloudce.go: {}
   internal/sdk/models/operations/updategiteacredentials.go:
     id: e445df842b48
-    last_write_checksum: sha1:44613491091e9a58d37c897b9bd7e8c96ef30ea7
     pristine_git_object: 2493ed41288f678b0616b40ada2b8aca9f9bcb2d
-  internal/sdk/models/operations/updategithubappcredentials.go:
-    last_write_checksum: sha1:5415d8436b3c16ec6ab770d512c135987c4b7fc5
+  internal/sdk/models/operations/updategithubappcredentials.go: {}
   internal/sdk/models/operations/updategithubcredentials.go:
     id: 43c4f783e72c
-    last_write_checksum: sha1:acbd3c77a14949ebd577222c6a3d1a0e8e3dfde1
     pristine_git_object: 4b71aeb5e7b08e2bde13e5d21a6d095edbc2597d
   internal/sdk/models/operations/updategitlabcredentials.go:
     id: c0057916d8d0
-    last_write_checksum: sha1:6ac4facc455cd3c8b8f8c07638980314426f46df
     pristine_git_object: 801506e4c2eb6dd2df6c7e776bc6060714eb072d
   internal/sdk/models/operations/updategooglecredentials.go:
     id: 2920a953e733
-    last_write_checksum: sha1:046b478ca405b2cff9a668cd4edf950cfba568ea
     pristine_git_object: 566a20b63b0c4b5395c0e16c466d87eb6a827827
   internal/sdk/models/operations/updatekubernetescredentials.go:
     id: 1733482dffe9
-    last_write_checksum: sha1:1bd49b5cda01bb32e1e9e31833c9d41a98ade6a3
     pristine_git_object: 28d1df7b47efaf54b4037d01581011a0b7bb80f5
   internal/sdk/models/operations/updatelabel.go:
     id: 05d3f0b86579
-    last_write_checksum: sha1:0fe8e503332fa016bd2f76e8b3423a5ac3a5e778
     pristine_git_object: 772478ab423b2082b92ec3801415300156851a49
-  internal/sdk/models/operations/updatemanagedcomputece.go:
-    last_write_checksum: sha1:cc28017783009559796b09742e82e0cca96e522b
+  internal/sdk/models/operations/updatemanagedcomputece.go: {}
   internal/sdk/models/operations/updatemanagedcredentials.go:
     id: b23eb77587f3
-    last_write_checksum: sha1:1fa7366b35dcf5c0bf1a2c8d0b40c0ecb9f5333b
     pristine_git_object: 0f176b6337b460f11830b66be1b50143b7ea5301
   internal/sdk/models/operations/updatemanagedidentity.go:
     id: 4d80b31781be
-    last_write_checksum: sha1:e123226e0929790e558cfaf5304f8f10eab699af
     pristine_git_object: 43f1ee46613ab0645c90fea392b82a947160ae33
   internal/sdk/models/operations/updateorganization.go:
     id: 1781040e237c
-    last_write_checksum: sha1:2399047ad6274ef8f9cf6202361dc7cecbe08db4
     pristine_git_object: 62a07917ba468ee0df15c4d01d5473a832be5222
   internal/sdk/models/operations/updateorganizationmemberrole.go:
     id: b05cf73e5412
-    last_write_checksum: sha1:e37802b5f5f6e3130b35951ecb5ce5cdf037f6b9
     pristine_git_object: 2be4a8f15c909d8bf635f31293ded40a2a42e915
   internal/sdk/models/operations/updateorganizationteam.go:
     id: ad6a7d6266d8
-    last_write_checksum: sha1:f0b92ddc66d4f65a58619b3c5246d956565c8a70
     pristine_git_object: 96461e6feeee0daa8d7a16614aa0760cca4b1593
   internal/sdk/models/operations/updatepipeline.go:
     id: 6a000cefe7e8
-    last_write_checksum: sha1:4efe5ed5313cdc76c07914d7e90d6f3bc4c02103
     pristine_git_object: c9319578c1eb87da59ccda27bdfe4de01324cef9
   internal/sdk/models/operations/updatepipelinesecret.go:
     id: 19b64d6519f2
-    last_write_checksum: sha1:3ce17f9e02824bc1e4303c8e3b2b2e1a7f71946d
     pristine_git_object: 91005128b148d00961beba2df4584c7aae183ea2
-  internal/sdk/models/operations/updatepipelineversion.go:
-    last_write_checksum: sha1:827b2ed98820558f8f4191216e0a16dba3a1d178
-  internal/sdk/models/operations/updaterole.go:
-    last_write_checksum: sha1:7feac14c3d3b7c101987f5de7e615dda2a8123de
+  internal/sdk/models/operations/updatepipelineversion.go: {}
+  internal/sdk/models/operations/updaterole.go: {}
   internal/sdk/models/operations/updatesshcredentials.go:
     id: c3e32df7fc4c
-    last_write_checksum: sha1:3cfd5deffed1103892ab3c710f43cbce798ed00e
     pristine_git_object: f4d49f6a36c2d3c57dd6c96c3d09559e95e0ff15
   internal/sdk/models/operations/updatetoweragentcredentials.go:
     id: 8dea002472d4
-    last_write_checksum: sha1:658a47a80756578536a7571dc857c98730cfa040
     pristine_git_object: 4dc70eebf922b15d90f62a4fcd90728452e06818
   internal/sdk/models/operations/updatetracebegin.go:
     id: abee57d8e078
-    last_write_checksum: sha1:a61364d9b38e4b0ac18924608b46d9d2f8af00fa
     pristine_git_object: 891e1abcfb6bc7f6e4cb7d1c6d61e67444d2c4cd
   internal/sdk/models/operations/updatetracecomplete.go:
     id: 893a78513d24
-    last_write_checksum: sha1:95739d8aa8d29ab091d997c57bd7bd49c79ed0f6
     pristine_git_object: 059a6a6022fb0c98580100b209e277dadcf27bbd
   internal/sdk/models/operations/updatetraceheartbeat.go:
     id: 9027a1702b55
-    last_write_checksum: sha1:878b102427c0f4ab28235e2b453718e835dc8f11
     pristine_git_object: 2e621cd1e296c3b2d32fed3901ca867eb6c39b2c
   internal/sdk/models/operations/updatetraceprogress.go:
     id: e288b67eece1
-    last_write_checksum: sha1:98ccedb9238426e4a01fc3172178a48d7d73ab4b
     pristine_git_object: 8918aa9b7eb4f02d09cffefe1d4e7a46f7b8e150
   internal/sdk/models/operations/updateuser.go:
     id: 08d7263339a0
-    last_write_checksum: sha1:c7f36f59012ee086ba78b8087016f4fba3feb15f
     pristine_git_object: 5cb303fdf9a8813cd2d04b70d12a6a5fd7367f7d
   internal/sdk/models/operations/updateworkspace.go:
     id: 5fbb1b5b9102
-    last_write_checksum: sha1:194c9c231673af94f3f086a4be7afdbb04b6957c
     pristine_git_object: 6fbd05ab34313526731e6fc1d8b4acb05ae928e0
   internal/sdk/models/operations/updateworkspaceparticipantrole.go:
     id: 9e61f96f193e
-    last_write_checksum: sha1:3889428d2a6fb97903c033025701e2bab495fbad
     pristine_git_object: 36475f31f137ea5598bfde65374d15c5e4e9675d
   internal/sdk/models/operations/uploaddataset.go:
     id: f17ea9138279
-    last_write_checksum: sha1:52a456b363f2ed1b8a4fc7252be794d474de27a8
     pristine_git_object: b0590bef3ebdbad17cc58c130f7b30b1da9560e4
   internal/sdk/models/operations/uploaddatasetv2.go:
     id: 42627a4fedc3
-    last_write_checksum: sha1:fe4cf94c301bee0576cb1cd27c3e26b775f86035
     pristine_git_object: 987fc8cc3abe77ebce55bc95bcc20399976a153a
   internal/sdk/models/operations/userinfo.go:
     id: dbff5d3e2348
-    last_write_checksum: sha1:59f3646d979a7fdd9e18ab3a45508977a613d839
     pristine_git_object: e2718d67aed7e6fa1a9ba86d0f12d67b3e264452
   internal/sdk/models/operations/validateactionname.go:
     id: cc16d14b8ce7
-    last_write_checksum: sha1:538723dbc3d158fd13ea4f1f2c78ced7c6b858bc
     pristine_git_object: cb89c449338759cd3042c09ccd94718e89e5d60f
   internal/sdk/models/operations/validatecomputeenvname.go:
     id: 4aa090a663cf
-    last_write_checksum: sha1:2273897d8050939467877c51e7552199c19d9f80
     pristine_git_object: e960ff557274179b79da4abbd3363a21bb8170e8
   internal/sdk/models/operations/validatecredentialsname.go:
     id: 7bde571bc59f
-    last_write_checksum: sha1:d71ba110d384731a6bbcffec01b9a638f43b70ce
     pristine_git_object: 7f8506eeaa62671dca2ccd1f12a46af362050dac
-  internal/sdk/models/operations/validatedataseturl.go:
-    last_write_checksum: sha1:b72fd20b6f116fd788db160144a6a42d82e0ecac
+  internal/sdk/models/operations/validatedataseturl.go: {}
   internal/sdk/models/operations/validatedatastudioname.go:
     id: 75bd8495b396
-    last_write_checksum: sha1:1b2224c2f47172cc24150f4dd3600da3db3b28ab
     pristine_git_object: 5315652a73b3fe6491f4a3ce6e62647bbd5153af
   internal/sdk/models/operations/validateorganizationname.go:
     id: 8ab1e6dd7f4d
-    last_write_checksum: sha1:f69521327277e08b08025b4831d58882dc4f6466
     pristine_git_object: 19ac7689ec97d199396dc5573f61b9d1c391afee
   internal/sdk/models/operations/validatepipelinename.go:
     id: 9d2a5180b5fc
-    last_write_checksum: sha1:cd1a8ebc30dfae716a36af26ac5cbc3053828df3
     pristine_git_object: 9ba88de9eed492f1a57446d4bc11165178177563
   internal/sdk/models/operations/validatepipelinesecretname.go:
     id: b1304cc793ad
-    last_write_checksum: sha1:9f41262c9731c80089c38e0ea83f2faeb61a9b05
     pristine_git_object: 933578121a05780760e63df5229bc917b3760522
-  internal/sdk/models/operations/validatepipelineversionname.go:
-    last_write_checksum: sha1:b25db8e5b5724413b9b0c1b85421ac71cc98ec9b
-  internal/sdk/models/operations/validaterolename.go:
-    last_write_checksum: sha1:c9561e40fefd08f254f45d0edd8f668dc90e9410
-  internal/sdk/models/operations/validatesshkey.go:
-    last_write_checksum: sha1:0ab4c67c95d14111fc6ec0666832b27ddf7037a5
-  internal/sdk/models/operations/validatesshkeyname.go:
-    last_write_checksum: sha1:1be9d3cf277584b3367defcf127845906ad39b4a
+  internal/sdk/models/operations/validatepipelineversionname.go: {}
+  internal/sdk/models/operations/validaterolename.go: {}
+  internal/sdk/models/operations/validatesshkey.go: {}
+  internal/sdk/models/operations/validatesshkeyname.go: {}
   internal/sdk/models/operations/validateteamname.go:
     id: c07ee6a5f2ff
-    last_write_checksum: sha1:92176c376f035719e70eb505c3e1f27fe7764187
     pristine_git_object: f8b3dc57a2a1697e4fdb20aab7fd3148653308c7
   internal/sdk/models/operations/validateusername.go:
     id: 49a84a83caf3
-    last_write_checksum: sha1:915ba2ef22e07a9d77a87e16a1ed0a7dad22168c
     pristine_git_object: c2b8d8a7ca3ec77db57d699f7a56c162ccb2df26
   internal/sdk/models/operations/validateworkflowconstraints.go:
     id: 913acd4b18c8
-    last_write_checksum: sha1:b7eef6ddaf8917fb1a3bf4b455370857afbe7457
     pristine_git_object: c163a9f55b36ccf63ab6b47d0f2b0e9a468d313a
   internal/sdk/models/operations/validateworkspacename.go:
     id: 8c92f76d9cc5
-    last_write_checksum: sha1:9b9a0bff255a99abf93b8a23a91410270cbeb299
     pristine_git_object: c0c6f27457b69cbebde5ccf02d3ff79ceb260f29
   internal/sdk/models/shared/abstractgridconfig.go:
     id: 01c85b369299
-    last_write_checksum: sha1:4c78a3c50df7b99a7f6cbd2085367f3dd488fa6c
     pristine_git_object: 96cafeb9288e230dc7f3851fee5028377ecb6614
   internal/sdk/models/shared/accesstoken.go:
     id: b6c12f20829f
-    last_write_checksum: sha1:caa28edb34d512c1e2bd8f2b0fe98c5fc318899d
     pristine_git_object: 42e5ef188787fba948bc6dd1f8e68ae528caec5e
   internal/sdk/models/shared/actionconfigtype.go:
     id: c6961286bf22
-    last_write_checksum: sha1:1864ea7c025b32d05c51bbbfdf3168b0a07a28ad
     pristine_git_object: 2b316fa6b8f23512b6e2d1c127240a224ff1b5e8
   internal/sdk/models/shared/actioneventtype.go:
     id: cd30fa613358
-    last_write_checksum: sha1:ad02e4ee4991f38caab91983a4832a9eb47be28e
     pristine_git_object: 730a625fa6922c93c90574273666fec9cdc3b496
-  internal/sdk/models/shared/actionlaunchrequest.go:
-    last_write_checksum: sha1:f7e5211d3ad1f09872f8f3460f0bb610d59eaa1e
+  internal/sdk/models/shared/actionlaunchrequest.go: {}
   internal/sdk/models/shared/actionqueryattribute.go:
     id: fc49f81f9928
-    last_write_checksum: sha1:4b9dd187de1586826868830da4ff5ae13fbbcef7
     pristine_git_object: 284ccea5cdb034b2a5287aefd3885b6d952ecb89
   internal/sdk/models/shared/actionresponsedto.go:
     id: 1bea6ad56102
-    last_write_checksum: sha1:0d96852baf5ce28d820fa8d8e66c82f168dfedca
     pristine_git_object: e64d6142e13521b48f5618cfee6337872d23c0d5
   internal/sdk/models/shared/actionsource.go:
     id: 780ed5da5aef
-    last_write_checksum: sha1:f02d09dbd10c59d1f8bf9a72754cda12bd186d23
     pristine_git_object: 4d93a514e884e23c5bf045c87dd20536a5b34fb1
   internal/sdk/models/shared/actionstatus.go:
     id: 11a7af4f4ad3
-    last_write_checksum: sha1:b34297c9372276dd1f20490bec8609890e4f2d5e
     pristine_git_object: dd075b1637964cf6abd879e08e2bcd6581c5b8ca
   internal/sdk/models/shared/actiontoweractionconfig.go:
     id: 41b2af0bc1ec
-    last_write_checksum: sha1:761fef7ff67027bfa7ed7e96b819d8e6ca1c990d
     pristine_git_object: 3fd1eec860a60d471d8282e69af8cf87da9483c0
   internal/sdk/models/shared/actiontoweractionevent.go:
     id: 9d0d831ad947
-    last_write_checksum: sha1:cfe237219e40fa9d870ea74ad63f84e38f9975ba
     pristine_git_object: a00c79c0512cfd7a956d9f357c0e20934ca264d7
   internal/sdk/models/shared/addmemberrequest.go:
     id: 07c2c3745c4e
-    last_write_checksum: sha1:2f24ea16acf469050283e73043d197d989ef0f97
     pristine_git_object: b659e4941c72ce4772fccf2ca96a771bfe0832d6
   internal/sdk/models/shared/addmemberresponse.go:
     id: d45b29197b0d
-    last_write_checksum: sha1:0e2c73d786c4667fb1505738726b4878b670fcc5
     pristine_git_object: 35961177f863e16e366023036232abc5b3b0c846
   internal/sdk/models/shared/addparticipantrequest.go:
     id: cd9a95e50f9b
-    last_write_checksum: sha1:06a13769e262d94d2b95e0e38fddd7e67a4cf846
     pristine_git_object: deebb5c936d984453dd42e5e2ab6bcf9726ab5bc
   internal/sdk/models/shared/addparticipantresponse.go:
     id: bd406ef7ec92
-    last_write_checksum: sha1:f3a8093e8f15c31017cfa7220480dbfc84b63628
     pristine_git_object: 94d70989b3c280ba3ed6b90ae0bb621b8a0befb5
   internal/sdk/models/shared/addteammemberresponse.go:
     id: 4e05e43e1280
-    last_write_checksum: sha1:2b70568f89371fc21536146e45fe151eb86d7df9
     pristine_git_object: d9d170e849d73dce8ac9bd090d16f2e2bd48f423
   internal/sdk/models/shared/analytics.go:
     id: 7126032f3891
-    last_write_checksum: sha1:2a44682522d4b7e844fb85e9c08b132fbcd85266
     pristine_git_object: d41a6e9507a1b7470012dbf46e572a5dc7cc8cae
   internal/sdk/models/shared/associateactionlabelsrequest.go:
     id: 029d49c9f31c
-    last_write_checksum: sha1:c0684f8859afd46787cb7c6585a16c1df3b74204
     pristine_git_object: b124117f8d16f9da97f8890b5d458558034a7bdb
   internal/sdk/models/shared/associatedatasetslabelsrequest.go:
     id: e6a7c935f45d
-    last_write_checksum: sha1:b197d6c1692e897edce30d837beb75ab5e190e93
     pristine_git_object: 2ed5d543459e3bd6a9662a4a91962403fdc76838
   internal/sdk/models/shared/associatepipelinelabelsrequest.go:
     id: 9445f84900f0
-    last_write_checksum: sha1:41bb6535abeb012770b6f4fd7723e90c17d4e266
     pristine_git_object: 8b68195ad1cb0eeab23642a07f9c7b48a507a63e
   internal/sdk/models/shared/associateworkflowlabelsrequest.go:
     id: fb0ac77e2b49
-    last_write_checksum: sha1:2a63d782def8908cf2e81fcbb32be7f2f9f72a4e
     pristine_git_object: c14800171064ba48a3968406e45caf0fecd7e0ac
   internal/sdk/models/shared/avatar.go:
     id: 1e961b750574
-    last_write_checksum: sha1:4961c9644d484c74cd27fb587d4cd8d8c1da804e
     pristine_git_object: eef8d70634addb13e9644d304a3f0b81bca78049
   internal/sdk/models/shared/awsbatchcecomputeconfiginput.go:
     id: 1c8b4e56d2b4
-    last_write_checksum: sha1:ba35c73d49ef014e4b6939d657374d3bd7b174a8
     pristine_git_object: 18e30f40d1932fcb8ee01325e79f17ee3d77c716
   internal/sdk/models/shared/awsbatchconfig.go:
     id: aa4705d45858
-    last_write_checksum: sha1:9ee9edc316c6c44ef0592fa7dca7a6740576a4c1
     pristine_git_object: a9a08e5a58a2f9a9df44522dc4695f3fac3230cc
   internal/sdk/models/shared/awsbatchplatformmetainfo.go:
     id: 86cf3ff126ca
-    last_write_checksum: sha1:74a9f02049cb4494f6dbee44ccb8b174d96759e2
     pristine_git_object: 75a578c6fe929ec20d53753a047e02e245e3e91d
-  internal/sdk/models/shared/awscloudcecomputeconfiginput.go:
-    last_write_checksum: sha1:da2a59c738ccc8ca4bcbc61f527eef5f1a8745ed
-  internal/sdk/models/shared/awscloudconfig.go:
-    last_write_checksum: sha1:780b9f975d426c16728552f6f48453fef0819193
+  internal/sdk/models/shared/awscloudcecomputeconfiginput.go: {}
+  internal/sdk/models/shared/awscloudconfig.go: {}
   internal/sdk/models/shared/awscloudplatformmetainfo.go:
     id: 28be3c81b43e
-    last_write_checksum: sha1:30fea4bc09a5b062b7440c106478a265b7502272
     pristine_git_object: dacc971ae5cbb275e16e900a86b94cac72af6382
   internal/sdk/models/shared/awscomputeenvcomputeconfiginput.go:
     id: 29a813efacc0
-    last_write_checksum: sha1:ac5d51baec89b3eb7a21086d1b20e0824b120557
     pristine_git_object: 41abb39480dcb63f5417d6dca691130fee15eb9b
   internal/sdk/models/shared/awscredential.go:
     id: 6a9e44208230
-    last_write_checksum: sha1:5f06969f05ac0eca49e255e7eb26cb56eea1d2ec
     pristine_git_object: 6937799095194b4fcab39215565cc6a37887fb8b
-  internal/sdk/models/shared/awscredentialsmode.go:
-    last_write_checksum: sha1:a43a49efc166ca0c6bb6e58f4a25442c89c04175
-  internal/sdk/models/shared/azbatchconfig.go:
-    last_write_checksum: sha1:ffb9a9a8878dd8488bbc3ee984c868be14569677
+  internal/sdk/models/shared/awscredentialsmode.go: {}
+  internal/sdk/models/shared/azbatchconfig.go: {}
   internal/sdk/models/shared/azbatchforgeconfig.go:
     id: d13b3a409e31
-    last_write_checksum: sha1:ae114fcb9a7379ddf0a15922488314803eb63b85
     pristine_git_object: dc5d7127f390fe2d4b560e69d3e2ac5ae3e97911
   internal/sdk/models/shared/azbatchplatformmetainfo.go:
     id: 26da3f95b1e5
-    last_write_checksum: sha1:2c2702eceee646a8d81d8b52cbad5e62f9380258
     pristine_git_object: 92c4406321976b69060298a0bf6771e65e27838d
-  internal/sdk/models/shared/azbatchpoolconfig.go:
-    last_write_checksum: sha1:b3bc917254e5acf45a5ddaebe6a1ef7defe73ccb
-  internal/sdk/models/shared/azcloudconfig.go:
-    last_write_checksum: sha1:ceb669a5d57f1c05986190cd321318b76622f486
-  internal/sdk/models/shared/azurebatchcecomputeconfiginput.go:
-    last_write_checksum: sha1:2dff8b40592cd6a35c0e94c70c0dae2bedbfce80
-  internal/sdk/models/shared/azurecloudcecomputeconfiginput.go:
-    last_write_checksum: sha1:a487e6199d84b5cba0e8ba16cd4fa0fba7f9bab5
-  internal/sdk/models/shared/azurecloudcredential.go:
-    last_write_checksum: sha1:1bbcc7bba31eb69ca902cf064e8657e2d7607863
+  internal/sdk/models/shared/azbatchpoolconfig.go: {}
+  internal/sdk/models/shared/azcloudconfig.go: {}
+  internal/sdk/models/shared/azurebatchcecomputeconfiginput.go: {}
+  internal/sdk/models/shared/azurecloudcecomputeconfiginput.go: {}
+  internal/sdk/models/shared/azurecloudcredential.go: {}
   internal/sdk/models/shared/azurecredential.go:
     id: d67155a3f009
-    last_write_checksum: sha1:178e7883a67f98bb4fbba21af675baf5a92ebcc4
     pristine_git_object: a19c8ae0ccb9dac4d7e8a63edfa348c0b6b3b3b2
-  internal/sdk/models/shared/azureentracredential.go:
-    last_write_checksum: sha1:b147727f022677149edaadbcfd01118be4a82aeb
+  internal/sdk/models/shared/azureentracredential.go: {}
   internal/sdk/models/shared/bitbucketcredential.go:
     id: 7dd213344297
-    last_write_checksum: sha1:747ff8e4bd6f6e0b69183fcedcbe300c06553dc7
     pristine_git_object: 4640c93ca517620630d52210c4f3c131d9acdd31
   internal/sdk/models/shared/bucket.go:
     id: c799c619a5f3
-    last_write_checksum: sha1:78582370221a5101ab4d7bdf03947cd39cee739b
     pristine_git_object: 440bbb7a8e98b8cd037100e2c5efb53adbb50cb3
-  internal/sdk/models/shared/bucketactionconfig.go:
-    last_write_checksum: sha1:1966e1ef2c082cc693052c5455316b209fdf3375
-  internal/sdk/models/shared/bucketactionevent.go:
-    last_write_checksum: sha1:6fc37647f87a9e77cb4b542fc94c983972caa849
-  internal/sdk/models/shared/bucketactionrequest.go:
-    last_write_checksum: sha1:25090eccca392a1d0e28e62109d0dc3e994e6df9
+  internal/sdk/models/shared/bucketactionconfig.go: {}
+  internal/sdk/models/shared/bucketactionevent.go: {}
+  internal/sdk/models/shared/bucketactionrequest.go: {}
   internal/sdk/models/shared/changedatasetvisibilityrequest.go:
     id: 32a641528840
-    last_write_checksum: sha1:e6ad27647486a629b5ad5ce6bd60b485664997dd
     pristine_git_object: ae25e05275b2d663fd39d3ae8c4c5eea0a4ab9c3
-  internal/sdk/models/shared/changestatus.go:
-    last_write_checksum: sha1:4e87f7b01e9dfd86b49de77d3cdd820305de6f7a
+  internal/sdk/models/shared/changestatus.go: {}
   internal/sdk/models/shared/cloudpricemodel.go:
     id: 8e761866be31
-    last_write_checksum: sha1:dfc7f10e0a4fa6f94a90f9a662e51c5861bb59df
     pristine_git_object: cc8547dd4b50e53073c00a2e2f3181a9fd23786a
   internal/sdk/models/shared/codecommitcredential.go:
     id: 5344cf634ea1
-    last_write_checksum: sha1:5ec332bfd451b6583b5f188e5ee81fb377e60614
     pristine_git_object: 168da50a9909ad4639d68c4ef0cb63bf647d949b
-  internal/sdk/models/shared/computeconfig.go:
-    last_write_checksum: sha1:5229eb62d2673b3616eddcffdc24517f7db05b42
-  internal/sdk/models/shared/computeenvcomputeconfiginput.go:
-    last_write_checksum: sha1:1bb6756bcedb7ad94f82cfa537689b6a6ba4f953
+  internal/sdk/models/shared/computeconfig.go: {}
+  internal/sdk/models/shared/computeenvcomputeconfiginput.go: {}
   internal/sdk/models/shared/computeenvqueryattribute.go:
     id: e1c918e85834
-    last_write_checksum: sha1:2a23d6eeb2fe769fcc665b88dcf77feadbbb1fe8
     pristine_git_object: 2a0d9974806899fa4f9187c35f5e7544b1d4fc51
   internal/sdk/models/shared/computeenvresponsedto.go:
     id: 97cdb3d73a3c
-    last_write_checksum: sha1:6fe9bf4871d5f69fd896440e1fe4a6effd5d882a
     pristine_git_object: 9b2e69ca2199afa1f8ecd7170faea6404849eac7
   internal/sdk/models/shared/computeenvstatus.go:
     id: dabffc117c29
-    last_write_checksum: sha1:6ae2b7efb8775076f23936698577acf64b94f497
     pristine_git_object: c3eee0ea8cbd7c674aeeeb0adf62617253dc8cc8
   internal/sdk/models/shared/computeplatform.go:
     id: da6201ac9b51
-    last_write_checksum: sha1:881d523b85e7c0987b72389d22ad8d5d8c1a8f4c
     pristine_git_object: 601640eee8dd8137909f013451d50f4f1576ffa4
   internal/sdk/models/shared/computeregion.go:
     id: 7c76c22f4f00
-    last_write_checksum: sha1:723f68e37044b50c887994dffcf65f158ba53063
     pristine_git_object: d4d48c774e1deb3acadfaba126f378697e4ee3ef
   internal/sdk/models/shared/configenvvariable.go:
     id: 733e7ad7e305
-    last_write_checksum: sha1:8ba4f20d04bc974f39a8b156518a9087a05b2da0
     pristine_git_object: 0e00106a83491f9bb55285e240c9a848463f8dcf
   internal/sdk/models/shared/containerdata.go:
     id: 2a08f584995d
-    last_write_checksum: sha1:de50251afc7537dbe6fbd7be978549a07a53cf59
     pristine_git_object: 4902f5c3d3419beeffcbfb00894fd70a90196353
   internal/sdk/models/shared/containerregistrycredential.go:
     id: ec1b043f32ef
-    last_write_checksum: sha1:d35abbdc00431be6080ec7ad174de3a0416a8c2b
     pristine_git_object: 2e21d84ace615328cc045c70a9c52e1260853306
   internal/sdk/models/shared/createaccesstokenrequest.go:
     id: 3f32ab63906f
-    last_write_checksum: sha1:b9f1d6fe706f5dcf0db7433c49fa48f51eb889af
     pristine_git_object: 521aa719cdb5f1164d4cef15352fe2a1ca481a8d
   internal/sdk/models/shared/createaccesstokenresponse.go:
     id: 047355ccd78f
-    last_write_checksum: sha1:fd420903a2ef2a2df98d8ef166615a71274d4a9e
     pristine_git_object: e8d0f3a5a1ba367ab5d3de41c39c6fe2709b63bb
   internal/sdk/models/shared/createactionrequest.go:
     id: 3535c016c767
-    last_write_checksum: sha1:6f7a45af9d9671abbb1aa59277a0de252d181de6
     pristine_git_object: e31748303dcf8afdd83f767b842dea31f7066eab
   internal/sdk/models/shared/createactionresponse.go:
     id: 3ac726a6a7cf
-    last_write_checksum: sha1:362be6281783e09447f300167e14b598c5a1c9c4
     pristine_git_object: 0ad4b562fb4cdfa299454815ad03a91974264035
   internal/sdk/models/shared/createavatarresponse.go:
     id: e5dd31cc3091
-    last_write_checksum: sha1:b24023b4715deed2cabb127f7691245a3142ad1d
     pristine_git_object: 25d07736b94fcd6a00ed915ce2cee19791e48143
   internal/sdk/models/shared/createawsbatchcerequest.go:
     id: 0ef161556631
-    last_write_checksum: sha1:e64ddd9f05d0bfe49187d4a886205cc43b9716b0
     pristine_git_object: f960c983782e1436c47dbd0dc27d762ab6dc89f9
   internal/sdk/models/shared/createawsbatchceresponse.go:
     id: f023249375f3
-    last_write_checksum: sha1:f84ea22c09e87f2900b5658fb544e4f6054ec7ad
     pristine_git_object: 978fb4f7181d1428a317d3ebf6c1f46c91f21ecb
-  internal/sdk/models/shared/createawscloudcerequest.go:
-    last_write_checksum: sha1:3b2dc43c690e23f1a273ae7b4a56f6b6ba9f82e3
-  internal/sdk/models/shared/createawscloudceresponse.go:
-    last_write_checksum: sha1:293e9c8f69b1648ffa94b69de3e6db6f056d4ea0
+  internal/sdk/models/shared/createawscloudcerequest.go: {}
+  internal/sdk/models/shared/createawscloudceresponse.go: {}
   internal/sdk/models/shared/createawscomputeenvrequest.go:
     id: d42fe5a6f6e3
-    last_write_checksum: sha1:db8028ebf5fca1814d39b0cbfc11085e71bf4fe0
     pristine_git_object: 380ce79aa2eca108450104b0410b69ea69763e59
   internal/sdk/models/shared/createawscomputeenvresponse.go:
     id: 747401b23ff2
-    last_write_checksum: sha1:fb1a6d069b7c3ed1cfb9a549c19bbd790da6c7b0
     pristine_git_object: 3afb051f88f7525fc930cf40331f2ebc06194534
   internal/sdk/models/shared/createawscredentialsrequest.go:
     id: eaa46066eefb
-    last_write_checksum: sha1:ae8f565084c3499abe0548ae04eaf7803c859618
     pristine_git_object: 1c88fd0ff37d093788ccf507c1aef3942e3d26d8
   internal/sdk/models/shared/createawscredentialsresponse.go:
     id: 0280ab4eb8b0
-    last_write_checksum: sha1:ffb5da37c8536c24265f7dde9d20a0c9aa3a2027
     pristine_git_object: 551872b10603e98b5e127b456ac9ca391d5dbed5
-  internal/sdk/models/shared/createazurebatchcerequest.go:
-    last_write_checksum: sha1:fa5c84e80979d46966a150e9b04bf5396da785d9
-  internal/sdk/models/shared/createazurebatchceresponse.go:
-    last_write_checksum: sha1:4e2323ccf99ddd4e86e436aef8c01eb75f85ec30
-  internal/sdk/models/shared/createazurecloudcerequest.go:
-    last_write_checksum: sha1:14a86c0c17fd34440b2c117860ba8a11b3ff59e7
-  internal/sdk/models/shared/createazurecloudceresponse.go:
-    last_write_checksum: sha1:dd308ac2c18b2ae33453ac4ebc7c894587aabc39
-  internal/sdk/models/shared/createazurecloudcredentialsrequest.go:
-    last_write_checksum: sha1:8937154cae152c336b18eef76607076e3d1971ba
-  internal/sdk/models/shared/createazurecloudcredentialsresponse.go:
-    last_write_checksum: sha1:66b5ec192a289b53616fc035075338fa97d48826
+  internal/sdk/models/shared/createazurebatchcerequest.go: {}
+  internal/sdk/models/shared/createazurebatchceresponse.go: {}
+  internal/sdk/models/shared/createazurecloudcerequest.go: {}
+  internal/sdk/models/shared/createazurecloudceresponse.go: {}
+  internal/sdk/models/shared/createazurecloudcredentialsrequest.go: {}
+  internal/sdk/models/shared/createazurecloudcredentialsresponse.go: {}
   internal/sdk/models/shared/createazurecredentialsrequest.go:
     id: eccbe7db1018
-    last_write_checksum: sha1:20efdc9f7af7c3f175ece49181bad7f12fe0ff79
     pristine_git_object: 342f240047f8fc3192387ab1637a110e4bd8cefe
   internal/sdk/models/shared/createazurecredentialsresponse.go:
     id: a6633d6d1834
-    last_write_checksum: sha1:ae9ac2c69821b441df8a386398ddb75524f7200e
     pristine_git_object: a16160c0613d10da1a556b74185958df4e87a409
-  internal/sdk/models/shared/createazureentracredentialsrequest.go:
-    last_write_checksum: sha1:00e68eb503c3f5c5d973fdcea0f4143ced8ebde9
-  internal/sdk/models/shared/createazureentracredentialsresponse.go:
-    last_write_checksum: sha1:afec66364aac86d5a856f9eab96ba89207dd58d4
+  internal/sdk/models/shared/createazureentracredentialsrequest.go: {}
+  internal/sdk/models/shared/createazureentracredentialsresponse.go: {}
   internal/sdk/models/shared/createbitbucketcredentialsrequest.go:
     id: b037579a80a7
-    last_write_checksum: sha1:4a3a15639ce34c967bf597a2666c57e3b3b8096d
     pristine_git_object: ac37e93b6a9cb9d7577401ce26e2215272e056e0
   internal/sdk/models/shared/createbitbucketcredentialsresponse.go:
     id: 914a302aaf04
-    last_write_checksum: sha1:fdec99ca624c2841910471878e5336ce49a5e2d8
     pristine_git_object: 5c8ce50d1e9f4188790add6aabc31c23d9030b5b
   internal/sdk/models/shared/createcodecommitcredentialsrequest.go:
     id: 00576402f79f
-    last_write_checksum: sha1:c4554a396944a04ffcec216abd1e28442c776fae
     pristine_git_object: 2489b7c0e88b4d18ade3a5e6706617caedf5ff7b
   internal/sdk/models/shared/createcodecommitcredentialsresponse.go:
     id: d9e015ff79ea
-    last_write_checksum: sha1:e1cb4054c7a0d0221d11ed93c99e514fadc81660
     pristine_git_object: ed9aac6786b93da93e7ff37280855b29ece8c9be
   internal/sdk/models/shared/createcomputeenvrequest.go:
     id: 5ecebb832a10
-    last_write_checksum: sha1:4ca65d0d536881da8f8b6e152c22e8316d41a0c6
     pristine_git_object: 1ff1a56b54ae8aa46472c29cfcb55084180999e7
   internal/sdk/models/shared/createcomputeenvresponse.go:
     id: 4e018414aa3a
-    last_write_checksum: sha1:356a05922bfc6b65aa3a753404155b639091c5f6
     pristine_git_object: 9e6f53467d4b1e86551eb21a2e48a07518671092
   internal/sdk/models/shared/createcontainerregistrycredentialsrequest.go:
     id: eec3753514d1
-    last_write_checksum: sha1:0a967dfcc0b65eaf3a5750fe7c7aa187facd2761
     pristine_git_object: d62533aeefa8dad6a7d22f50790c133236a9097a
   internal/sdk/models/shared/createcontainerregistrycredentialsresponse.go:
     id: 5eba48078ed1
-    last_write_checksum: sha1:6942b956a54817ad47714573c2398e49da092a67
     pristine_git_object: 6b937290635757304387e2a33067d7f6b3e4fa02
   internal/sdk/models/shared/createcredentialsrequest.go:
     id: adce3f273899
-    last_write_checksum: sha1:63b00f7e736802541bb43ceb06da0255e676acda
     pristine_git_object: 49890f63b186b3a248a125b0b91bf012917821ea
   internal/sdk/models/shared/createcredentialsresponse.go:
     id: 6a3547aa199c
-    last_write_checksum: sha1:8f7efdc3444603abc46787446c63d7c6aac3e3db
     pristine_git_object: e8156147182640e87f4af93cf96c13fd16ad4151
   internal/sdk/models/shared/createdatasetrequest.go:
     id: 2e7be5c6dc73
-    last_write_checksum: sha1:0e1d3c1aa597dd21e9a6bcf199b71384988f0b56
     pristine_git_object: d6b85afb0cbb072dc27c85473ee6cdc9a65907b2
   internal/sdk/models/shared/createdatasetresponse.go:
     id: 5caa6b80d585
-    last_write_checksum: sha1:27398fb79a55f44894237568a10dfeabf05df410
     pristine_git_object: 2e8245ed0e28650fd2fd961e82f06b5fa0fb8f5d
-  internal/sdk/models/shared/creategcpbatchcerequest.go:
-    last_write_checksum: sha1:db87d9b6e64c2bfadf22aeae3061d860e079a3d2
-  internal/sdk/models/shared/creategcpbatchceresponse.go:
-    last_write_checksum: sha1:4dded06cdee0a9a1be70c18be4c21a7c77802097
-  internal/sdk/models/shared/creategcpcloudcerequest.go:
-    last_write_checksum: sha1:2701907bbddf6388938bcc9260e2085eec6d946e
-  internal/sdk/models/shared/creategcpcloudceresponse.go:
-    last_write_checksum: sha1:b6968d203143127a889ec2651c527df503895151
+  internal/sdk/models/shared/creategcpbatchcerequest.go: {}
+  internal/sdk/models/shared/creategcpbatchceresponse.go: {}
+  internal/sdk/models/shared/creategcpcloudcerequest.go: {}
+  internal/sdk/models/shared/creategcpcloudceresponse.go: {}
   internal/sdk/models/shared/creategiteacredentialsrequest.go:
     id: 2ae396ab7cd2
-    last_write_checksum: sha1:d1c453b34900ebaf7a173fbb3260293ce75bee13
     pristine_git_object: c939f42baedccdaab1ed06535d3769a495c9c32c
   internal/sdk/models/shared/creategiteacredentialsresponse.go:
     id: 13c2c7dd7c30
-    last_write_checksum: sha1:2392452c8f8a9ba1280d15326202214fe149c650
     pristine_git_object: 34a8eacc222c93883d317a356c88d2e0eab8d946
-  internal/sdk/models/shared/creategithubappcredentialsrequest.go:
-    last_write_checksum: sha1:6b93f13bcda487c87982a125daebfc6e10c4fec4
-  internal/sdk/models/shared/creategithubappcredentialsresponse.go:
-    last_write_checksum: sha1:2e19d5fc6ad6242803bee08bca408fcce02cec66
+  internal/sdk/models/shared/creategithubappcredentialsrequest.go: {}
+  internal/sdk/models/shared/creategithubappcredentialsresponse.go: {}
   internal/sdk/models/shared/creategithubcredentialsrequest.go:
     id: c74ef2fb8373
-    last_write_checksum: sha1:73b16e547c021ac4436038afc53779689b166ae3
     pristine_git_object: c87d980050cd6b2ca54a6c2ce255397094be9df3
   internal/sdk/models/shared/creategithubcredentialsresponse.go:
     id: "042490240e46"
-    last_write_checksum: sha1:0a81f8183c6e34bcd7657f8769d99488d93363db
     pristine_git_object: c15eb22681c2a4de6d491c4411e97ff34c40fa22
   internal/sdk/models/shared/creategitlabcredentialsrequest.go:
     id: 2a470091c0d3
-    last_write_checksum: sha1:c57488e78d05dc8765f5735f412f012bc683759b
     pristine_git_object: ee5d2e047102c69627ad6525a7f594ca8a351361
   internal/sdk/models/shared/creategitlabcredentialsresponse.go:
     id: 25f5b88ece0d
-    last_write_checksum: sha1:6d520e6fc97eeae809dafbcb46e3b69875c8bb0c
     pristine_git_object: a49c4df63dc929337b848174d763cfe0ae4aef2a
   internal/sdk/models/shared/creategooglecredentialsrequest.go:
     id: 1ae1c3d0cf5d
-    last_write_checksum: sha1:1a8ef237442bbae545bb7f39ddbe96d7fe6a648f
     pristine_git_object: 15ddba07239842996b9f47498c15fc918b8e440a
   internal/sdk/models/shared/creategooglecredentialsresponse.go:
     id: 65f8763a17f7
-    last_write_checksum: sha1:0e6588fba4d75294a9cf5a7815fa612cfa52e70e
     pristine_git_object: f56dc72e3f3703386b6befc4b98a5126a3005513
   internal/sdk/models/shared/createkubernetescredentialsrequest.go:
     id: 412f326904a5
-    last_write_checksum: sha1:0beff03bf26ab4e9ac91fa0502d47d98472b8d89
     pristine_git_object: 5abb059ad81c04b2eb50255a50a9c022213a1894
   internal/sdk/models/shared/createkubernetescredentialsresponse.go:
     id: cd834f582ce7
-    last_write_checksum: sha1:b0a62ba4a69e437114cd784f074d3490f69ab8cd
     pristine_git_object: c44cc31f71fef5adb1e1f24bba4fa5d1c8c5670f
   internal/sdk/models/shared/createlabelrequest.go:
     id: 5493d4aad05d
-    last_write_checksum: sha1:33001b08e1edc141b7fb50bff2154e677740b7d4
     pristine_git_object: 31cb7e608ce4af22de6d901b709d45faa06ca8fe
   internal/sdk/models/shared/createlabelresponse.go:
     id: 20e6917be565
-    last_write_checksum: sha1:9f321a197042a1d4aa3b77c317a475328dd87332
     pristine_git_object: 2f3d3956bbda89b74c6567e36b85e13806a818a0
   internal/sdk/models/shared/createmanagedcomputecerequest.go:
     id: 794725842e1b
-    last_write_checksum: sha1:f37a684c723b58d65b26b1674fd77d642cc10b2d
     pristine_git_object: a016e4b2b022ca6011d9ab76a46d718626558b1a
   internal/sdk/models/shared/createmanagedcomputeceresponse.go:
     id: 0453e76c20cc
-    last_write_checksum: sha1:42b7ee9329f56b1ad66389edf19c56574438fe64
     pristine_git_object: fc5583a70660cf9b743b49b9e8c94c73d0659fdf
   internal/sdk/models/shared/createmanagedcredentialsrequest.go:
     id: ce11a3910aca
-    last_write_checksum: sha1:7fa719d1ea494c780c4f04ab1615109dabfb6429
     pristine_git_object: 2057bef876ebe773de8c317cad91f758c1df7bc0
   internal/sdk/models/shared/createmanagedcredentialsresponse.go:
     id: 1d990f5b703e
-    last_write_checksum: sha1:0292a8bdcc066fa993171e2e5fd359978c710b92
     pristine_git_object: 55f279aa0c0327e96ae7277fd2e99387d2cc5e3b
   internal/sdk/models/shared/createmanagedidentityrequest.go:
     id: bfe21e425901
-    last_write_checksum: sha1:38c9d48fc17af1e386163c0734746836e23edb30
     pristine_git_object: 49c31291609e1d75de9a956f26272df3eaa72d03
   internal/sdk/models/shared/createmanagedidentityresponse.go:
     id: 8082a03fe206
-    last_write_checksum: sha1:3778ea80ac11457801da3fe4869dcb002527411b
     pristine_git_object: 5eef4388a12030d941d8359f310db74b00c34429
   internal/sdk/models/shared/createorganizationrequest.go:
     id: 283ba99a3085
-    last_write_checksum: sha1:303cd131826dc35b9d8926b7f0c2ef2d201c11d4
     pristine_git_object: 19d82efa59506846e9de81112ebd604238b6cf7e
   internal/sdk/models/shared/createorganizationresponse.go:
     id: 163f3a07ee73
-    last_write_checksum: sha1:4766587eb1318e62c945c8e17f9589caf2f66c90
     pristine_git_object: a67f52bcaddcba5647b35283493bfd4e7c2641be
   internal/sdk/models/shared/createpipelinerequest.go:
     id: 6507ca147cfc
-    last_write_checksum: sha1:13578513c41d4953bc69ab4d5aeea604d3cc2982
     pristine_git_object: 287369639c711d81175bda5b4111eddc3d9688ef
   internal/sdk/models/shared/createpipelineresponse.go:
     id: 06300849d84e
-    last_write_checksum: sha1:3a4b314190dddb7e6b6bfc5f4e7611f8013db419
     pristine_git_object: 0171e760438f1f8ff56ac4b2a956bac9bc4da270
-  internal/sdk/models/shared/createpipelineschemarequest.go:
-    last_write_checksum: sha1:932138a1a74d59ad2e4299d147c8b712661e6388
-  internal/sdk/models/shared/createpipelineschemaresponse.go:
-    last_write_checksum: sha1:911f0abbc3dc58f3c5165d5e294e28abd22132ac
+  internal/sdk/models/shared/createpipelineschemarequest.go: {}
+  internal/sdk/models/shared/createpipelineschemaresponse.go: {}
   internal/sdk/models/shared/createpipelinesecretrequest.go:
     id: 6278f21bd0ec
-    last_write_checksum: sha1:cd3e862306ba52feafc4c5059279ec2579377859
     pristine_git_object: f9dc449040506214193c3f986d3094e3fe3dbe5e
   internal/sdk/models/shared/createpipelinesecretresponse.go:
     id: a679795c4feb
-    last_write_checksum: sha1:0caeb2564d83697ae03148645075864df830e07d
     pristine_git_object: ddeb2fca966e5639ed4b3a10ad73adb162675505
-  internal/sdk/models/shared/createpipelineversionrequest.go:
-    last_write_checksum: sha1:f5585a1e04a309058445bdd3844c809fd21d34ed
-  internal/sdk/models/shared/createrolerequest.go:
-    last_write_checksum: sha1:4359a5d29aeec68feb55375593131aa31b8c1746
-  internal/sdk/models/shared/createroleresponse.go:
-    last_write_checksum: sha1:1ce0af6d8f59dfe8f3394f83947776dfb1654926
+  internal/sdk/models/shared/createpipelineversionrequest.go: {}
+  internal/sdk/models/shared/createrolerequest.go: {}
+  internal/sdk/models/shared/createroleresponse.go: {}
   internal/sdk/models/shared/createsshcredentialsrequest.go:
     id: 102d56444714
-    last_write_checksum: sha1:35876e12b78f5a7af28ba68c886ba9ddb0062e2b
     pristine_git_object: 03fd93884bf0447227de0de04345b77b76d9411b
   internal/sdk/models/shared/createsshcredentialsresponse.go:
     id: 8c43c40b534d
-    last_write_checksum: sha1:e8519a395a073e5f4acba448fb6248d24eac6b38
     pristine_git_object: 341bd3ba6c6ba5eb577e3fa9f3bb094bd7d9fb4a
-  internal/sdk/models/shared/createsshkeyrequest.go:
-    last_write_checksum: sha1:02d63e123da34c11b06dac76c3cb55cba8ec02e4
-  internal/sdk/models/shared/createsshkeyresponse.go:
-    last_write_checksum: sha1:2ce2fc413188e7ac13cd185f785a9e7193aa94fa
+  internal/sdk/models/shared/createsshkeyrequest.go: {}
+  internal/sdk/models/shared/createsshkeyresponse.go: {}
   internal/sdk/models/shared/createteammemberrequest.go:
     id: 21a1df21be9e
-    last_write_checksum: sha1:e0eca95e36b71dbba8fa8c7124be98383c5e5f39
     pristine_git_object: ef034887fe12e404e7d629aedceefb58a8b4edbd
   internal/sdk/models/shared/createteamrequest.go:
     id: 4805dc8be6a6
-    last_write_checksum: sha1:9f7f157ae8ba1ec1f7af3829ab7b4cd476ccb74f
     pristine_git_object: 885862f46d431e90f111c20c5a481fe0b7faf314
   internal/sdk/models/shared/createteamresponse.go:
     id: 6a7867071527
-    last_write_checksum: sha1:ec76284692a39b72bfecac2eac25312a33750b8d
     pristine_git_object: 78a8a191a706fccb00a737d9cd5706a001c02879
   internal/sdk/models/shared/createtoweragentcredentialsrequest.go:
     id: 178cd7234713
-    last_write_checksum: sha1:301b9fe6944d8f91c10b4bcb4769b21df7f19d67
     pristine_git_object: 707171ac17d36832ed3585d2052ff4c4d0975036
   internal/sdk/models/shared/createtoweragentcredentialsresponse.go:
     id: c900fc1d3471
-    last_write_checksum: sha1:6da9b77632b536f7e3c39bbb2a3c24c29f005ac8
     pristine_git_object: 9a36b4504082aad217f35b2423efb40757d25094
   internal/sdk/models/shared/createworkflowstarresponse.go:
     id: 09a76f25ba68
-    last_write_checksum: sha1:55d5f0a773c589ad7c5030eb1c584a649b65a37b
     pristine_git_object: 5bc7dc7aab779683af5910de33c8d95378d9e2b0
   internal/sdk/models/shared/createworkspacerequest.go:
     id: a2adda010c27
-    last_write_checksum: sha1:aa0332cf968b01e3480a40ea8ae13c2b67b62dfc
     pristine_git_object: 2ebce7d4a98ac96809aac2f82ee61771d3d44bce
   internal/sdk/models/shared/createworkspaceresponse.go:
     id: aee357718cbf
-    last_write_checksum: sha1:879f97765310a3ef2749558e183bba6c28b4cbfc
     pristine_git_object: f6597ec3ea4952d1d73ccf4169c329b4e947f7c3
   internal/sdk/models/shared/credentialsinput.go:
     id: a9735abcd6a9
-    last_write_checksum: sha1:e338f1f44548264bea1e146a242477b7ac3084a7
     pristine_git_object: b8ae95231871f580a17018cea2c1bd0795eccf9c
-  internal/sdk/models/shared/cronactionconfig.go:
-    last_write_checksum: sha1:2ea64bdf736ce64c9e23e015702fd0dc04b2343d
-  internal/sdk/models/shared/cronactionevent.go:
-    last_write_checksum: sha1:a5262822862cb529884ce0c6340259e01ddd10f6
-  internal/sdk/models/shared/cronactionrequest.go:
-    last_write_checksum: sha1:fd4c5268f5ba282f36034347ed091a98074f772f
+  internal/sdk/models/shared/cronactionconfig.go: {}
+  internal/sdk/models/shared/cronactionevent.go: {}
+  internal/sdk/models/shared/cronactionrequest.go: {}
   internal/sdk/models/shared/datalinkcontentresponse.go:
     id: 33df464c7812
-    last_write_checksum: sha1:8350d4691799252032a67b006ae67ac5624b55f8
     pristine_git_object: 4db6f6b6d4cd906bd14c1379d581c0a9e1e995e0
   internal/sdk/models/shared/datalinkcontenttreelistresponse.go:
     id: fbc2b3100d55
-    last_write_checksum: sha1:f454f6a67156965585ffadfc26dbc6780d6b6fb6
     pristine_git_object: c175e1c31e9a4fa1c3ded2d1c633a8963bae645c
   internal/sdk/models/shared/datalinkcreaterequest.go:
     id: b0cfaa0899cd
-    last_write_checksum: sha1:6fda2e47360f08db59fe77b3e173d6dcfdd83430
     pristine_git_object: e1bb14db818fe0e2ff79da687b26314663285d66
   internal/sdk/models/shared/datalinkcredentials.go:
     id: c42b39f17535
-    last_write_checksum: sha1:abc792e86735080e60b968cb403ffb078540ef77
     pristine_git_object: 3f845d4648a6f292528c58c6d1e9714465c2bad0
   internal/sdk/models/shared/datalinkdeleteitemrequest.go:
     id: 966674229d1f
-    last_write_checksum: sha1:ebbf90feeebca3a1bfaf1e851fd8fb777da6fcab
     pristine_git_object: 36066af503515b7b94ad8415c3a74e36cab811f0
   internal/sdk/models/shared/datalinkdeleteitemresponse.go:
     id: 464d903a8760
-    last_write_checksum: sha1:00329b6aa8ec84dba6cee327b9d88ba7c321d018
     pristine_git_object: 431e5aa5a8eac21c551b3db3e165bb6eb95b123c
   internal/sdk/models/shared/datalinkdownloadscriptresponse.go:
     id: 71b4eccf7fb9
-    last_write_checksum: sha1:72c720cea2477dd1798f204ac3a1b539891b2a66
     pristine_git_object: 0ae598a2e7c880a272b03b99e01fd2f333f8f9f4
   internal/sdk/models/shared/datalinkdownloadurlresponse.go:
     id: 5f84fea697aa
-    last_write_checksum: sha1:af40f3d56493048570b3b291a310611676bb6cbd
     pristine_git_object: 0e6d8fe3999c1dddc3946c461a69fdbf202fad8f
   internal/sdk/models/shared/datalinkdto.go:
     id: 5b92f13f1e83
-    last_write_checksum: sha1:2228523d27e442f46582684aff62364cd44be18b
     pristine_git_object: c7d163766c28007ac37cbcf2093a5a16732a158b
   internal/sdk/models/shared/datalinkfinishmultipartuploadrequest.go:
     id: d71bb92372e2
-    last_write_checksum: sha1:ea18c4ddb4200a29f4ad8acbca11df07eb6f0471
     pristine_git_object: 09bc398401a5ae040e29cf2c7d528d5735634eed
   internal/sdk/models/shared/datalinkitem.go:
     id: 5aaedf83bae5
-    last_write_checksum: sha1:decb8de9b154720bfb14815628d6ba4707a64f0e
     pristine_git_object: 74d7463434251bbff86cd8c76c697e5447a7b183
   internal/sdk/models/shared/datalinkitemdeletionfailure.go:
     id: ea58d041ab51
-    last_write_checksum: sha1:314b9fccbe013c1e2ea769a34ce1569ae584dde4
     pristine_git_object: 61fefad8432ab22237326f460823178ef30f7660
   internal/sdk/models/shared/datalinkitemtype.go:
     id: 880c380d1507
-    last_write_checksum: sha1:fb601e880186f1de94ab529e8e7af76dc08129d3
     pristine_git_object: a264b42c0cf023788a59f4ee15a89c7191fce4e7
   internal/sdk/models/shared/datalinkmultipartuploadrequest.go:
     id: e1ecfa54fafc
-    last_write_checksum: sha1:10439728bb5a1d5d9f570c2537fe620adc9f40ae
     pristine_git_object: 79aa78147a811e84e9410915773d48c823a1ba11
   internal/sdk/models/shared/datalinkmultipartuploadresponse.go:
     id: 56054d65ea1e
-    last_write_checksum: sha1:61b6eacf40f59d339d9eaa99cefc04a76c02ffcc
     pristine_git_object: c51fbd79bc5170930ef1c437a64b01d607026ee9
   internal/sdk/models/shared/datalinkresponse.go:
     id: 4eca9400d4c9
-    last_write_checksum: sha1:192b10dc92847499b1cc96708f104672f52efab3
     pristine_git_object: 4c2591defa1f84c899704fc22112ed42a402781b
   internal/sdk/models/shared/datalinksimpleitem.go:
     id: 1f6b2f20f1ec
-    last_write_checksum: sha1:31f3ad0c22f91a03ed72b75fe271e2497ab4e97f
     pristine_git_object: 879d6242b198d474f671732ec44c8354ce760b32
   internal/sdk/models/shared/datalinktype.go:
     id: 2df15ac31941
-    last_write_checksum: sha1:feddf653e464ff71b0c2bd98e758f8c1796679e8
     pristine_git_object: 7118946702875c9baf22accd44454d2f40b56e9e
   internal/sdk/models/shared/datalinkupdaterequest.go:
     id: 80eab2e315e4
-    last_write_checksum: sha1:73e8d65828f64f28a07c93aa93adb0fb1364fb8b
     pristine_git_object: 0096c5c9fa1605ec9305ad6bd98d13977200e40d
   internal/sdk/models/shared/datasetdto.go:
     id: b074571b3884
-    last_write_checksum: sha1:b3b5a6814d2fae791924619978bb2e6091aff59b
     pristine_git_object: 4ecf8266e8d8deb599c269187b729037d5325b1a
-  internal/sdk/models/shared/datasetpreviewresponse.go:
-    last_write_checksum: sha1:27f658fb69423badba37a6355bf4ca26292c0973
+  internal/sdk/models/shared/datasetpreviewresponse.go: {}
   internal/sdk/models/shared/datasetqueryattribute.go:
     id: 0f64395f994a
-    last_write_checksum: sha1:f495185e8e34c570688dd15c46ba7d87b54fc3e1
     pristine_git_object: dbc35210f6dc126f6711385c789c854c0b259396
   internal/sdk/models/shared/datasetversiondto.go:
     id: 1f228cf15b72
-    last_write_checksum: sha1:705b46f57f434f39447d8fdb2466eba6f3105d7c
     pristine_git_object: 0587a5793ac51e565d25e5084d2440153d08009f
   internal/sdk/models/shared/datastudiocheckpointdto.go:
     id: 30033bf61a25
-    last_write_checksum: sha1:7c7c876c93e8edda918a7193086c812b7b66c66f
     pristine_git_object: 7e2b65ed2f3db5d38ddd7b33d5dbd2aeea6eb153
   internal/sdk/models/shared/datastudiocheckpointupdaterequest.go:
     id: f842d6a810bc
-    last_write_checksum: sha1:04f5c3c84268820612331d512a70f41b5a73f5fb
     pristine_git_object: c6e060a4e61e58bfb98c361d15a73f79ed1530b4
   internal/sdk/models/shared/datastudioconfiguration.go:
     id: 5841b2c71ba6
-    last_write_checksum: sha1:83e5857ccdb122c868e1aeddc42a23490accd808
     pristine_git_object: 227f1fede7b4f984a6dccff2b3f650fec8187799
   internal/sdk/models/shared/datastudiocreaterequest.go:
     id: f3e2d037c2c4
-    last_write_checksum: sha1:5b0a216c35fe3326f3b6b553982e71475e460b48
     pristine_git_object: dc064ad9e53d57fa56e83968852b6c130e6c0d1a
   internal/sdk/models/shared/datastudiocreateresponse.go:
     id: 920a1e5b9ac1
-    last_write_checksum: sha1:44148cc463f105e695c78f4f8af25441355d7466
     pristine_git_object: 89ec20df5b4c222b73ea2376c4d354ac5dfa2479
   internal/sdk/models/shared/datastudiodto.go:
     id: e7da86830815
-    last_write_checksum: sha1:1789b53b8e86222f62878bbb92c3236f16700abe
     pristine_git_object: 31d366345ef0f16a13e69c4a39d3516b82279009
   internal/sdk/models/shared/datastudiolistcheckpointsresponse.go:
     id: 5fb970629399
-    last_write_checksum: sha1:884c5e1890567aad3d8b574e72ce574aa11ad9b6
     pristine_git_object: d8ced19804d75bccfa1010931fda452d4b6f3758
   internal/sdk/models/shared/datastudiolistresponse.go:
     id: b92abaffc65c
-    last_write_checksum: sha1:3c427794bcfe181259c9bcf87d7e034eedde53e7
     pristine_git_object: 5d5992d84b3fe1b8cb06bec38b88fc32531a73b9
   internal/sdk/models/shared/datastudiomountedlinksresponse.go:
     id: ff90555e64b3
-    last_write_checksum: sha1:324193d996966df6ec7a1b5d6cd873e7ef616066
     pristine_git_object: b46041a54199a0af8a5cfae971358bf95fd8e867
   internal/sdk/models/shared/datastudioqueryattribute.go:
     id: 3a013062da57
-    last_write_checksum: sha1:a9d9fed12ae1f218431cd6036a08d4416c888d1a
     pristine_git_object: 3104ed27b944f32f90731e9cd17879d45737ebdb
   internal/sdk/models/shared/datastudiostartrequest.go:
     id: b85784e03a6b
-    last_write_checksum: sha1:5c5fb907bfcaa9345d934f20b7b0b3a8a5897aca
     pristine_git_object: e375bdb5fe5a91b9eb237dc7a7206d475005ec74
   internal/sdk/models/shared/datastudiostartresponse.go:
     id: 26501a0284dc
-    last_write_checksum: sha1:12c3dc6d08079023a807bc15815510a6d97863db
     pristine_git_object: ac955ba5a865e5d8d2aaf307d3fab4cd20a3392d
   internal/sdk/models/shared/datastudiostatus.go:
     id: c42fa7ad62a5
-    last_write_checksum: sha1:dd4a0fc7a0e5d1adfea1c558527d446c10932987
     pristine_git_object: a1644b32d1a6b682f52ed100b9dc282536c5d7ad
   internal/sdk/models/shared/datastudiostatusinfo.go:
     id: 026e85d14925
-    last_write_checksum: sha1:f64cc335899e6cc4a39752bd2b1c99e1808224eb
     pristine_git_object: 3cfada19dde6016b9d18ddb2bd6ac55625a1141c
   internal/sdk/models/shared/datastudiostopreason.go:
     id: 9ccc5de4e821
-    last_write_checksum: sha1:3350ebae6a1281b4532920034aa07231b4a48aa9
     pristine_git_object: 975d25fae2f55a3a1aa94d010444489d77c914bb
   internal/sdk/models/shared/datastudiostopresponse.go:
     id: 479eccdf6c23
-    last_write_checksum: sha1:0b74f761ed5754fbb58c50ca3be84a67a1fe68de
     pristine_git_object: a1f288cd99b5142ec5671be21b90d9dc6518ecae
   internal/sdk/models/shared/datastudiotemplate.go:
     id: ef4d0ab26db3
-    last_write_checksum: sha1:e4f610a505100879f515c91591bad78c159452f8
     pristine_git_object: ec2bc5a9f65f4640b2469c2a5d1df28b62c87970
   internal/sdk/models/shared/datastudiotemplateslistresponse.go:
     id: 4349933d6e2b
-    last_write_checksum: sha1:7734d539280cb6d5f8d56be85f571cf1c77ac98d
     pristine_git_object: 251edc9e8feb883f0826e0275ea45e7005d0bb43
-  internal/sdk/models/shared/datastudioupdaterequest.go:
-    last_write_checksum: sha1:0e11dd81e3922ba015dfaf47232d75d0ec4d0bfa
+  internal/sdk/models/shared/datastudioupdaterequest.go: {}
   internal/sdk/models/shared/datastudioversionstatus.go:
     id: 138d7204dd92
-    last_write_checksum: sha1:80c44d07827e51f93b4525dd51b474083ff489a6
     pristine_git_object: dca98697457896ff486268fad3d1504f50ba18ff
-  internal/sdk/models/shared/datastudioworkspacesettingsrequest.go:
-    last_write_checksum: sha1:6292e10d9a4263143f51e1691271556df4214789
+  internal/sdk/models/shared/datastudioworkspacesettingsrequest.go: {}
   internal/sdk/models/shared/datastudioworkspacesettingsresponse.go:
     id: 62bb5fd9d1a5
-    last_write_checksum: sha1:c18863c8139491cac2f225a72adb604914c2ec7c
     pristine_git_object: 5d9c663cf52d1d7394738deb0cd2d61721c74d49
-  internal/sdk/models/shared/defaultworkflowengineparameter.go:
-    last_write_checksum: sha1:1f4d2a3d790a4efbe34d09a1620277170a00828d
+  internal/sdk/models/shared/defaultworkflowengineparameter.go: {}
   internal/sdk/models/shared/deletecredentialsconflictresponse.go:
     id: e8d764d9feab
-    last_write_checksum: sha1:51331f96113ebb471d2073f612bd1fcedf7d31a6
     pristine_git_object: fac9418e55eb15c839e541d0e1413d3ef9c27160
   internal/sdk/models/shared/deletecredentialsconflictresponseconflict.go:
     id: 14730103fb9f
-    last_write_checksum: sha1:f770a678fdf863e193305f9fb3ecd3d7651bf384
     pristine_git_object: be92245c8237b2c175b67be1a2210b62e025d780
   internal/sdk/models/shared/deletedatasetsrequest.go:
     id: 20de98824f0b
-    last_write_checksum: sha1:26fbe1a17347ee8aa851c45324ba2040aeb04563
     pristine_git_object: 13a6311cba2e23da748f62e77402cde9034dee9d
   internal/sdk/models/shared/deletedatasetsresponse.go:
     id: 6b0e6bcec11c
-    last_write_checksum: sha1:7d64e4e344929b8ac9f537699cedbb76771cecb6
     pristine_git_object: 0fb52fcb36bbfb09c9020fdbaf91d39f96ec8e39
   internal/sdk/models/shared/deletemanagedcredentialsconflictresponse.go:
     id: 7f6ce0439a98
-    last_write_checksum: sha1:5ec33a5eff08515ec6bbc0c392953fd11625afb8
     pristine_git_object: 7c7351d1981cefa2cb9e863e4a20269d84522859
   internal/sdk/models/shared/deletemanagedcredentialsconflictresponseconflict.go:
     id: f27629845676
-    last_write_checksum: sha1:5143a283879bba156d888ae57d0f5d1a47eef50c
     pristine_git_object: 09b71f53acc3420ab69cbc9d93498666c2fa4ade
   internal/sdk/models/shared/deleteworkflowsrequest.go:
     id: 4420dc02bbbb
-    last_write_checksum: sha1:179e44281752182c10a23588c07ef96ee48ff4cd
     pristine_git_object: 1cb9e0a0a0e6d26bc989e270aa5ba1c310dbcfad
   internal/sdk/models/shared/deleteworkflowsresponse.go:
     id: d82f60386a7d
-    last_write_checksum: sha1:aeee6fbfe27633fc07615f1cb433455cefc52dba
     pristine_git_object: eb827570fc11abdc4a644c483375e8685dedfdbe
   internal/sdk/models/shared/describeactionresponse.go:
     id: ab359c7b82f7
-    last_write_checksum: sha1:8bb524c6f5cbe1c8b37bce884844585ab3c136f2
     pristine_git_object: 71a5bbd72e862967e067266938c69364b8235e98
   internal/sdk/models/shared/describeawsbatchceresponse.go:
     id: b47c6385fa7e
-    last_write_checksum: sha1:e9580a661402054fa70c1b08fda02f43e8f5de95
     pristine_git_object: 3c26e133a595a49692fe0212ed86d01d6b0e718a
-  internal/sdk/models/shared/describeawscloudceresponse.go:
-    last_write_checksum: sha1:d10753dcda41f8b2b26ab9c09f66dbc33480a6a5
+  internal/sdk/models/shared/describeawscloudceresponse.go: {}
   internal/sdk/models/shared/describeawscomputeenvresponse.go:
     id: dde051051f9a
-    last_write_checksum: sha1:be9f46ad0c9f8a011a8f016fc149bc08e58d1be0
     pristine_git_object: a4be7d7681635d2d4c3c7310a54b67bc90434aee
   internal/sdk/models/shared/describeawscredentialsresponse.go:
     id: e18d07794e57
-    last_write_checksum: sha1:bb02b9953bbe9f9a0ace0b94c740a9ef247ce0d2
     pristine_git_object: 46c92d5a7f203d898564cda714d1a975e88503cd
-  internal/sdk/models/shared/describeazurebatchceresponse.go:
-    last_write_checksum: sha1:ba58e8d76b91ca7635cf66c11d9db037c0f1e046
-  internal/sdk/models/shared/describeazurecloudceresponse.go:
-    last_write_checksum: sha1:1e76fac8d1e60d30561b5f5a862e98134399d6b7
-  internal/sdk/models/shared/describeazurecloudcredentialsresponse.go:
-    last_write_checksum: sha1:6c9f08d972825f1a07752626e1f4c94dc4a5f6d3
+  internal/sdk/models/shared/describeazurebatchceresponse.go: {}
+  internal/sdk/models/shared/describeazurecloudceresponse.go: {}
+  internal/sdk/models/shared/describeazurecloudcredentialsresponse.go: {}
   internal/sdk/models/shared/describeazurecredentialsresponse.go:
     id: 32026d2b47cd
-    last_write_checksum: sha1:88086fbc19f9f5eab7ead6aa48b929e72d3ecb0a
     pristine_git_object: 0d41fe273a72ec9f7e1c74a3dc3f89351a7b55b7
-  internal/sdk/models/shared/describeazureentracredentialsresponse.go:
-    last_write_checksum: sha1:263a39b282bf6d2fb51aec457fa8b76b4375f329
+  internal/sdk/models/shared/describeazureentracredentialsresponse.go: {}
   internal/sdk/models/shared/describebitbucketcredentialsresponse.go:
     id: c66f87eab65f
-    last_write_checksum: sha1:d1c556a70f2e47e68518a3ee03ef882229274b9d
     pristine_git_object: 1abcda8559eec2693cf9a2e1f2d60e7d397b073f
   internal/sdk/models/shared/describecodecommitcredentialsresponse.go:
     id: 3187bd97c40a
-    last_write_checksum: sha1:38f0160dd8f4fdc2fd7d380793eff20a0901ef9a
     pristine_git_object: d7a425b3eb31ecb3eedcf25fa0dc4f3c93f88d2c
   internal/sdk/models/shared/describecomputeenvresponse.go:
     id: 7fdd10227324
-    last_write_checksum: sha1:bcb0a7a64ca3ec15bf76e62317ee267cee0be2ea
     pristine_git_object: 7f8bf4f66239eafa46cd9c4323c6e8b2dedaba90
   internal/sdk/models/shared/describecontainerregistrycredentialsresponse.go:
     id: 53e575119066
-    last_write_checksum: sha1:c1db4bf3eaa57566ecc3e388a496b7016e373a31
     pristine_git_object: c8335a83d37450bd897228218f5c09f62eac45a0
   internal/sdk/models/shared/describecredentialsresponse.go:
     id: 346f57229132
-    last_write_checksum: sha1:ba06df93dfe700e1dde9c62a67708f946f08cb75
     pristine_git_object: f734fae9c3c41139e6b7fceac0ebb417cdd50074
   internal/sdk/models/shared/describedatasetresponse.go:
     id: 9e2cc1777c6e
-    last_write_checksum: sha1:8c333670d473f14b52f7e887a04fe89cf4769073
     pristine_git_object: b6c3b86924889128fd8d9e163dc14b7dff0b4ee1
-  internal/sdk/models/shared/describegcpbatchceresponse.go:
-    last_write_checksum: sha1:291f68d44678126b1b4d57c30757de93b6c4c986
-  internal/sdk/models/shared/describegcpcloudceresponse.go:
-    last_write_checksum: sha1:93cd69ea95dff30625c21d7a89da30610aa2365d
+  internal/sdk/models/shared/describegcpbatchceresponse.go: {}
+  internal/sdk/models/shared/describegcpcloudceresponse.go: {}
   internal/sdk/models/shared/describegiteacredentialsresponse.go:
     id: 503b0436a476
-    last_write_checksum: sha1:6c0cbbb5c8831aa837c28aae30b0d8cb52e595be
     pristine_git_object: 2d3204c2182912ba37e46ece72f680c0d3212980
-  internal/sdk/models/shared/describegithubappcredentialsresponse.go:
-    last_write_checksum: sha1:7ffcc923de3ee1ae6979cef1bb4ab2123a74acb3
+  internal/sdk/models/shared/describegithubappcredentialsresponse.go: {}
   internal/sdk/models/shared/describegithubcredentialsresponse.go:
     id: ab4393e59108
-    last_write_checksum: sha1:7aaf3bff76803e3babcd1b15305a2e9a34e9c382
     pristine_git_object: 54ef80d48a1fd4c58732abacd68807a30d619ae9
   internal/sdk/models/shared/describegitlabcredentialsresponse.go:
     id: a3ee86f0f903
-    last_write_checksum: sha1:faaed229543b414e8f1ddcc3fae6562051067cd3
     pristine_git_object: d108d8512c6989e38c7f0cd35492943397f15f6c
   internal/sdk/models/shared/describegooglecredentialsresponse.go:
     id: c6ac895dcc3c
-    last_write_checksum: sha1:b6939c35ff95406208e678426c84bedb63f9e955
     pristine_git_object: 04dcee92d0679c112cb7fcf9b875af96a6f1054f
   internal/sdk/models/shared/describekubernetescredentialsresponse.go:
     id: 1b89e736abdf
-    last_write_checksum: sha1:4b0d7f188d08f1f441834be13a7e46d399e89f00
     pristine_git_object: dc83ee3f5c97197e94b7673f34725386c8a12b23
   internal/sdk/models/shared/describelaunchresponse.go:
     id: 8bac3ea3f695
-    last_write_checksum: sha1:7d6eebdc0000a37e82cc7c3744a3f0feddd469b6
     pristine_git_object: cc828502467c3acfd6735be0f16693c9bc45d011
   internal/sdk/models/shared/describemanagedcomputeceresponse.go:
     id: f95224111ee9
-    last_write_checksum: sha1:d556ca73fc4c92638d2226f21591961e39b4359d
     pristine_git_object: f0a842f8ef24d51b7852174545391fe83af04d3c
   internal/sdk/models/shared/describeorganizationquotasresponse.go:
     id: 310fea62d258
-    last_write_checksum: sha1:66c4b21de06cf1f1159fc4de2b4b4e9fa329f864
     pristine_git_object: 2be926510d170683a20d3fd782ab557bb33036ab
   internal/sdk/models/shared/describeorganizationresponse.go:
     id: 432ca34e7c80
-    last_write_checksum: sha1:bb30abb042908f68db5c5771a9810a7acd5bd518
     pristine_git_object: 6bfd884a3e392f803e06153390fd925f4600f530
   internal/sdk/models/shared/describepipelineinforesponse.go:
     id: 7ca306f71e81
-    last_write_checksum: sha1:d042a4b10cd1edd1b35fc0c476a1b55c012e48aa
     pristine_git_object: ea42e7370bb6ae9d7388e4f51f4f6a7b663151d8
   internal/sdk/models/shared/describepipelineresponse.go:
     id: 971d22d66779
-    last_write_checksum: sha1:e4deaa58c230ca8c0e8ff24c7deb92150b91c920
     pristine_git_object: b2dc9d886d6b5d6da273b6d1b84c2611ef72f503
   internal/sdk/models/shared/describepipelinesecretresponse.go:
     id: 526262f75107
-    last_write_checksum: sha1:8232d380db89bae425cf85b2a4635dd926651efa
     pristine_git_object: deb9bdd53e4ed24409f471bd2042d86441391ae4
   internal/sdk/models/shared/describeplatformresponse.go:
     id: f42987bfff26
-    last_write_checksum: sha1:9b82dfe9410dba4a47821d027eb01cbd156511ea
     pristine_git_object: 69c9e3a2125cfe44213fea0df88b62c456a7ea34
-  internal/sdk/models/shared/describeroleresponse.go:
-    last_write_checksum: sha1:57d71a16d76dc2b92e305cc0dfe0e8f51ec9add0
+  internal/sdk/models/shared/describeroleresponse.go: {}
   internal/sdk/models/shared/describesshcredentialsresponse.go:
     id: db6455452f9f
-    last_write_checksum: sha1:36d831dccf816dc66af19f966649ec7114db20cd
     pristine_git_object: 70db4cabf5ff71f84ca0511cb0eb28fcac723c8c
-  internal/sdk/models/shared/describesshkeyresponse.go:
-    last_write_checksum: sha1:67dea40387699ef65998a16dc6c5aa0acca23c1d
+  internal/sdk/models/shared/describesshkeyresponse.go: {}
   internal/sdk/models/shared/describetaskresponse.go:
     id: bde6c2c5a1bd
-    last_write_checksum: sha1:b3af3e3f828f109a9aa295fee5c5f07df7121c05
     pristine_git_object: 838e85500ffc8ae7bcb8629dc65fbd67fad1cced
   internal/sdk/models/shared/describeteamresponse.go:
     id: a25fc78247d2
-    last_write_checksum: sha1:7b5af5d63e7e1f940159a84842157c5c5f720027
     pristine_git_object: 22211eae79188b4ee253894d771c4c947d6b288d
   internal/sdk/models/shared/describetoweragentcredentialsresponse.go:
     id: 08f4e831ace6
-    last_write_checksum: sha1:8422e814d4218c64f464b2a6a890efab872de8d3
     pristine_git_object: 1940de39d08fbb390bc87097c966b21073060d3e
   internal/sdk/models/shared/describeuserresponse.go:
     id: 9f15a824aef3
-    last_write_checksum: sha1:4d3bf91eeaf315c814c203c50ba0e96bb44604b8
     pristine_git_object: 7b1dd43d83c211980e4f9c51a7e4114dc04d6e8f
   internal/sdk/models/shared/describeworkflowlaunchresponse.go:
     id: 3ed32806a302
-    last_write_checksum: sha1:9cb72d3bd446ef2f0e1cd21d998a364843378e86
     pristine_git_object: 4d50a2aa4f9d347610611cd2c7dbb0c13584944a
   internal/sdk/models/shared/describeworkflowresponse.go:
     id: cb46c0306832
-    last_write_checksum: sha1:762650aa1b04e298f3486bbfa046ad8d5921262d
     pristine_git_object: 43bc140ba6761af9a9802c976cd34258868edbe5
   internal/sdk/models/shared/describeworkspaceresponse.go:
     id: 5b7149929e4d
-    last_write_checksum: sha1:9672926591c4ac5c7b098557f00f1012c41d781f
     pristine_git_object: ed703a8366da72ab5a001328c5d4bf7a9e86a498
   internal/sdk/models/shared/efsfilesystem.go:
     id: 136655f68e55
-    last_write_checksum: sha1:4b0b9b0d167a1474b7c6da58de6654fdad0c62a1
     pristine_git_object: e467ff62c0a3ed189227b3d3850cc4775cf78946
   internal/sdk/models/shared/eksplatformmetainfo.go:
     id: 292166043b15
-    last_write_checksum: sha1:b1682e860d657dd7a25dc6d31c89747efa5bb6ab
     pristine_git_object: 989c6edb0ecc1627fcd40b551b1bc6583ce3c95f
   internal/sdk/models/shared/emptybodyrequest.go:
     id: c5fa2c16ca1f
-    last_write_checksum: sha1:ac80ab518963ca4fd0d3e2751310546c4e8d6f79
     pristine_git_object: 3fe30f50686382aca22529762760626f57065737
   internal/sdk/models/shared/errorresponse.go:
     id: 9ff13edc1b2c
-    last_write_checksum: sha1:f2ffab873bdd22a21880b337c6c6266a2b2658d6
     pristine_git_object: ada24091c457aa33845ecac684584c922e9d640f
   internal/sdk/models/shared/eventtype.go:
     id: e98033ee76da
-    last_write_checksum: sha1:0fd9cc76e400d9aa0902445c73a09a40ae173855
     pristine_git_object: fe9ce6f2d92dc2374fd266280d28c7068cddcf24
-  internal/sdk/models/shared/feature.go:
-    last_write_checksum: sha1:93b860d1faddc91ee78aad5c0859a04dc7d3cd98
+  internal/sdk/models/shared/feature.go: {}
   internal/sdk/models/shared/forgeconfig.go:
     id: f0d74f37365a
-    last_write_checksum: sha1:9243eefbbf9216ab818fa09cbf5f990bda031340
     pristine_git_object: 8640f7531d89ba50ae044b7c3ee95155583a20bd
   internal/sdk/models/shared/fsxfilesystem.go:
     id: f00388b21ac4
-    last_write_checksum: sha1:9c3cb50bd1541957cbb896738ff116f43daf17a5
     pristine_git_object: 94b0a48a8ab8d445271b58b00395202b0e8903d7
-  internal/sdk/models/shared/gcpbatchcecomputeconfiginput.go:
-    last_write_checksum: sha1:c25b0539f1588a3bfd4f72d45e8499b3b70cf64b
-  internal/sdk/models/shared/gcpcloudcecomputeconfiginput.go:
-    last_write_checksum: sha1:ee7e3ab1db1d5ba13d22bb76cbc50e44ff3b0fb1
-  internal/sdk/models/shared/getcredentialskeysresponse.go:
-    last_write_checksum: sha1:ef9d236feb954cb6365cc4ae7cfc746a9009d90c
+  internal/sdk/models/shared/gcpbatchcecomputeconfiginput.go: {}
+  internal/sdk/models/shared/gcpcloudcecomputeconfiginput.go: {}
+  internal/sdk/models/shared/getcredentialskeysresponse.go: {}
   internal/sdk/models/shared/getprogressresponse.go:
     id: e4eb67e532d0
-    last_write_checksum: sha1:7229d6e7ebee0a7825aa442bd2c02c0721227b93
     pristine_git_object: 42837c237c28748d888bbbcf050d98c47ee88c95
   internal/sdk/models/shared/getworkflowmetricsresponse.go:
     id: 3d7a2cb5c721
-    last_write_checksum: sha1:c33a08faf08888f5ea172e9901fa813871adf117
     pristine_git_object: f2dfcf01b5586b5f4fabf4179fc9f48717d201d9
   internal/sdk/models/shared/giteacredential.go:
     id: dfce6a8fcdf0
-    last_write_checksum: sha1:f67071816c8bb4d84f1849ec32e02ec4125bf1ad
     pristine_git_object: 7637ba2ec7d6a8ecf7312350d60e081f096f9a96
   internal/sdk/models/shared/githubactionconfig.go:
     id: f9c267b87cce
-    last_write_checksum: sha1:51bd175a7587f2f47431c51784eeb45192765e28
     pristine_git_object: 787b4251b54538684ea5faba1c1bc633e4f92fb9
   internal/sdk/models/shared/githubactionevent.go:
     id: a0d80eab2a2b
-    last_write_checksum: sha1:58e9de2f520107f6e2ff72bf5be064c3d2e6be20
     pristine_git_object: 17c90fd61a9fdd0f3467eccfeab719d950ad8d75
-  internal/sdk/models/shared/githubappcredential.go:
-    last_write_checksum: sha1:3769399b2c35c72cb446514d73392fefcc829f48
+  internal/sdk/models/shared/githubappcredential.go: {}
   internal/sdk/models/shared/githubcredential.go:
     id: ff7ad720d02c
-    last_write_checksum: sha1:ff15a41d5840fee94ba6f00c7f14f1df8bfa4269
     pristine_git_object: 79b31488d52fa8ac1243a3872b8897e67b34dd4b
   internal/sdk/models/shared/gitlabcredential.go:
     id: 22d18787c458
-    last_write_checksum: sha1:063844a6c5ecf1d637aabe106046b43b102d47c8
     pristine_git_object: 05f9c000d0738657deb5c5f3bee3445ac5780f92
   internal/sdk/models/shared/gkeplatformmetainfo.go:
     id: e8e0a0401118
-    last_write_checksum: sha1:3bbceb36b0f1a5ae35c59650dd1458501167441f
     pristine_git_object: d93e4f9224bfcf068b716b3e11f95edf7cf26158
-  internal/sdk/models/shared/googlebatchconfig.go:
-    last_write_checksum: sha1:02d22933d3fc300c846a4c732dfe4e00406dfb81
-  internal/sdk/models/shared/googlecloudconfig.go:
-    last_write_checksum: sha1:616efeaa58a7df5b13ad17f726d4c40cf4242bf6
+  internal/sdk/models/shared/googlebatchconfig.go: {}
+  internal/sdk/models/shared/googlecloudconfig.go: {}
   internal/sdk/models/shared/googlecredential.go:
     id: a084779f2e36
-    last_write_checksum: sha1:87d1dacba480523574d2cfa71ed8a03a6f447702
     pristine_git_object: 8fa752a4783e5b119cbcdb50b6dc72cd4c5a29f5
-  internal/sdk/models/shared/googleimage.go:
-    last_write_checksum: sha1:33a6a88c16b3df789e3e1a63b171b2245ffa312c
-  internal/sdk/models/shared/googleinstancetype.go:
-    last_write_checksum: sha1:74d420f672e6719e0364e411765ec88d56c5ca4d
+  internal/sdk/models/shared/googleimage.go: {}
+  internal/sdk/models/shared/googleinstancetype.go: {}
   internal/sdk/models/shared/googleplatformmetainfo.go:
     id: beb9543985be
-    last_write_checksum: sha1:71e40ec33bde684bc8ad642a305530e45e30b63f
     pristine_git_object: a6cbb30909dd0ccfea1ba91ecba51011cba2a76e
   internal/sdk/models/shared/googleplatformmetainfobucket.go:
     id: 9171858da66f
-    last_write_checksum: sha1:f7fb6b6d060b4f4bab5fca4ae00f3bd037ed5719
     pristine_git_object: 98ed279f07592f5375b8694d0b084d09f14a2f95
   internal/sdk/models/shared/googleplatformmetainfofilestore.go:
     id: 7ead380d4941
-    last_write_checksum: sha1:996f91f0676c94a5c063c1c241551a6b9dc338e9
     pristine_git_object: 9674397bdb94a7bf9e335f96bdcc0b41f972a81f
   internal/sdk/models/shared/gridplatformmetainfo.go:
     id: 5fdad7c9a6d3
-    last_write_checksum: sha1:4e87f5cff066a34e38265d612b6ed3aaa5ffa583
     pristine_git_object: 7123c4e5960ce98abbce7152014961b8d4f30482
   internal/sdk/models/shared/image.go:
     id: c63d9aff3853
-    last_write_checksum: sha1:286392a220b816911520778673f5477762d03444
     pristine_git_object: b78ff41dc0b125a7d6ee8c4f1c93fb8bbeac8f72
   internal/sdk/models/shared/instancetype.go:
     id: f088143313c8
-    last_write_checksum: sha1:7abcd63e8b18554a15b78e52f8ceb758619110f9
     pristine_git_object: f3fe93890eb2f0b566cc6ea4e5802af50124bb25
   internal/sdk/models/shared/jobqueue.go:
     id: ca3b1b08cf50
-    last_write_checksum: sha1:de56dda98bc675d041f43428c1df09cf337687e2
     pristine_git_object: 39b819e0d11d50eeff1c9c767133c1aafba0463a
   internal/sdk/models/shared/k8splatformmetainfo.go:
     id: eb0eb018163b
-    last_write_checksum: sha1:d374cd83a4be3e7b891f8f175353d5024f79776a
     pristine_git_object: 0c21b12e52de3aa371634e192d353eb5c563286d
   internal/sdk/models/shared/kubernetescredential.go:
     id: 6cf20ba318a9
-    last_write_checksum: sha1:a19c07050dfadeaf9b1b17eba278555f27a6ed81
     pristine_git_object: 844e20a2429f42fc26fcb77430963158f4d4059a
   internal/sdk/models/shared/labeldbdto.go:
     id: 45e15e6c711e
-    last_write_checksum: sha1:1ae7fade7b5ebd8eabe5c91ce6ebf0b0dea569cb
     pristine_git_object: a8dd7c4c13fa70bdcd7cf3b77f17cab4c56f8b1e
   internal/sdk/models/shared/labeltype.go:
     id: 0050e50fd2c9
-    last_write_checksum: sha1:2e5ce5a4745a90608fc7f886603ab8b26aa92f8b
     pristine_git_object: fe9c695f86891f4b3d35acf81d0fb455b2792eca
   internal/sdk/models/shared/launchactionrequest.go:
     id: 7b611666d3be
-    last_write_checksum: sha1:f698c2304d4c4d4a14731eaad1ebf10197992e4b
     pristine_git_object: 8a21481be00ca49d7463f90c1170068a0c558bf4
   internal/sdk/models/shared/launchactionresponse.go:
     id: 48f1ddcebd6a
-    last_write_checksum: sha1:df630144fbe276623a0d21b4fb5771e4c829b062
     pristine_git_object: 0ac170c9ca4204d1d3cd7e2cdd67041692cd6449
-  internal/sdk/models/shared/launchdbdto.go:
-    last_write_checksum: sha1:d7d7d8dc4e674dba00a54ebd74c7130d7031db5b
-  internal/sdk/models/shared/linkedsourcedto.go:
-    last_write_checksum: sha1:aaca7862a2fa767873e9216ae73228ed828d3d1d
-  internal/sdk/models/shared/linkversionrequest.go:
-    last_write_checksum: sha1:9d29c8bed2508b94bfb567469c145b4dad9b280f
+  internal/sdk/models/shared/launchdbdto.go: {}
+  internal/sdk/models/shared/linkedsourcedto.go: {}
+  internal/sdk/models/shared/linkversionrequest.go: {}
   internal/sdk/models/shared/listaccesstokensresponse.go:
     id: e9e6ce9fec76
-    last_write_checksum: sha1:9b797009922784402c2ff28b68da883dbdab2472
     pristine_git_object: 9be387aa4ba395600e75f3661e9153d1112a7e99
   internal/sdk/models/shared/listactionsresponse.go:
     id: "490020610762"
-    last_write_checksum: sha1:40bf6914ee674ccdb6d556cf28f3cb2c461f6ab2
     pristine_git_object: 10cbd11d220a84ecc26e1becfe108aaab3072e70
   internal/sdk/models/shared/listactionsresponseactioninfo.go:
     id: 3c6a2b607f2a
-    last_write_checksum: sha1:28350fab7c674881dbe1aaef9e1cd96ee094bfb0
     pristine_git_object: 46248fe0283e2c4fbff0ca9647108f091c8caf2c
   internal/sdk/models/shared/listcomputeenvsresponse.go:
     id: 2deb1eefd497
-    last_write_checksum: sha1:f5cbf3a0f00b4aecc2da464c4b7cca36e13a3b17
     pristine_git_object: a5756bdeb6858b5bcc2ad4109d1a79b8bbc98c53
   internal/sdk/models/shared/listcomputeenvsresponseentry.go:
     id: 335626813aac
-    last_write_checksum: sha1:fc1862ad1326b1371acc625139fe1d3dd4496464
     pristine_git_object: 31fc9642b4b50a211a2f4a4aaa7a9595ad7a1e4f
   internal/sdk/models/shared/listcredentialsdatasourceresponse.go:
     id: 415c06299b6f
-    last_write_checksum: sha1:d789e389fa62343000f43b229bb25fdb1b367b8c
     pristine_git_object: be69f40a905bb352919aa7a7594ccb8106fa176f
   internal/sdk/models/shared/listdatalinksdatasourceresponse.go:
     id: cfd2cb5780a4
-    last_write_checksum: sha1:ef42759c135a554a234fb5d983fe046cf34b79e9
     pristine_git_object: add607b620a772dc03f8c67f4a1fd16199522276
   internal/sdk/models/shared/listdatasetsresponse.go:
     id: 03ea45bbcf66
-    last_write_checksum: sha1:d06aed9464281bcd4ec0ba7171afdcbf04a8b19d
     pristine_git_object: 4cdfbeb857a5d8f979108fd0bdba837dbf8ba6a0
   internal/sdk/models/shared/listdatasetversionsresponse.go:
     id: 461039e42d54
-    last_write_checksum: sha1:0e7caa74f0faad583c69e253a8d1bc45238a4366
     pristine_git_object: 2d71b3ce8ea4edf67c06e7a4e0a7cc2d8241bed3
   internal/sdk/models/shared/listeventtypesresponse.go:
     id: a157b9d7a390
-    last_write_checksum: sha1:0e5cf77f63cd24eacc2eb05bb77b325e4597cbc2
     pristine_git_object: 5c498aba9fcf9b5cf996ba3d4a4557d0355031d5
   internal/sdk/models/shared/listlabelsresponse.go:
     id: 9a59f065e1f2
-    last_write_checksum: sha1:203c3270870b8fc5beb0692bb3db751f9670174f
     pristine_git_object: 78e6625814cb6c2921c8aa0cfcc2641a1b6faa3e
   internal/sdk/models/shared/listmanagedcredentialsrespdto.go:
     id: ccc127110aea
-    last_write_checksum: sha1:5ef0f8bd363077ee7c53550f9047673c54af1019
     pristine_git_object: 2dcd197f0414ad65045dce6f217b51d332a7e44a
   internal/sdk/models/shared/listmanagedcredentialsresponse.go:
     id: 03f8facddd9c
-    last_write_checksum: sha1:a1e023eef8719b3927627f0ec6e014ba6ae65eff
     pristine_git_object: 57bcb8528546899a478822afd3dcf0db67d94f9b
   internal/sdk/models/shared/listmanagedidentitiesresponse.go:
     id: 027dd64b1800
-    last_write_checksum: sha1:2dd2a4733b12be9daa1f2d7f700955fa14d6d4dc
     pristine_git_object: f7d82ed35c3b99277331d3fff0ae46001f3e7509
   internal/sdk/models/shared/listmembersresponse.go:
     id: fcf193b9913a
-    last_write_checksum: sha1:bde387608667ee7d347033037ca989b63116e4e3
     pristine_git_object: f092a39ef0b22546d5fef6adb640150fbd70f502
   internal/sdk/models/shared/listorganizationsresponse.go:
     id: 6fa3d71fc5ca
-    last_write_checksum: sha1:f9df33c3897209239cd996d3ef69470f83ac0161
     pristine_git_object: a2b6bac1eca4cc3e16b7989501676cfef61c38e2
   internal/sdk/models/shared/listparticipantsresponse.go:
     id: 5698803b6d10
-    last_write_checksum: sha1:9065d58105d7156271b69d56d364255103f80bad
     pristine_git_object: 19fd629f6f139e3969ac0daf4efee00f880c1a76
   internal/sdk/models/shared/listpipelineinforesponse.go:
     id: 94b01cad1f37
-    last_write_checksum: sha1:9c7bdb6450be41f45dedc0c7bb5e41579be6a6ec
     pristine_git_object: 1dc4a2bbd2c75e732bff0118a8e6c99c0a3beeb9
   internal/sdk/models/shared/listpipelinesecretsresponse.go:
     id: 0a13fa1d0c18
-    last_write_checksum: sha1:b01bf5c225eca14dd7cc69e5e9e910c0c0c6fc9a
     pristine_git_object: 1c3e3262be00c40c3e093b4c0bcc034300b4f2b0
   internal/sdk/models/shared/listpipelinesresponse.go:
     id: f1204f41287b
-    last_write_checksum: sha1:ff936c65d1a50f71ce2662210433fb1e8c4cef0e
     pristine_git_object: 664bb7dc9f4b2196e81a338ff5829d4bdce44681
-  internal/sdk/models/shared/listpipelineversionsresponse.go:
-    last_write_checksum: sha1:7412e9ac26df459e681ad7ebe0adb3f6245b67df
+  internal/sdk/models/shared/listpipelineversionsresponse.go: {}
   internal/sdk/models/shared/listplatformsresponse.go:
     id: f4510616e78a
-    last_write_checksum: sha1:307c37d2701d9797340b44f3bf8de093f65c6804
     pristine_git_object: b5af8c26afe9c43586ce5f54cc89deb6d1ad72c9
   internal/sdk/models/shared/listregionsresponse.go:
     id: a4cc95d239cd
-    last_write_checksum: sha1:b5fff2a435a1ec38bbfd45f944515316eecd01c4
     pristine_git_object: 3e04d3445cf3a45189f719d6f25ffe02f0fc903a
-  internal/sdk/models/shared/listrolepermissionsresponse.go:
-    last_write_checksum: sha1:6aea4e76b1fb4a97147effbbb436eeaf938e7e24
-  internal/sdk/models/shared/listrolesresponse.go:
-    last_write_checksum: sha1:0ef68ab48bd47a567a2bed217cb9d17da7648509
-  internal/sdk/models/shared/listrolesresponseroleinfo.go:
-    last_write_checksum: sha1:7d94ceeefdcdd15f22379750527c90a3ec607be8
-  internal/sdk/models/shared/listsshkeysresponse.go:
-    last_write_checksum: sha1:be019d1c96490c1528854ca2414607f53d089d9e
+  internal/sdk/models/shared/listrolepermissionsresponse.go: {}
+  internal/sdk/models/shared/listrolesresponse.go: {}
+  internal/sdk/models/shared/listrolesresponseroleinfo.go: {}
+  internal/sdk/models/shared/listsshkeysresponse.go: {}
   internal/sdk/models/shared/listtasksresponse.go:
     id: d898eef18570
-    last_write_checksum: sha1:3fdcec423d302fc9cdd3634a08722b7822f2da36
     pristine_git_object: 714a4437d39a056f867a98020df4a204c6677828
   internal/sdk/models/shared/listteamresponse.go:
     id: fdc28e45fdcb
-    last_write_checksum: sha1:55cb902d612bb41ce4a75d596e5fce276470f58a
     pristine_git_object: c34c06d2c652d052d622ca07207989eea32af187
-  internal/sdk/models/shared/listuserrolesresponse.go:
-    last_write_checksum: sha1:d2d005ad70a1525f7f3b1fc0b8fc24f499d7d3dd
+  internal/sdk/models/shared/listuserrolesresponse.go: {}
   internal/sdk/models/shared/listworkflowsresponse.go:
     id: bc8305d22b0a
-    last_write_checksum: sha1:7b3a4dd955f6e44b6fd3e7c823a97ceb8b902a71
     pristine_git_object: c7b036b2a18eb73f01cd830209b518e2ec1007f0
   internal/sdk/models/shared/listworkflowsresponselistworkflowselement.go:
     id: 2be84e6e6f9a
-    last_write_checksum: sha1:d7187b2a9c70de31148767f20992ac6bbe709aad
     pristine_git_object: 442bd18c87c20f5d31110c1eda2100b50ac4f515
   internal/sdk/models/shared/listworkspacesandorgresponse.go:
     id: cf1ac68fda5d
-    last_write_checksum: sha1:d293aab22312e95cb89abb04c400f1ff8dc1cbd1
     pristine_git_object: d24316eb70bf7811a116aa024a686dfafb5f2fed
   internal/sdk/models/shared/listworkspacesbyteamresponse.go:
     id: 23e9de36d41a
-    last_write_checksum: sha1:2bdfed1155b2eae7edc2d59ef575a82645ba3276
     pristine_git_object: 09b34166edf51779a150e3b53cfcaf661d98325d
   internal/sdk/models/shared/listworkspacesresponse.go:
     id: f9de274aae98
-    last_write_checksum: sha1:548a6f80457c27bb90cec5e33b5f465129c38670
     pristine_git_object: 1eb32c161a810efa542b49b594ecb9382ef3f308
   internal/sdk/models/shared/localplatformmetainfo.go:
     id: 83aa560b3a83
-    last_write_checksum: sha1:264bfdc37ad29e54ba44580b309924c204d1eaf6
     pristine_git_object: e05cf95d0e43afbc6526e19b34f1832ff2868879
   internal/sdk/models/shared/log.go:
     id: e1b3f1b742c6
-    last_write_checksum: sha1:a3e230c79f8cd64e8d4b5bd1177f3908e7f26ddc
     pristine_git_object: f818718e330199cb26552b8baa0cb9c772a92ec5
   internal/sdk/models/shared/logpage.go:
     id: 0cf625998f99
-    last_write_checksum: sha1:994d5f8b9e0b9d8082b95cd7d9e76aa65a257a37
     pristine_git_object: 4a3e765ac8a2b1a2ec69895c19d6fd947bb170f7
   internal/sdk/models/shared/logpagedownload.go:
     id: 6b1375e92968
-    last_write_checksum: sha1:39710556f54e59d622d787b61a9903024f6c978d
     pristine_git_object: 26b3bbf325408f55485076ebeb3735ff106e85b9
   internal/sdk/models/shared/managedcomputececomputeconfiginput.go:
     id: b61b6426185b
-    last_write_checksum: sha1:464de170c882dea69c0112add0b8fe7df6f55e5a
     pristine_git_object: c42c622e89e5569eeae7f55d32b4b51e9d21655c
   internal/sdk/models/shared/managedcredentialsdbdto.go:
     id: 1c90d0daeff5
-    last_write_checksum: sha1:f783e52fefe66aa8b3eb568069e704e195bc412b
     pristine_git_object: 8926add559a35c9aa0b6d5a3a1c261af7e62e717
   internal/sdk/models/shared/managedcredentialsmetadata.go:
     id: 0a7c92f07638
-    last_write_checksum: sha1:37f00df0d6822effe3e3b1a1a06e2c5ff2757a9b
     pristine_git_object: 115954fc987778ca0272c5914679b623faa5d785
   internal/sdk/models/shared/managedcredentialsmetadatainput.go:
     id: 416232b58f1f
-    last_write_checksum: sha1:b94500479922379ca8181bfeb45f10f1982b6db6
     pristine_git_object: accafd2fcef84aace4df38dca8759d97afbef306
   internal/sdk/models/shared/managedidentitydbdtoabstractgridconfig.go:
     id: 7b0feeadbd91
-    last_write_checksum: sha1:9b28bb483d86f7f4c6658a2bfb946462d1ceb7ef
     pristine_git_object: 852fb4270ad4b7919df4c204da17d3c627bb0700
   internal/sdk/models/shared/memberdbdto.go:
     id: 35794a08491e
-    last_write_checksum: sha1:c630aa94b9b4591a721158c7ae8356630121c57a
     pristine_git_object: bc829d8840721d025fe69676064eec6f900539ae
-  internal/sdk/models/shared/mountdata.go:
-    last_write_checksum: sha1:771948d660df5bd349762049544e4d708fedcfd0
+  internal/sdk/models/shared/mountdata.go: {}
   internal/sdk/models/shared/multirequestfileschema.go:
     id: bb5e470b2566
-    last_write_checksum: sha1:e131dbbeb3fb6bfb08278ee10218dd2baa01e4d1
     pristine_git_object: e48da9a12e6c46e353a24de39c5062f0dfe58fc8
   internal/sdk/models/shared/navbarconfig.go:
     id: 11092f5f6e30
-    last_write_checksum: sha1:d172e3e260a31d7fd14d043b18a00fd0b8f97bea
     pristine_git_object: 80b633099d7cb4becd9b09b5a2f155e2a4a96367
   internal/sdk/models/shared/navbarconfignavbarmenu.go:
     id: d2ca73000c3c
-    last_write_checksum: sha1:9a2f8defc0e008d652279d105f04e481f7eb6d96
     pristine_git_object: 96fe8509792dfcfb76aabdfd947955fee6620a41
   internal/sdk/models/shared/organdworkspacedto.go:
     id: f163e4764451
-    last_write_checksum: sha1:c30b1c1d5765248c2e997bf65154ff57a4d0bda6
     pristine_git_object: a55f3e71026d76874a738065ff056f574e26b3a4
   internal/sdk/models/shared/organization.go:
     id: e4f0dc144992
-    last_write_checksum: sha1:5f9685f8292f831e70393dd24302065501a5fd17
     pristine_git_object: 091ec3592a1e043eadd2c56b5f515056df1fc71c
   internal/sdk/models/shared/organizationdbdto.go:
     id: 743698f7345f
-    last_write_checksum: sha1:c81dbc1ac62072a30d42e3a4a71f4259b39b44c5
     pristine_git_object: ed662ad9da6e6efcb588e485cc1d4c41d50ee43e
   internal/sdk/models/shared/organizationquotas.go:
     id: 653380a41b95
-    last_write_checksum: sha1:133d7300428289eebe6dcbe52a06069bca947f00
     pristine_git_object: 4d5ba2552e9c82854928307286b0ff6ee507b39f
   internal/sdk/models/shared/orgrole.go:
     id: ed5779593dea
-    last_write_checksum: sha1:820cf69533ff038e0e35b2b6bb57f55dfe362345
     pristine_git_object: 216f13d193ab1137d827a87061058aa6aa0f239a
   internal/sdk/models/shared/orgtype.go:
     id: 4a0bba33099f
-    last_write_checksum: sha1:665b83346cf34fb9329e6ba5d013d24876b6f3e8
     pristine_git_object: 13fe96a8021598c1f6b21b80139bf9c9d637b881
   internal/sdk/models/shared/participantresponsedto.go:
     id: 395d9018c66e
-    last_write_checksum: sha1:d811e435032454e1df3bdfcbeffc23f3729ea84d
     pristine_git_object: abb39bee1d289db94cf26b2b8eb6a5e923d85cbe
   internal/sdk/models/shared/participanttype.go:
     id: 4b24861c8c3d
-    last_write_checksum: sha1:d550a24a73103f41647e234ff2c8ebb522f3fa5b
     pristine_git_object: 37ce998cf58b840e48da44d7bb0cb29e5143108f
   internal/sdk/models/shared/pipelinedbdto.go:
     id: ab8ad3b3fa8a
-    last_write_checksum: sha1:9cef5e5326369cc5dfa5035f0b6435e8539d06ad
     pristine_git_object: 4e92c835cc6c6b1bf6fff9027a42ca0ea78dabf7
   internal/sdk/models/shared/pipelineinfo.go:
     id: 4179c13facd2
-    last_write_checksum: sha1:43016833a1170cbcb62f211378f290f804cdbd78
     pristine_git_object: 0a1420177bd0ed88993580aa7879f848a284fe60
   internal/sdk/models/shared/pipelinelistparamssortby.go:
     id: 277000176aeb
-    last_write_checksum: sha1:15005d073899d5b8703d7853e79297d9b4c3fc2e
     pristine_git_object: 777dc0f24c0d0a18b2a6d0d7f3ffba0b0cba1ffa
   internal/sdk/models/shared/pipelinelistparamssortdir.go:
     id: 837befa2c548
-    last_write_checksum: sha1:5c74f5d1a349a6a3251f3661d7b7d91f5e58b99b
     pristine_git_object: 626e4afe7ec0bb32293d24647057fc61b6bb4a6b
-  internal/sdk/models/shared/pipelinemininforesponse.go:
-    last_write_checksum: sha1:b220f430f15e68a387c91598b848579c4af2de37
-  internal/sdk/models/shared/pipelinemininforesponsepipelineversionmininforesponse.go:
-    last_write_checksum: sha1:e7bde2c2aa5bad0a264a749179597cf68d18699f
+  internal/sdk/models/shared/pipelinemininforesponse.go: {}
+  internal/sdk/models/shared/pipelinemininforesponsepipelineversionmininforesponse.go: {}
   internal/sdk/models/shared/pipelinequeryattribute.go:
     id: 5b59269d409b
-    last_write_checksum: sha1:ff1b252c2da88d43cdd4bef5f31f141fe8b768b6
     pristine_git_object: cae45209138e53b7aa1de2f73f2c76df09bb7ad2
   internal/sdk/models/shared/pipelineschemaattributes.go:
     id: e88d32017f8e
-    last_write_checksum: sha1:56b3fee17dfc69b7f6a0076cb6311b617b408c86
     pristine_git_object: aa8e545c55aef8a9e9ccb5df7d7088c2c06ace42
-  internal/sdk/models/shared/pipelineschemadbdto.go:
-    last_write_checksum: sha1:15df7d3b830337e8f99030b53607d7a99306371c
+  internal/sdk/models/shared/pipelineschemadbdto.go: {}
   internal/sdk/models/shared/pipelineschemaresponse.go:
     id: 068f82900c1e
-    last_write_checksum: sha1:bea9d222372994f452b36e46286b8ce363e86078
     pristine_git_object: 1f895b70c2e20ba9367564b4ad4988b15654737d
   internal/sdk/models/shared/pipelinesecret.go:
     id: 7a4e83a4b916
-    last_write_checksum: sha1:d33412b9e9a2f480e9e8c9afe926ab69a17651f7
     pristine_git_object: d44a6507099d85a8c4d8d8c4911795888ae623cf
-  internal/sdk/models/shared/pipelineversionfullinfodto.go:
-    last_write_checksum: sha1:21f400ef7bc05284d947fc876e9cd497b432bfa2
-  internal/sdk/models/shared/pipelineversionmanagerequest.go:
-    last_write_checksum: sha1:4460d81e975fa6cc4e92cd27a67db5aaa2a1f4ca
+  internal/sdk/models/shared/pipelineversionfullinfodto.go: {}
+  internal/sdk/models/shared/pipelineversionmanagerequest.go: {}
   internal/sdk/models/shared/platformmetainfo.go:
     id: 9c55ebf6564b
-    last_write_checksum: sha1:009bbb41e32ddb120a023602e3d6278bd2686994
     pristine_git_object: 7a6a7a43120ad13ae83b1daefb5377910690c39c
   internal/sdk/models/shared/podcleanuppolicy.go:
     id: c7e8da39155a
-    last_write_checksum: sha1:dc210c6ebcceaae7c27d1b37d9f0d2ab24e0aa20
     pristine_git_object: 3836239e9f0fe18773ebbf5fb9ad17e20eeba074
   internal/sdk/models/shared/processload.go:
     id: f5d885d8d805
-    last_write_checksum: sha1:b482449aa29e069193c30b338b33a9f12a81054b
     pristine_git_object: dfad302503d5b0805bcc9fba1749ec248c333354
   internal/sdk/models/shared/progressdata.go:
     id: e6d38d47bbbf
-    last_write_checksum: sha1:20b6abdca583de4af543f03b3a04bf8845609e60
     pristine_git_object: 8f74c4af32b53bb789f6f1af569f22d22c2e2163
   internal/sdk/models/shared/providertype.go:
     id: f4e6c685bed2
-    last_write_checksum: sha1:7a64b47a997024f82a3d6a0831a4364758308a07
     pristine_git_object: dfd50f48bf5d2562210c79988837c5178a1e315f
   internal/sdk/models/shared/randomworkflownameresponse.go:
     id: ad51c7db1e49
-    last_write_checksum: sha1:ccf1675ce63128cea9025f9e53c03518a6443706
     pristine_git_object: a039dd2bbe0e72b25a8c8592121da4e81992a7bd
-  internal/sdk/models/shared/resourceallocation.go:
-    last_write_checksum: sha1:4068443a103aa165da6bb2efba4cafe930d3fdbb
+  internal/sdk/models/shared/resourceallocation.go: {}
   internal/sdk/models/shared/resourcedata.go:
     id: c390aa593bc1
-    last_write_checksum: sha1:dd49583273ffd4269c639808a82b4fd7830a4378
     pristine_git_object: 0f1a811a5e550def410f370cd8546ecead0b9ae3
-  internal/sdk/models/shared/roledto.go:
-    last_write_checksum: sha1:1b77f7de243b242e050e85390f6d6b2d59badaeb
-  internal/sdk/models/shared/rolepermissionresponsedto.go:
-    last_write_checksum: sha1:6965d46468fb40f86ada57b7441a4b08e68fff76
+  internal/sdk/models/shared/roledto.go: {}
+  internal/sdk/models/shared/rolepermissionresponsedto.go: {}
   internal/sdk/models/shared/runid.go:
     id: 2dd23e7f9e55
-    last_write_checksum: sha1:f4d810d16227554ebc66ec269bc1ca07bbc96f12
     pristine_git_object: 9a98af5d427ea54aa5c3553b4ef67ab706cd8c4c
   internal/sdk/models/shared/runlistresponse.go:
     id: f79031cadba6
-    last_write_checksum: sha1:ef3e3eecf0a3bce61b5f086671b3bd45de915395
     pristine_git_object: 1f1689cceeb8c1b44a00348e5af09b06e5f9d448
   internal/sdk/models/shared/runlog.go:
     id: c1067ba6c935
-    last_write_checksum: sha1:b94d3f66aaabc57183d7fa18577453f6b955c14d
     pristine_git_object: 310c567ba89f3a453fa7947d32dc4641a971e56d
   internal/sdk/models/shared/runrequest.go:
     id: f403faf2fd3d
-    last_write_checksum: sha1:b22b4a63553baf2bec2be70e2a0c61ccf7295f6e
     pristine_git_object: 00e0ca8f04c46e396f247acb20a6216870e09497
   internal/sdk/models/shared/runstatus.go:
     id: e2f3cbb7ae20
-    last_write_checksum: sha1:747d1ea1ccfe36e7f1f5cfe7bc237b01a2fbfd58
     pristine_git_object: d4ae89cfca8f1a8d235ef8339bc449e64e31d3f3
-  internal/sdk/models/shared/schedconfig.go:
-    last_write_checksum: sha1:aa82346a4f4c1bfc58d714ab18fed45072d2a596
+  internal/sdk/models/shared/schedconfig.go: {}
   internal/sdk/models/shared/security.go:
     id: 9098af98367e
-    last_write_checksum: sha1:7d9694f1ffd9b3ff53fcc16dff2d625d3e677d60
     pristine_git_object: 9ed88ed95ffd6ee743ce250b2c9f3528d60e7b88
   internal/sdk/models/shared/securitygroup.go:
     id: 7e7e34abe0c5
-    last_write_checksum: sha1:f3d8660517ea37616675c53f3a09120d7baec2b4
     pristine_git_object: f8f84a647fb41e4699edeabb4e9de5a3ef96862f
   internal/sdk/models/shared/securitykeys.go:
     id: 3647791ccf11
-    last_write_checksum: sha1:e025b3410c260a19441bdf2a890039e5a2c947df
     pristine_git_object: d3f44a479e97fb40e5dd5d7368755cf3b6bc322d
   internal/sdk/models/shared/seqeracomputecloudinstancetypesize.go:
     id: 74042e18e0e1
-    last_write_checksum: sha1:5311fff087cef22a757c3cc7123bd1706b8b1223
     pristine_git_object: dbc4620b157442c58c43439125bc2c7392e8c935
   internal/sdk/models/shared/serviceinfo.go:
     id: 18e2052471c9
-    last_write_checksum: sha1:636410aefaafac2965d8319c280a8136ca6f45b4
     pristine_git_object: 0008df58bab87596da85d9faec7d40db61fdb705
   internal/sdk/models/shared/serviceinforesponse.go:
     id: c3defb5867b6
-    last_write_checksum: sha1:2f7c54da05bef4ce33cd31f2a8737546f4e03989
     pristine_git_object: b5c4b72bb15e4d5db70f09634a5933e3abaa38ea
-  internal/sdk/models/shared/sourcetype.go:
-    last_write_checksum: sha1:ea64a9a80ba3aa84a9456d30ebda502a9e93d50c
+  internal/sdk/models/shared/sourcetype.go: {}
   internal/sdk/models/shared/sshcredential.go:
     id: 1a87a201cd9a
-    last_write_checksum: sha1:45bf59c4261b4700c6341e5288009a0ea6cffe9c
     pristine_git_object: 06ae72e7724d5f0464c0c5511d9131ed83732dee
   internal/sdk/models/shared/state.go:
     id: 9ab3d61a9713
-    last_write_checksum: sha1:77950bf0648143ed4864996eb19bfe60e8ab3d2c
     pristine_git_object: d28ac74304296ae9087c0ac933948eda8c4c55b1
   internal/sdk/models/shared/studiocheckpointstatus.go:
     id: 9c451637265e
-    last_write_checksum: sha1:559ec8cfb52d8b1cc50be9dd37c386f0d709f9aa
     pristine_git_object: e89a32e94505a1a8c19a8da814c7120319e1716a
   internal/sdk/models/shared/submitworkflowlaunchrequest.go:
     id: a88f0bc5be47
-    last_write_checksum: sha1:750cc528a39c3e79f3703d5d0a21c5f03bc1f32f
     pristine_git_object: f19fe72bd54181f07f5c691e10297908bdf4f749
   internal/sdk/models/shared/submitworkflowlaunchresponse.go:
     id: 8ebba35bccf1
-    last_write_checksum: sha1:ea6336f982129c1a11e0219eb37dba64010f7dcd
     pristine_git_object: 1a85bba27986e83f2a728074d6dc444392600f6f
   internal/sdk/models/shared/subnet.go:
     id: da1fc873837b
-    last_write_checksum: sha1:08039aa2cc9e01625d9c2db6d605efd932cc7a99
     pristine_git_object: bbac02ad6533237c15c11bcf58413b6b33584035
   internal/sdk/models/shared/task.go:
     id: ebbf5622a904
-    last_write_checksum: sha1:c35ae3b1e842f2851d85aa7c9635be4ae890d0c3
     pristine_git_object: cc080e2454e015b6817959c0cbe8475372cbf7dd
   internal/sdk/models/shared/taskstatus.go:
     id: 2313fd64b531
-    last_write_checksum: sha1:f5142d6885922fe46b7cb28eaff424e3f5937c66
     pristine_git_object: de71c53149bac56bdea039254d0bdaef80be7b2b
   internal/sdk/models/shared/team.go:
     id: 5078781d2658
-    last_write_checksum: sha1:5434046cb30e7f858dbaa43a147890511d80bdb1
     pristine_git_object: 7792f7a7084c873bb4eb1d650777802ad5763a71
   internal/sdk/models/shared/teamdbdto.go:
     id: ee24b7228b4c
-    last_write_checksum: sha1:5ee65fcd74fb7d074c78477211df7cf29acaaae1
     pristine_git_object: c7ecedae2f88deb2e9c68175ace0168cfbbc006b
-  internal/sdk/models/shared/teamtype.go:
-    last_write_checksum: sha1:dd76c8622f69f1fe12881e71323ccd25f842e2a4
+  internal/sdk/models/shared/teamtype.go: {}
   internal/sdk/models/shared/toweragentcredential.go:
     id: 9035b6976eb3
-    last_write_checksum: sha1:4bf7e1b86afe887ace0618514a52b5f79efeae01
     pristine_git_object: df7b2a4139a0d7d29eba4b5e4bfc4cf25af30f96
   internal/sdk/models/shared/tracebeginrequest.go:
     id: 14c21c68d13b
-    last_write_checksum: sha1:c28234069f71e35c33a69b85080f980b07d42ef1
     pristine_git_object: ca89d9361eaaac4dd4ca92b5eab695b1cb9f6ed0
   internal/sdk/models/shared/tracebeginresponse.go:
     id: 61d6797554ac
-    last_write_checksum: sha1:1aa3dc7d8c565ca40bc51b7beb29439e5cb9419a
     pristine_git_object: 07a7851e2ce7ec84db0a19a5abe940bed88f9474
   internal/sdk/models/shared/tracecompleterequest.go:
     id: ed2809b2abeb
-    last_write_checksum: sha1:97c5907e5abd005f08290e99b8c9131f9c9e29ce
     pristine_git_object: 2bad0176f68e8c1533a3ba7a445c730e8fb22203
   internal/sdk/models/shared/tracecompleteresponse.go:
     id: 21433f9f0d09
-    last_write_checksum: sha1:01e6216f7d4de8a5c32ac40b10210f3d3b45cf9b
     pristine_git_object: 94bf55dfd636af325631e4e8a063e17f22d90185
   internal/sdk/models/shared/tracecreaterequest.go:
     id: b7dc628fc204
-    last_write_checksum: sha1:07f7ac150f75274781c5fad81c8e4ac2c3958a27
     pristine_git_object: 6cf8104575927b86080a3dfe6ef17fb4ed1a9d02
   internal/sdk/models/shared/tracecreateresponse.go:
     id: 344d3f130cca
-    last_write_checksum: sha1:7db726eccebe93f0d243600079a8dfbcc406abee
     pristine_git_object: cb84e7d6fabe7ed8b551c2c732f74045d97f06ac
   internal/sdk/models/shared/traceheartbeatrequest.go:
     id: 4af3b0160bc0
-    last_write_checksum: sha1:e5b88e501bf6e40f3768b7747ec170c02d7dd872
     pristine_git_object: 5baa26dc2c0545847eab9b54f1f92222478e5274
   internal/sdk/models/shared/traceheartbeatresponse.go:
     id: 7690a8f8be0e
-    last_write_checksum: sha1:fffb973ce0deaba291a992f2859f488203ade9f4
     pristine_git_object: ca506013ba98c8e83ae394a4a9368e6e42e4c44c
   internal/sdk/models/shared/traceprocessingstatus.go:
     id: e6336f5e5d30
-    last_write_checksum: sha1:5fbcaa1b8dd1ea8422f68ad9d7683f9366fe1c2e
     pristine_git_object: afb30e469a1c8e08f41499bf697ade96ae5725e4
   internal/sdk/models/shared/traceprogressdata.go:
     id: 2afc308a5e6c
-    last_write_checksum: sha1:fa9c862dc549c9c7fae8871120cce201e6c33a03
     pristine_git_object: 2ef76b2359b6e9971cc707f2554d0b9eca0723ba
   internal/sdk/models/shared/traceprogressdetail.go:
     id: e4af54af1966
-    last_write_checksum: sha1:82909064d1384963acef9cf7439793e52300da44
     pristine_git_object: 90a95b54a2516965dd0a8ba22f73897dd2687354
   internal/sdk/models/shared/traceprogressrequest.go:
     id: 25df72fd4832
-    last_write_checksum: sha1:4f571d9ef9b09638e58416c43879a5a6529b91e0
     pristine_git_object: 68d18f2b5d00aa08ad185ff9dba2cb4863ea8d66
   internal/sdk/models/shared/traceprogressresponse.go:
     id: 1379598073a7
-    last_write_checksum: sha1:d0427947615c7c21952ca955a183b45a5f82846f
     pristine_git_object: df0e25bf5dcb57896c10e2e781522b8b5fef05c7
   internal/sdk/models/shared/updateactionrequest.go:
     id: 9f97f091423d
-    last_write_checksum: sha1:86010a054529ceb20b2216d88cdd4e0701aaca00
     pristine_git_object: 44d1c2364849e064e9cdc3652ba65ee6c1af0f83
   internal/sdk/models/shared/updateawscredentialsrequest.go:
     id: da5abce18ae5
-    last_write_checksum: sha1:c64c8697d4ac2695f122a2a8c57c77ab824a41c8
     pristine_git_object: f7c3d8badf7396ba242541f67049c35fafd7bb27
-  internal/sdk/models/shared/updateazurecloudcredentialsrequest.go:
-    last_write_checksum: sha1:08f2793ca58776fbc16f84d7be807c524cb8c28c
+  internal/sdk/models/shared/updateazurecloudcredentialsrequest.go: {}
   internal/sdk/models/shared/updateazurecredentialsrequest.go:
     id: 0892be61b088
-    last_write_checksum: sha1:484666d871bc632234c71f9d402cb246fbe02199
     pristine_git_object: c0ad7c694e25294a39a07128bc35469c1414061d
-  internal/sdk/models/shared/updateazureentracredentialsrequest.go:
-    last_write_checksum: sha1:25c715c6aea065916e388ecf9670a2e69a09f52f
+  internal/sdk/models/shared/updateazureentracredentialsrequest.go: {}
   internal/sdk/models/shared/updatebitbucketcredentialsrequest.go:
     id: f4cedea3a54a
-    last_write_checksum: sha1:a8e78f45971fb056b44e0e12a25f4bb445b455a8
     pristine_git_object: 323d719afc11f3d37760cc4e1c6f3248e65c402e
   internal/sdk/models/shared/updatecodecommitcredentialsrequest.go:
     id: ac5507964e0f
-    last_write_checksum: sha1:62130cd0fdce7e042434dd7981f5f7b7707c1ff1
     pristine_git_object: 245fb4f4cf67f1ac7a7e6c66682dd975b09af670
   internal/sdk/models/shared/updatecomputeenvrequest.go:
     id: 3d22c31fbcec
-    last_write_checksum: sha1:e760b9b5fd40cde23f65c820b11e15ae35e05dcf
     pristine_git_object: 3ae5ab866483d41e97c3dbc2d62506601f5a13b9
   internal/sdk/models/shared/updatecontainerregistrycredentialsrequest.go:
     id: 304e08820dd7
-    last_write_checksum: sha1:8e713e0699a968ff31aee82caee0c7a013f954ff
     pristine_git_object: 14f85ae55a34ff6cf2b95d380c9c484a865a2d4d
   internal/sdk/models/shared/updatecredentialsrequest.go:
     id: c4485310afcc
-    last_write_checksum: sha1:ef6abcd30f102dda2b1a7a8b01fecf2762d83b14
     pristine_git_object: 8b36df5b28704350030aaed7f182b4ab285119d8
   internal/sdk/models/shared/updatedatasetrequest.go:
     id: d2466c97e271
-    last_write_checksum: sha1:8194e7a7441b0872fb5150b9a97c51617911023e
     pristine_git_object: 8f9b63c9e27a9788967945078e43c0d86e2673e4
   internal/sdk/models/shared/updategiteacredentialsrequest.go:
     id: a0e01a63f60b
-    last_write_checksum: sha1:6aed2817e64b94fe63a29e9c1c67664f14b7a2c6
     pristine_git_object: 48f41016ae3ddb1d4b5ec5a2df6b826290df5b65
-  internal/sdk/models/shared/updategithubappcredentialsrequest.go:
-    last_write_checksum: sha1:433a419256a058a6552565d0f160e31bd4bc8713
+  internal/sdk/models/shared/updategithubappcredentialsrequest.go: {}
   internal/sdk/models/shared/updategithubcredentialsrequest.go:
     id: 11d125e6edf5
-    last_write_checksum: sha1:fe1cb3b65e8bbeb0371fc8f797d99f986cc227d2
     pristine_git_object: bf3c5748b2cc8decfe4c6d43d50ebbe8d6e87950
   internal/sdk/models/shared/updategitlabcredentialsrequest.go:
     id: 8305e24a4e87
-    last_write_checksum: sha1:02366437f3106501374cfe9fcacf7d0ac2245adf
     pristine_git_object: 1c81c6cde0116456e66790be1e1ce79051fffc2b
   internal/sdk/models/shared/updategooglecredentialsrequest.go:
     id: 1cf52e7003be
-    last_write_checksum: sha1:03a9103b9eeb655908db9b64f0413a9ba907f9df
     pristine_git_object: 34ab44e2924342389999601f6a62951bc10a2023
   internal/sdk/models/shared/updatekubernetescredentialsrequest.go:
     id: 1de1a8545f1b
-    last_write_checksum: sha1:1a5585b047f26e12e4fd541827be29f29798887f
     pristine_git_object: 6d3ba8783edec9d75205a1171e54ee29192bcee2
   internal/sdk/models/shared/updatelabelrequest.go:
     id: 6c18ff9a46b8
-    last_write_checksum: sha1:875bb5a7a3f3a098430b100e03a630af6afa002f
     pristine_git_object: a153cb823cd0d08cce13ab5734aaa114d4a6e420
   internal/sdk/models/shared/updatelabelresponse.go:
     id: 9fe555da4e29
-    last_write_checksum: sha1:359ec1967a8801f5467531209e099795be96043c
     pristine_git_object: 3c581dde1bd99c00e7b89b354ad1350a22fc1ce1
   internal/sdk/models/shared/updatemanagedcredentialsrequest.go:
     id: e19c8cca1f25
-    last_write_checksum: sha1:4111ab46ecceff5b634d5e0ffade3db58593505d
     pristine_git_object: 2c8b4a8e255648c55aa1b04921e3e4e2292082e6
   internal/sdk/models/shared/updatemanagedidentityrequest.go:
     id: 7ed5af927185
-    last_write_checksum: sha1:45560959a30683e166ad39731a953f5307fea6f1
     pristine_git_object: 4c09f778f4d9b65d99a0d485f7ef0887d8a333c3
   internal/sdk/models/shared/updatememberrolerequest.go:
     id: 3a7cc7acde0c
-    last_write_checksum: sha1:dbfc52a1faf4cce85c8b5836ba9e7fc931787202
     pristine_git_object: c43a83e84f1675dc9a3bd95f2961f46a12593b78
   internal/sdk/models/shared/updateorganizationrequest.go:
     id: 4d527a4553ed
-    last_write_checksum: sha1:3fd7f8e5607291d81fd5d26f752d44dc9480b3be
     pristine_git_object: 6d42bca84a10c4ad767a82277bbda0d94d20ccde
   internal/sdk/models/shared/updateparticipantrolerequest.go:
     id: 50863f8feb09
-    last_write_checksum: sha1:4fad7eaffce0e440c0c3f57849b2db754b30ac6f
     pristine_git_object: 89b75ad334c76f6351c04d2448a9eac2436126d3
   internal/sdk/models/shared/updatepipelinerequest.go:
     id: ae98460d91cd
-    last_write_checksum: sha1:48185becb66d3be9797e44b7a857a61226fb7737
     pristine_git_object: d757e0edd2cbb38767a871823c2723adf9a273c6
   internal/sdk/models/shared/updatepipelineresponse.go:
     id: 1c80175b04c8
-    last_write_checksum: sha1:34204fe7af5945dede6b5aafa42d2892302a1916
     pristine_git_object: 2f5cbf1a47262c88cd123f0c980344f1c1be3bd4
   internal/sdk/models/shared/updatepipelinesecretrequest.go:
     id: 196b618004af
-    last_write_checksum: sha1:5fd01feeb7e0ec0a5057d4936aa1c21e3f584784
     pristine_git_object: b83731b94c8d61871174b7633f465ecc3fb4fdd0
-  internal/sdk/models/shared/updaterolerequest.go:
-    last_write_checksum: sha1:e4f0657d008e167c1760e582038288a129233892
+  internal/sdk/models/shared/updaterolerequest.go: {}
   internal/sdk/models/shared/updatesshcredentialsrequest.go:
     id: bf4577c6b87f
-    last_write_checksum: sha1:cb7192c01fad55f1c93a1ec54ed8e0deff25c8e7
     pristine_git_object: 11ee591651b73664cb6b52e8b7b1039cfd01bbcd
   internal/sdk/models/shared/updateteamrequest.go:
     id: 3e926097ef7e
-    last_write_checksum: sha1:ffddccde37d1d92e7f3b8d83e1f106462a0e176e
     pristine_git_object: 682c89b0085195d89c113983e3057b6094efea84
   internal/sdk/models/shared/updatetoweragentcredentialsrequest.go:
     id: 0befec12a31b
-    last_write_checksum: sha1:740b22094d8c1d0ef1c456c0e7c74d4da833989b
     pristine_git_object: 4ce8f63499554d4dc7e3894d27bff4772e6f3d20
   internal/sdk/models/shared/updateworkspacerequest.go:
     id: 8227a1e8e903
-    last_write_checksum: sha1:d1e5fdcd9269bcc7cb8528f66c46784df2cfc3bc
     pristine_git_object: 063be23e99b042a1fccfa2a8fed63659cb066ba6
   internal/sdk/models/shared/uploaddatasetversionresponse.go:
     id: 65c716795cd6
-    last_write_checksum: sha1:8ea88903045e6bbefa5988cc66f81282959bb96f
     pristine_git_object: d3df32e2e30644fbf8be13f57cd07e0ba6818cd9
   internal/sdk/models/shared/uploadetag.go:
     id: e1d6626625fc
-    last_write_checksum: sha1:09a4ce3299f5e13b3baab7afadb07736c1beb8d9
     pristine_git_object: e45aebbd5de7eceabeae6d5be90d33a9622e2846
   internal/sdk/models/shared/upsertuserrequest.go:
     id: 72fc23caa5e9
-    last_write_checksum: sha1:2873dd223ce29e5ba8ee19a4fe1bfc77e20c39d2
     pristine_git_object: a15ea2de68e36fec2b45d7304ba0db60ec298d96
   internal/sdk/models/shared/userinfo.go:
     id: f0ace1ffcd13
-    last_write_checksum: sha1:2b88870645742ffe950d2e9a5b1b81b1753a95af
     pristine_git_object: 57ee3b992288d1366cc52c1ec2e56fd0efdb1f97
   internal/sdk/models/shared/userresponsedto.go:
     id: 70f552c0c33f
-    last_write_checksum: sha1:b03a1caa1abceb00cb1ff73314667beee7ae3daf
     pristine_git_object: edb71a4804774e8b40bf1eaa8a8bbca50b1ba968
-  internal/sdk/models/shared/usersshpublickeydto.go:
-    last_write_checksum: sha1:121d894f1d81546046975275da10fe1f28db897c
-  internal/sdk/models/shared/userworkspacepermissiondto.go:
-    last_write_checksum: sha1:cefe64faf782c2393503905e3b476526d7119a78
-  internal/sdk/models/shared/userworkspaceroledto.go:
-    last_write_checksum: sha1:7ed6fdef9dcf02e20d74f2eb66f6f99f6a849c54
-  internal/sdk/models/shared/userworkspacerolesdto.go:
-    last_write_checksum: sha1:92aee875db7745c6a919abca510420d9c160fd76
-  internal/sdk/models/shared/validateurlrequest.go:
-    last_write_checksum: sha1:8fc59c2a808e1796d85b3113df12dfe0123c303f
-  internal/sdk/models/shared/validateurlresponse.go:
-    last_write_checksum: sha1:c303468a034dee555f827c069662f2042595a314
+  internal/sdk/models/shared/usersshpublickeydto.go: {}
+  internal/sdk/models/shared/userworkspacepermissiondto.go: {}
+  internal/sdk/models/shared/userworkspaceroledto.go: {}
+  internal/sdk/models/shared/userworkspacerolesdto.go: {}
+  internal/sdk/models/shared/validateurlrequest.go: {}
+  internal/sdk/models/shared/validateurlresponse.go: {}
   internal/sdk/models/shared/visibility.go:
     id: 67300ab25b55
-    last_write_checksum: sha1:6a4df30069507cf7fff071fcb545849ee8914afa
     pristine_git_object: de7687ae66f9491e7aa9a21df75b4dee816e3041
   internal/sdk/models/shared/vpc.go:
     id: 9da5f70da25e
-    last_write_checksum: sha1:66d04099fbf6f64bc246fa31b0bd16958bcc721a
     pristine_git_object: 57149c1612bda56bac3ccc3b1b73f1c195a83153
   internal/sdk/models/shared/weserrorresponse.go:
     id: f2e9bf1a6bcf
-    last_write_checksum: sha1:c4fa6179adee798924ea195382747e928ca46dbb
     pristine_git_object: b562bffe27b0109067b6c14098c2104ba03b3bc5
-  internal/sdk/models/shared/wesserviceinfo.go:
-    last_write_checksum: sha1:eca359900be98b1e3d61ff654f19749dddd94979
-  internal/sdk/models/shared/wffusionmeta.go:
-    last_write_checksum: sha1:2cd183abd4736386902dace16cc164e189beb45e
+  internal/sdk/models/shared/wesserviceinfo.go: {}
+  internal/sdk/models/shared/wffusionmeta.go: {}
   internal/sdk/models/shared/wfmanifest.go:
     id: a59fc1c07d43
-    last_write_checksum: sha1:67a93d8160ce15ce66b14f98c6ddc249d33072fc
     pristine_git_object: 5ac309afbe595c9a530c8b6cf12e594711bba806
   internal/sdk/models/shared/wfnextflow.go:
     id: 4f5feca0b805
-    last_write_checksum: sha1:d7cad5bb7f923441ba3ede22daf4c79d927ae21f
     pristine_git_object: 9549b6305ef1546e37e5250f6d28c7d6d0347575
   internal/sdk/models/shared/wfstats.go:
     id: 85e50271aee7
-    last_write_checksum: sha1:6e597db436e4b87263a0cf814fb6999fdc1aa1a4
     pristine_git_object: f43f1d0001435091a6c4b982fce923c16604d4f5
-  internal/sdk/models/shared/wfwavemeta.go:
-    last_write_checksum: sha1:f387b2895aed69dc047ac75996f00eb55604eaa1
+  internal/sdk/models/shared/wfwavemeta.go: {}
   internal/sdk/models/shared/workflowdbdto.go:
     id: e47bdf72a96a
-    last_write_checksum: sha1:951cdc274eaa2f472100b49c9c744daae93ac35f
     pristine_git_object: 3bc4009b3e5d627558d496fdfa955c0de921bde3
-  internal/sdk/models/shared/workflowinput.go:
-    last_write_checksum: sha1:16102510d016ad90544f6b4a708cc1c5d298db3a
+  internal/sdk/models/shared/workflowinput.go: {}
   internal/sdk/models/shared/workflowlaunchrequest.go:
     id: 2b0df021cbad
-    last_write_checksum: sha1:b8122789e52939bfbe454bac4e542b4385151582
     pristine_git_object: 610d44495458858e298def213b53372951961f8e
   internal/sdk/models/shared/workflowlaunchresponse.go:
     id: 58befbe96295
-    last_write_checksum: sha1:0a68fcabe5d65476506ea740b5ba62b55ea8f242
     pristine_git_object: 13b67e02a553d72cb892d94b902fc42711fc730f
   internal/sdk/models/shared/workflowload.go:
     id: 07709e14f2ba
-    last_write_checksum: sha1:c60693618a42330095cd9f377bc2369e8e2bc32b
     pristine_git_object: fe08dfb369e047ca51f57a255ce66cb9741c3bca
   internal/sdk/models/shared/workflowlogresponse.go:
     id: a72344038467
-    last_write_checksum: sha1:90a4051bc431a3973fdf8802dabf0e73fec28ae7
     pristine_git_object: 56d0ef18ecdaf77866c74900461affc550f200c4
   internal/sdk/models/shared/workflowmetrics.go:
     id: 7011b720dc2e
-    last_write_checksum: sha1:dbf3e203b806a8b8e8d2d122f778f26092ab7e56
     pristine_git_object: 19626a7317800294d67ca09c4be933e52c7545ac
   internal/sdk/models/shared/workflowqueryattribute.go:
     id: 78928d95cca7
-    last_write_checksum: sha1:33d3be05adb9edfff8fad8f49e42f2b2a48153e6
     pristine_git_object: 849bcaec15faf1cb62796c21634b4330571f5a2a
   internal/sdk/models/shared/workflowstatus.go:
     id: 357b47045cd2
-    last_write_checksum: sha1:9d6763980116dc140cbf17fa4ebcaa5005db1f50
     pristine_git_object: 3c4a5fc9c65c36bfa47f6f0627643a8dc89d5ee5
-  internal/sdk/models/shared/workflowtypeversion.go:
-    last_write_checksum: sha1:d19bce102f9147906f8ece3c89db8f9b7e03786e
+  internal/sdk/models/shared/workflowtypeversion.go: {}
   internal/sdk/models/shared/workspace.go:
     id: e51ad67224b2
-    last_write_checksum: sha1:4bb38b0a3e4c417958a82d338393726b3d8fca67
     pristine_git_object: 112cad1c5a5eab2368f338715ebe28dc1f993f89
   internal/sdk/models/shared/workspacedbdto.go:
     id: 163affec0c67
-    last_write_checksum: sha1:e3592c55afb255ced942abdbfa035401c79791f5
     pristine_git_object: ab4968045f5c87a8c5ec8df1a438af66536cd8b7
   internal/sdk/models/shared/workspaceparticipantresponsedto.go:
     id: b31a7a242ffd
-    last_write_checksum: sha1:7007a769d01a6d2a623311590445a854aee10659
     pristine_git_object: f36c85c944a8707c4e63584a6767cfdd9b539cb9
-  internal/sdk/models/shared/wsprolesourcetype.go:
-    last_write_checksum: sha1:8651e150485722ac0b90360d96005a5c0518bac1
+  internal/sdk/models/shared/wsprolesourcetype.go: {}
   internal/sdk/optionalnullable/optionalnullable.go:
     id: 4b83aa3f3df3
-    last_write_checksum: sha1:d6aff1a420c31e025ea21d46cf056e305ae76fe8
     pristine_git_object: c6739be0619b6726565e0f11855ffe44b0e5607e
   internal/sdk/optionalnullable/optionalnullable_test.go:
     id: 3920a41dfc4c
-    last_write_checksum: sha1:2e9433eff1651ac77d6678ea76880d9a4980cbc2
     pristine_git_object: e6e5a01c6e721e879e24a38a1f97e3e27d4686d4
   internal/sdk/orgs.go:
     id: b443341f8fef
-    last_write_checksum: sha1:78ba69b471fa008eb1b49cdc5a80c73e7de1c619
     pristine_git_object: 05f3f4ec06f44d5212ea663d306bdf51c30024d9
   internal/sdk/pipelines.go:
     id: 64e6650df2cf
-    last_write_checksum: sha1:3fed290d5c10cdaaa1839d2031de6ed7170e5502
     pristine_git_object: 69fc62f69e5ed13ea997427572422dbdbfd632b1
-  internal/sdk/pipelineschemas.go:
-    last_write_checksum: sha1:29ff604083f3843a8a7b7ad883473cbb9f3c484a
+  internal/sdk/pipelineschemas.go: {}
   internal/sdk/pipelinesecrets.go:
     id: 0d183f1e5ea3
-    last_write_checksum: sha1:733f0b6ab571a4c05488973729194c2a37208bad
     pristine_git_object: 2188dfe7a0cabe59810364096f7a645011f7d2b5
-  internal/sdk/pipelineversions.go:
-    last_write_checksum: sha1:f77c5a24cfabf728db79a020cc2f5438846efe3d
+  internal/sdk/pipelineversions.go: {}
   internal/sdk/platforms.go:
     id: 517ff966abb5
-    last_write_checksum: sha1:c91c77264cacb252d0ace0ba284a2b4a50658392
     pristine_git_object: d07fa87cfd1375e9b69b5bf95f4cce5884a4f4f4
   internal/sdk/retry/config.go:
     id: 7ea5fa9128b6
-    last_write_checksum: sha1:102d1953fbd7e9f312c4442c71ccca2eaaeaa27d
     pristine_git_object: aa809fccb3445b1e2530a979dad620512f50e70f
-  internal/sdk/roles.go:
-    last_write_checksum: sha1:4254ac7cabfdf1410c8e69888cc51a81318bbfb4
+  internal/sdk/roles.go: {}
   internal/sdk/seqera.go:
     id: b1c23bc5193c
-    last_write_checksum: sha1:e8cbfe92970cdf40aea8b0d6ac4c282b53c8b225
     pristine_git_object: 89364ed6208c4c999b317d23d7d954d63ac46bc5
   internal/sdk/serviceinfo.go:
     id: 085db9a15b34
-    last_write_checksum: sha1:955467d6b0e5d9097720045f6725ff9a0f54b857
     pristine_git_object: 4ecf30e85a2643beb02282ca8b755fb6227540be
-  internal/sdk/sshkeys.go:
-    last_write_checksum: sha1:bbcb7abc4c8543d7e3b525592da59b25b744f150
+  internal/sdk/sshkeys.go: {}
   internal/sdk/studios.go:
     id: 73a47ef758cd
-    last_write_checksum: sha1:f935d7ad97bd39469f74b23c09d0e86d3347a7b1
     pristine_git_object: 3bc50b8a5605a36ac2b1c3ca4ddc3b14e2877863
   internal/sdk/teams.go:
     id: 02169081f812
-    last_write_checksum: sha1:b09f6daf366d8d795d3c3f22ff933dc053c039b3
     pristine_git_object: fd857515aaf7a995b1d1bb21ac160cffa80808fd
   internal/sdk/tokens.go:
     id: dfb2da414c8f
-    last_write_checksum: sha1:b6be6936de314371fbddad0283cb55147c94d6fa
     pristine_git_object: 1519c6c08b1d1879e90725f85e0511a1a69438d9
   internal/sdk/trace.go:
     id: 636bdeb664c9
-    last_write_checksum: sha1:bf7e08e3d766fcaa98652abad9900d5e3adbb6ff
     pristine_git_object: 76ca08d09b41e5e44850040dc2e111fb7ea70bbf
   internal/sdk/types/bigint.go:
     id: fc530b70337e
-    last_write_checksum: sha1:49b004005d0461fb04b846eca062b070b0360b31
     pristine_git_object: 9c6a086d51595888a6ff787ebcb8693559afee95
   internal/sdk/types/date.go:
     id: c4bff082c66f
-    last_write_checksum: sha1:3036a2e1ed15a1d484c093367eba000c38f384d0
     pristine_git_object: 5b2782f219efe6bfbce46fc2dec68998eb759438
   internal/sdk/types/datetime.go:
     id: a8109857c712
-    last_write_checksum: sha1:196d050af6450669214e9ae4fd28e56263ae2b5d
     pristine_git_object: 3eff332daa04e34cec5ffb10add670bafd8ac454
   internal/sdk/types/pointers.go:
     id: 2f3f971639f6
-    last_write_checksum: sha1:fc2275ea006257ba9ba4ff6f2a2cdb6205371eef
     pristine_git_object: 35c439d2661e08fcb6a854096fd7b9a8561b3938
   internal/sdk/users.go:
     id: 1e7895d789b5
-    last_write_checksum: sha1:5a66183f5dbdc86ed0e375c332a5055c1f0a8d90
     pristine_git_object: 9a5668fa10e470d4ae7faaf5e2d75b1090dbd725
   internal/sdk/workflows.go:
     id: eb945f718741
-    last_write_checksum: sha1:6130ee7325dde6c78276f5d26bd6ccc6a26818ef
     pristine_git_object: 91a3b4d0c0584a32dd833674f6238c44a30dbfd2
   internal/sdk/workflowstar.go:
     id: 74a5346bd7e2
-    last_write_checksum: sha1:0f3c046f29279efacdc94c0084e58acb52a92dce
     pristine_git_object: 7a31812dea055180ae105fa0218d2244299469e0
   internal/sdk/workspaces.go:
     id: 436a1d832809
-    last_write_checksum: sha1:0f5581f360fb5251bfe1867189e49e798ce4c51e
     pristine_git_object: c5824c63bd96905d849ebd2cc9c02a61c73f0e88
   internal/validators/DateValidator.go:
     id: 4fdfa187ab97
-    last_write_checksum: sha1:b9d7786ac1268baa0f7d1cdfca2311a9485551bb
     pristine_git_object: 04ab09d7de51f1c50a72bedeed0ad7483870cb26
   internal/validators/ExactlyOneChild.go:
     id: 66e7bd50b47d
-    last_write_checksum: sha1:ab8e18d1763fbd5b262c3e7d917c81ac40ba839f
     pristine_git_object: 1765a3a0b83d38a6cc8f118ea2cfab67ab44c910
   internal/validators/JSONParseValidator.go:
     id: ce72f37482f5
-    last_write_checksum: sha1:77af551821798350f868410aab90352f7ec7b370
     pristine_git_object: b8bb96b5e0930635eb754f169b3eaf285d48dd1c
   internal/validators/RFC3339Validator.go:
     id: 0cf126c9a956
-    last_write_checksum: sha1:8d9accfc3aa477a74b0f927652f5e2ae3d28061d
     pristine_git_object: f5e61466b5c639cb17d0cb2cfe28611957297ce9
   internal/validators/boolvalidators/not_null.go:
     id: 865145e65396
-    last_write_checksum: sha1:89a7362be9d519ed7c9fb7c4989d273a3aa5f279
     pristine_git_object: 6eca17e0cff87f7682f8baa2cd81cd33bc972f4c
   internal/validators/float32validators/not_null.go:
     id: 330748f4ff91
-    last_write_checksum: sha1:4f0a859aa9d7348056c6559bad9ca336104beaef
     pristine_git_object: c9a8973c7dc830b9c5aac546ea7cbe6021f01629
   internal/validators/float64validators/not_null.go:
     id: 8f5e6362f0f5
-    last_write_checksum: sha1:f2436a4a1323d58ffcff3b153167c4e463325c12
     pristine_git_object: 8f786d278597ffac3c525755e429c9a3caa60b20
   internal/validators/int32validators/not_null.go:
     id: ea876d1f8b07
-    last_write_checksum: sha1:d08335af46ab809d0076da8543b3455662fb66a0
     pristine_git_object: ec9a3f10adfdd29c3cca40e53dc42db329cf37d7
   internal/validators/int64validators/not_null.go:
     id: d3f822eb4c69
-    last_write_checksum: sha1:b5bf5b539f2631813ee8771cf00d8ea9744c6dd3
     pristine_git_object: 707ff9573f026b7b7ee3f59462c7a8ba10a1aba9
   internal/validators/listvalidators/not_null.go:
     id: b3ee156dafa7
-    last_write_checksum: sha1:11f33dfa3cb1b9eadc7e4a8287518135ddae191e
     pristine_git_object: 9b88e520b7d58c14c6844d3dbc26ce4f96d39af1
   internal/validators/mapvalidators/not_null.go:
     id: 9cff80d0791c
-    last_write_checksum: sha1:64117afe6cdb1a0e1b57df970da8df0e18d10442
     pristine_git_object: dc6959e9cdadb16e0e1ea90f98b2d27f2d357b64
   internal/validators/numbervalidators/not_null.go:
     id: b335c948bcf4
-    last_write_checksum: sha1:54d925f13a630f21e14709ce6181e5eaf96bd6e3
     pristine_git_object: 57d4da0ae000f671698384abc550196744884871
   internal/validators/objectvalidators/not_null.go:
     id: dd14631b3a38
-    last_write_checksum: sha1:5f897f5dcd2686d43c9bd683900572a8d7ef6473
     pristine_git_object: bf0189497acb3b1214f2480e9db071186d85ecad
   internal/validators/setvalidators/not_null.go:
     id: e612a6618fac
-    last_write_checksum: sha1:de772bcb14615735a8ebd2a9ffaae06f464a86d5
     pristine_git_object: f859d64810168dd4ec7bfb1ea1c0186c551f8987
   internal/validators/stringvalidators/not_null.go:
     id: 80be7ffedf6c
-    last_write_checksum: sha1:df498b49dd87f9508f3eaec3a63ed0a08ae3c16e
     pristine_git_object: 1e40ac1b6ce68540327e01910f0dc91a60b62607
   main.go:
     id: 0607f785dfa3
-    last_write_checksum: sha1:b0612e435f7e92108d08b8e32e88c655f15feb7e
     pristine_git_object: 3b8f5967920ee401cbd21a5a4df07dfaa11903f8
   terraform-registry-manifest.json:
     id: fc3d63fd06e1
-    last_write_checksum: sha1:45b609f3f65164bc2f00b6e2b24faf64627e15b8
     pristine_git_object: fec2a5691e493a1941bd79b312b3925403a91aa6
   tools/tools.go:
     id: 683390d33800
-    last_write_checksum: sha1:8239addbb5e66af0488adc7dc4aba098e4634d88
     pristine_git_object: 36b25801b3a26b57ee042a610a3c35ca65b1376a
 examples:
   ListActions:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.785.0
+speakeasyVersion: 1.789.0
 sources:
     Seqera API:
         sourceNamespace: seqera-api

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Project Overview
 

--- a/docs-internal/README.md
+++ b/docs-internal/README.md
@@ -19,6 +19,14 @@ Complete reference of Speakeasy OpenAPI extensions for SDK and Terraform provide
 - Usage notes and common patterns
 - Important warnings about non-existent or deprecated extensions
 
+### [STATE_UPGRADER_GUIDE.md](./STATE_UPGRADER_GUIDE.md)
+The **default** pattern for writing state upgraders so prior state upgrades
+cleanly (no "unsupported attribute" errors when the schema drops fields). Covers:
+- When a schema version bump / upgrader is actually needed (rarely)
+- Why hand-stripping removed attributes is wrong, and the framework mechanism behind it
+- The inject-schema + lenient-re-decode pattern (since Speakeasy can't emit `PriorSchema`)
+- Testing against the real schema and end-to-end verification
+
 ## Audience
 
 These guides are for:

--- a/docs-internal/SPEAKEASY_EXTENSIONS_REFERENCE.md
+++ b/docs-internal/SPEAKEASY_EXTENSIONS_REFERENCE.md
@@ -160,7 +160,11 @@ Complete reference of Speakeasy OpenAPI extensions for SDK and Terraform provide
 #### x-speakeasy-entity-version
 - **Purpose**: Specify Terraform resource schema version for state migration
 - **Level**: Schema
-- **Note**: Use sparingly; adding/removing attributes doesn't require versioning
+- **Note**: Use sparingly; adding/removing attributes doesn't require versioning.
+  Only bump for a breaking type change or a rename. When you do bump it, the
+  matching state upgrader **must** follow the default pattern in
+  [STATE_UPGRADER_GUIDE.md](./STATE_UPGRADER_GUIDE.md), or prior state will fail
+  to upgrade with an "unsupported attribute" error.
 
 #### x-speakeasy-entity-description
 - **Purpose**: Provide description for the Terraform resource

--- a/docs-internal/STATE_UPGRADER_GUIDE.md
+++ b/docs-internal/STATE_UPGRADER_GUIDE.md
@@ -1,0 +1,215 @@
+# State Upgrader Guide
+
+How to write `seqera_compute_env`-style state upgraders in this provider so that
+prior state upgrades **cleanly** — without spurious "unsupported attribute"
+errors when the generated schema drops fields.
+
+**This is the default pattern.** Any new upgrader (or edit to an existing one)
+should follow it. The reference implementation is `internal/stateupgraders/computeenv_v0.go`,
+`computeenv_v1.go`, and the injector `internal/provider/computeenv_upgrade_schema.go`.
+
+## TL;DR
+
+1. **You rarely need an upgrader at all.** Speakeasy: *"adding/removing attributes
+   doesn't require versioning"* (`x-speakeasy-entity-version`). Only bump the
+   version for a **breaking type change** or a **rename** — a value transform the
+   framework can't do on its own.
+2. When you do bump the version, the upgrader must return state that decodes
+   **strictly** against the current schema. Do **not** hand-strip removed
+   attributes one by one — that is whack-a-mole and always incomplete.
+3. Instead: do only the genuine **value transforms** on the raw JSON, then
+   **re-decode leniently against the current schema** so every removed attribute
+   is dropped automatically (at any nesting depth, now and on future regens).
+
+## Why this is subtle (the mechanism)
+
+`terraform-plugin-framework` (`internal/fwserver/server_upgraderesourcestate.go`)
+has three upgrade code paths, and they treat unknown attributes **differently**:
+
+| Path | How prior state is unmarshalled | Unknown attributes |
+|------|--------------------------------|--------------------|
+| stored version == current (no migration) | `UnmarshalWithOpts(..., IgnoreUndefinedAttributes: true)` | **silently dropped** |
+| `StateUpgrader.PriorSchema` set | lenient unmarshal → typed `req.State`; you re-map onto current schema | **naturally absent** |
+| upgrader returns `resp.DynamicValue` (raw JSON) | framework calls `DynamicValue.Unmarshal(currentType)` — **no** `IgnoreUndefinedAttributes` | **strict → hard error** |
+
+The raw-JSON path is the "advanced" one, and it is what a hand-written upgrader
+naturally uses. Its output is re-validated **strictly**, so any attribute left in
+the returned state that no longer exists in the schema fails the whole upgrade:
+
+```
+Error: Unable to Upgrade Resource State
+After attempting a resource state upgrade to version N, the provider returned
+state data that was not compatible with the current schema.
+AttributeName("compute_env").AttributeName("config").AttributeName("aws_cloud").AttributeName("enable_fusion"):
+unsupported attribute "enable_fusion"
+```
+
+Two consequences:
+
+- **Removing a field from the schema is legitimate** — the framework even has a
+  built-in mechanism (`IgnoreUndefinedAttributes`) to drop it. It just doesn't
+  apply that leniency to the DynamicValue output path.
+- The failure is path-specific: it trips on the **first** unknown attribute it
+  reaches, so fixing one (e.g. `deleted`) can reveal the next (`enable_fusion`).
+  Enumerating removed attributes never converges as the schema drifts.
+
+Upstream best practice is `StateUpgrader.PriorSchema` (see [HashiCorp: State
+Upgrade](https://developer.hashicorp.com/terraform/plugin/framework/resources/state-upgrade)).
+We can't set it here — see the next section — so we reproduce its effect.
+
+## Why we can't just set `PriorSchema`
+
+`PriorSchema` is a field on the `resource.StateUpgrader` **registration**, which
+Speakeasy **generates** into `*_resource.go` from `x-speakeasy-entity-version`:
+
+```go
+// generated, NOT in .genignore — regenerated on every `speakeasy run`
+func (r *ComputeEnvResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {StateUpgrader: stateupgraders.ComputeenvStateUpgraderV0},
+		1: {StateUpgrader: stateupgraders.ComputeenvStateUpgraderV1},
+	}
+}
+```
+
+Speakeasy emits **no** `PriorSchema` and offers no extension to add one. Editing
+the generated map would be overwritten on the next generation, and adding the
+whole resource file to `.genignore` would freeze it (blocking all future schema
+regens). So we keep the generated registration as-is and reproduce the lenient
+decode **inside the upgrader function**, using the current schema type injected
+from the provider package.
+
+## The default pattern
+
+### 1. Injector (provider package, `.genignore`-protected)
+
+The upgrader functions live in `internal/stateupgraders` (the generated code
+references them by name), but they need the current schema and can't import the
+provider package (import cycle). Inject the schema type at `init()`:
+
+```go
+// internal/provider/computeenv_upgrade_schema.go  (add to .genignore)
+package provider
+
+// One init() registers the schema type of every resource that implements state
+// upgrades — no per-resource wiring. Iterating Resources() keeps this in sync as
+// resources are added.
+func init() {
+	ctx := context.Background()
+	p := &SeqeraProvider{}
+	var providerMeta provider.MetadataResponse
+	p.Metadata(ctx, provider.MetadataRequest{}, &providerMeta)
+
+	for _, newResource := range p.Resources(ctx) {
+		res := newResource()
+		if _, ok := res.(resource.ResourceWithUpgradeState); !ok {
+			continue // only resources with upgraders need their schema registered
+		}
+		var meta resource.MetadataResponse
+		res.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: providerMeta.TypeName}, &meta)
+		var schemaResp resource.SchemaResponse
+		res.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			continue
+		}
+		stateupgraders.RegisterSchemaType(meta.TypeName, schemaResp.Schema.Type().TerraformType(ctx))
+	}
+}
+```
+
+### 2. Shared finalizer + helper (stateupgraders/upgrade.go)
+
+A per-resource-type registry, plus `upgradeToCurrentSchema` — the one entry point
+every upgrader calls:
+
+```go
+var schemaTypes = map[string]tftypes.Type{} // keyed by resource type name
+
+func RegisterSchemaType(resourceTypeName string, t tftypes.Type) { schemaTypes[resourceTypeName] = t }
+
+// upgradeToCurrentSchema is the default state-upgrade implementation. It applies
+// an optional in-place value transform, then re-decodes against the current
+// schema, dropping (via IgnoreUndefinedAttributes, recursively) any attribute the
+// schema no longer defines.
+func upgradeToCurrentSchema(resourceTypeName string, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse, transform func(map[string]interface{})) {
+	var rawState map[string]interface{}
+	json.Unmarshal(req.RawState.JSON, &rawState) // + error handling
+	if transform != nil {
+		transform(rawState)
+	}
+	// marshal → RawState.UnmarshalWithOpts(schemaTypes[name], {IgnoreUndefinedAttributes:true})
+	// → tfprotov6.NewDynamicValue → resp.DynamicValue
+}
+```
+
+### 3. Each upgrader is a one-liner: type name + optional transform
+
+```go
+// No value transform — pure passthrough that drops removed attributes:
+func AwscredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	upgradeToCurrentSchema("seqera_aws_credential", req, resp, nil)
+}
+
+// With a value transform (rename / derived value):
+func ComputeenvStateUpgraderV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	upgradeToCurrentSchema("seqera_compute_env", req, resp, func(rawState map[string]interface{}) {
+		if ce, ok := rawState["compute_env"].(map[string]interface{}); ok {
+			applyComputeEnvV2Migrations(ce) // e.g. azure_batch string -> bool derive
+		}
+	})
+}
+```
+
+Rules of thumb for the transform step:
+
+- **Only encode changes that derive a new value from an old one** — renames
+  (copy old key → new key before finalizing, or the value is dropped), and
+  type/shape changes where the new field must be computed from the old.
+- **Never `delete()` a removed attribute** — the finalizer handles removals. If
+  the only change is a removal, the transform step is empty.
+- The framework does **not** chain upgraders. Each registered version migrates
+  **directly to the current schema**, so a `vN` upgrader must apply every
+  transform from `vN` through to current (share helpers across versions).
+
+## Testing
+
+Put upgrader tests in the **provider package** (`internal/provider`), not
+`internal/stateupgraders` — the schema injection only happens there, and testing
+against the **real** schema is the whole point (synthetic fixtures miss removed
+fields). Mirror the framework's strict check:
+
+```go
+value, err := resp.DynamicValue.Unmarshal(schemaType) // strict — the exact framework check
+// err != nil here is the "unsupported attribute" regression.
+```
+
+Cover: (a) a populated fixture carrying attributes removed in the current schema
+decodes cleanly, (b) surviving attributes are preserved, (c) each value transform
+produces the right result, (d) explicitly-set values aren't clobbered.
+
+**Also verify end-to-end for any real upgrade.** Build the old tagged provider in
+a worktree, `apply` a real resource to produce genuine old-schema state, then
+`plan`/`apply` with the current build and confirm a clean plan. Unit tests with
+synthetic fixtures are necessary but not sufficient — the aws-cloud gap in #228
+was invisible until an e2e run with a populated config.
+
+## Decision checklist
+
+- [ ] Is a version bump actually needed? (rename / type change → yes; add/remove → **no**)
+- [ ] Does the transform step contain **only** value derivations, no `delete()` of removed fields?
+- [ ] Does the upgrader delegate to `upgradeToCurrentSchema(typeName, req, resp, transform)`?
+- [ ] Does every registered version migrate **directly** to the current schema?
+- [ ] Is the new upgrader file added to `.genignore`? (the shared injector auto-registers its schema — no per-resource wiring)
+- [ ] Tests in the provider package, asserting via the strict `DynamicValue.Unmarshal`?
+- [ ] E2E: old tag → real state → current build → clean plan?
+
+## Reference
+
+- Shared infrastructure: `internal/stateupgraders/upgrade.go` (registry,
+  `upgradeToCurrentSchema`, shared transforms), `internal/provider/stateupgrader_schemas.go` (injector)
+- Example upgraders: `internal/stateupgraders/computeenv_{v0,v1}.go` (value transforms),
+  any `*_credential_v0.go` (pure passthrough)
+- Tests: `internal/provider/computeenv_upgrade_decode_test.go`
+- Framework internals: `terraform-plugin-framework/internal/fwserver/server_upgraderesourcestate.go`,
+  `terraform-plugin-go/tftypes/value_json.go`
+- Issue: [#228](https://github.com/seqeralabs/terraform-provider-seqera/issues/228)

--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -83,6 +83,7 @@ resource "seqera_action" "tower_advanced" {
     compute_env_id = seqera_compute_env.aws.id
     work_dir       = "s3://my-bucket/production/work"
     revision       = "master"
+    syntax_parser  = "v2"
 
     params_text = jsonencode({
       input_data  = "s3://my-bucket/input/data.csv"

--- a/docs/resources/azure_batch_ce.md
+++ b/docs/resources/azure_batch_ce.md
@@ -41,6 +41,7 @@ resource "seqera_azure_batch_ce" "minimal" {
       vm_count            = 5
       auto_scale          = true
       dispose_on_deletion = true
+      boot_disk_size_gb   = 100
     }
   }
 }
@@ -64,14 +65,16 @@ resource "seqera_azure_batch_ce" "dual_pool" {
       dual_pool_config    = true
       dispose_on_deletion = true
       head_pool = {
-        vm_type    = "Standard_E8s_v3"
-        vm_count   = 1
-        auto_scale = false
+        vm_type           = "Standard_E8s_v3"
+        vm_count          = 1
+        auto_scale        = false
+        boot_disk_size_gb = 200
       }
       worker_pool = {
-        vm_type    = "Standard_D4s_v3"
-        vm_count   = 10
-        auto_scale = true
+        vm_type           = "Standard_D4s_v3"
+        vm_count          = 10
+        auto_scale        = true
+        boot_disk_size_gb = 100
       }
     }
   }

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -41,6 +41,7 @@ resource "seqera_pipeline" "basic" {
     compute_env_id = seqera_compute_env.aws.compute_env.id
     work_dir       = "s3://my-bucket/work"
     revision       = "main"
+    syntax_parser  = "v2"
   }
 }
 

--- a/internal/provider/computeenv_upgrade_decode_test.go
+++ b/internal/provider/computeenv_upgrade_decode_test.go
@@ -1,0 +1,247 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/seqeralabs/terraform-provider-seqera/internal/stateupgraders"
+)
+
+// computeEnvUpgraders are the two registered seqera_compute_env upgraders. The
+// framework does not chain upgraders, so both must migrate their version directly
+// to the current schema. These tests run against the real schema (registered by
+// this package's init() in stateupgrader_schemas.go), which is the only place the
+// removed-attribute handling can be exercised faithfully.
+var computeEnvUpgraders = map[string]func(context.Context, resource.UpgradeStateRequest, *resource.UpgradeStateResponse){
+	"v0": stateupgraders.ComputeenvStateUpgraderV0,
+	"v1": stateupgraders.ComputeenvStateUpgraderV1,
+}
+
+// runUpgraderAgainstSchema runs an upgrader over priorState and returns the
+// upgraded state decoded as a tfsdk.State against the current schema of the
+// resource built by newResource. The decode uses the framework's own strict
+// DynamicValue.Unmarshal (no IgnoreUndefinedAttributes) — the exact check that
+// rejected old state before this fix — so any attribute the upgrader failed to
+// drop fails the test here.
+func runUpgraderAgainstSchema(
+	t *testing.T,
+	newResource func() resource.Resource,
+	upgrade func(context.Context, resource.UpgradeStateRequest, *resource.UpgradeStateResponse),
+	priorState map[string]interface{},
+) tfsdk.State {
+	t.Helper()
+	ctx := context.Background()
+
+	schemaResp := &resource.SchemaResponse{}
+	newResource().Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema errors: %v", schemaResp.Diagnostics)
+	}
+	schemaType := schemaResp.Schema.Type().TerraformType(ctx)
+
+	priorJSON, err := json.Marshal(priorState)
+	if err != nil {
+		t.Fatalf("marshal prior state: %v", err)
+	}
+
+	req := resource.UpgradeStateRequest{RawState: &tfprotov6.RawState{JSON: priorJSON}}
+	resp := &resource.UpgradeStateResponse{}
+	upgrade(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("upgrader diagnostics: %v", resp.Diagnostics)
+	}
+	if resp.DynamicValue == nil {
+		t.Fatalf("upgrader returned no DynamicValue")
+	}
+
+	value, err := resp.DynamicValue.Unmarshal(schemaType)
+	if err != nil {
+		t.Fatalf("upgraded state failed to decode against v2 schema: %v", err)
+	}
+
+	return tfsdk.State{Schema: schemaResp.Schema, Raw: value}
+}
+
+// TestComputeenvUpgrade_DropsRemovedAttributesAndPreservesData reproduces issue
+// #228: prior state carries attributes removed from the v2 schema — the
+// top-level `deleted` and (this is what the synthetic fixtures originally missed)
+// per-platform fields like `config.aws_cloud.enable_fusion`. The upgraded state
+// must decode cleanly against v2 (removed attributes dropped) while preserving
+// the attributes that still exist.
+func TestComputeenvUpgrade_DropsRemovedAttributesAndPreservesData(t *testing.T) {
+	ctx := context.Background()
+
+	for name, upgrade := range computeEnvUpgraders {
+		t.Run(name, func(t *testing.T) {
+			state := runUpgraderAgainstSchema(t, NewComputeEnvResource, upgrade, map[string]interface{}{
+				"id":             "ce-123",
+				"compute_env_id": "ce-123",
+				"compute_env": map[string]interface{}{
+					"compute_env_id": "ce-123",
+					"name":           "compute_spot_fusion",
+					"deleted":        false, // removed in v2
+					"credentials_id": "cred-1",
+					"platform":       "aws-cloud",
+					"config": map[string]interface{}{
+						"aws_cloud": map[string]interface{}{
+							"region":        "eu-west-2", // still present in v2
+							"work_dir":      "s3://bucket/work",
+							"enable_fusion": true, // removed from aws_cloud in v2
+							"enable_wave":   true, // removed from aws_cloud in v2
+							"ebs_boot_size": 50,   // removed from aws_cloud in v2
+						},
+					},
+				},
+			})
+
+			// Decoding succeeded (removals dropped). Confirm a surviving attribute
+			// was carried across unchanged.
+			var region types.String
+			diags := state.GetAttribute(ctx, path.Root("compute_env").AtName("config").AtName("aws_cloud").AtName("region"), &region)
+			if diags.HasError() {
+				t.Fatalf("reading region: %v", diags)
+			}
+			if region.ValueString() != "eu-west-2" {
+				t.Errorf("expected region preserved as eu-west-2, got %q", region.ValueString())
+			}
+		})
+	}
+}
+
+// TestComputeenvUpgrade_DerivesAzureDeleteJobsOnCompletion covers the value
+// transform: the legacy `delete_jobs_on_completion` string becomes the boolean
+// `delete_jobs_on_completion_enabled`.
+func TestComputeenvUpgrade_DerivesAzureDeleteJobsOnCompletion(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name  string
+		state map[string]interface{}
+		want  *bool
+	}{
+		{"on_success -> true", azureBatchState("on_success", nil), boolPtr(true)},
+		{"always -> true", azureBatchState("always", nil), boolPtr(true)},
+		{"never -> false", azureBatchState("never", nil), boolPtr(false)},
+		{"explicit false preserved", azureBatchState("always", boolPtr(false)), boolPtr(false)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Exercise the v1 upgrader; the v0 upgrader shares the same transform.
+			state := runUpgraderAgainstSchema(t, NewComputeEnvResource, stateupgraders.ComputeenvStateUpgraderV1, tc.state)
+
+			var enabled types.Bool
+			diags := state.GetAttribute(ctx, path.Root("compute_env").AtName("config").AtName("azure_batch").AtName("delete_jobs_on_completion_enabled"), &enabled)
+			if diags.HasError() {
+				t.Fatalf("reading delete_jobs_on_completion_enabled: %v", diags)
+			}
+			if enabled.IsNull() {
+				t.Fatalf("expected delete_jobs_on_completion_enabled to be set, got null")
+			}
+			if enabled.ValueBool() != *tc.want {
+				t.Errorf("expected delete_jobs_on_completion_enabled=%v, got %v", *tc.want, enabled.ValueBool())
+			}
+		})
+	}
+}
+
+// TestComputeenvUpgrade_V0RenamesNvmeFlag covers the v0->v1 rename of the
+// misspelled `nvnme_storage_enabled` flag, carrying its value to the correctly
+// spelled attribute.
+func TestComputeenvUpgrade_V0RenamesNvmeFlag(t *testing.T) {
+	ctx := context.Background()
+
+	state := runUpgraderAgainstSchema(t, NewComputeEnvResource, stateupgraders.ComputeenvStateUpgraderV0, map[string]interface{}{
+		"id":             "ce-123",
+		"compute_env_id": "ce-123",
+		"compute_env": map[string]interface{}{
+			"compute_env_id": "ce-123",
+			"name":           "compute_spot_fusion",
+			"credentials_id": "cred-1",
+			"platform":       "aws-batch",
+			"config": map[string]interface{}{
+				"aws_batch": map[string]interface{}{
+					"region":                "eu-west-2",
+					"work_dir":              "s3://bucket/work",
+					"nvnme_storage_enabled": true, // misspelled v0 name
+				},
+			},
+		},
+	})
+
+	var nvme types.Bool
+	diags := state.GetAttribute(ctx, path.Root("compute_env").AtName("config").AtName("aws_batch").AtName("nvme_storage_enabled"), &nvme)
+	if diags.HasError() {
+		t.Fatalf("reading nvme_storage_enabled: %v", diags)
+	}
+	if nvme.IsNull() || !nvme.ValueBool() {
+		t.Errorf("expected nvme_storage_enabled=true after rename, got %v", nvme)
+	}
+}
+
+func azureBatchState(deleteJobsOnCompletion string, enabled *bool) map[string]interface{} {
+	azureBatch := map[string]interface{}{
+		"delete_jobs_on_completion": deleteJobsOnCompletion,
+	}
+	if enabled != nil {
+		azureBatch["delete_jobs_on_completion_enabled"] = *enabled
+	}
+	return map[string]interface{}{
+		"id":             "ce-123",
+		"compute_env_id": "ce-123",
+		"compute_env": map[string]interface{}{
+			"compute_env_id": "ce-123",
+			"name":           "azure_ce",
+			"credentials_id": "cred-1",
+			"platform":       "azure-batch",
+			"deleted":        false,
+			"config": map[string]interface{}{
+				"azure_batch": azureBatch,
+			},
+		},
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestAwscredentialUpgrade_DropsRemovedAttributes covers the passthrough-style
+// upgrader on a non-compute-env resource. Real v0.25.x seqera_aws_credential
+// state carries attributes since removed from the schema (`deleted`, `keys`,
+// `date_created`, `base_url`, `category`, …). The upgrader must drop them so the
+// state decodes against the current schema, while preserving what remains.
+func TestAwscredentialUpgrade_DropsRemovedAttributes(t *testing.T) {
+	ctx := context.Background()
+
+	state := runUpgraderAgainstSchema(t, NewAWSCredentialResource, stateupgraders.AwscredentialStateUpgraderV0, map[string]interface{}{
+		"id":             "cred-1",
+		"credentials_id": "cred-1",
+		"name":           "my-cred", // still present in the current schema
+		// Attributes removed from the schema since v0.25.x:
+		"deleted":      false,
+		"date_created": "2024-01-01T00:00:00Z",
+		"last_used":    nil,
+		"last_updated": nil,
+		"base_url":     nil,
+		"category":     nil,
+		"checked":      false,
+		"description":  nil,
+		"keys": map[string]interface{}{
+			"access_key": "AKIAEXAMPLE",
+			"secret_key": "secret",
+		},
+	})
+
+	var name types.String
+	if diags := state.GetAttribute(ctx, path.Root("name"), &name); diags.HasError() {
+		t.Fatalf("reading name: %v", diags)
+	}
+	if name.ValueString() != "my-cred" {
+		t.Errorf("expected name preserved as my-cred, got %q", name.ValueString())
+	}
+}

--- a/internal/provider/computeenv_upgrade_decode_test.go
+++ b/internal/provider/computeenv_upgrade_decode_test.go
@@ -210,6 +210,49 @@ func azureBatchState(deleteJobsOnCompletion string, enabled *bool) map[string]in
 
 func boolPtr(b bool) *bool { return &b }
 
+// TestAwsComputeEnvUpgrade_RenamesNvmeAndDropsFusion covers the confirmed-broken
+// legacy seqera_aws_compute_env migration. Real v0.25.x state carries
+// config.{nvnme_storage_enabled (misspelled), fusion_enabled, fusion2_enabled,
+// wave_enabled}. The current schema renamed the nvme flag and removed the three
+// fusion flags (replaced by enable_fusion/enable_wave). The upgrader must carry
+// the nvme value to the new name, drop the removed flags, and preserve the rest.
+func TestAwsComputeEnvUpgrade_RenamesNvmeAndDropsFusion(t *testing.T) {
+	ctx := context.Background()
+
+	state := runUpgraderAgainstSchema(t, NewAWSComputeEnvResource, stateupgraders.AwscomputeenvStateUpgraderV0, map[string]interface{}{
+		"id":             "ce-1",
+		"compute_env_id": "ce-1",
+		"name":           "legacy-aws-ce",
+		"platform":       "aws-batch",
+		"config": map[string]interface{}{
+			"region":                "eu-west-2", // preserved
+			"work_dir":              "s3://bucket/work",
+			"nvnme_storage_enabled": true, // misspelled v0 name -> renamed
+			"fusion_enabled":        true, // removed in current -> dropped
+			"fusion2_enabled":       true, // removed in current -> dropped
+			"wave_enabled":          true, // removed in current -> dropped
+		},
+	})
+
+	// Decoding succeeded, so the removed fusion flags were dropped. Confirm the
+	// nvme rename carried its value and a surviving attribute is intact.
+	var nvme types.Bool
+	if diags := state.GetAttribute(ctx, path.Root("config").AtName("nvme_storage_enabled"), &nvme); diags.HasError() {
+		t.Fatalf("reading nvme_storage_enabled: %v", diags)
+	}
+	if nvme.IsNull() || !nvme.ValueBool() {
+		t.Errorf("expected nvme_storage_enabled=true after rename, got %v", nvme)
+	}
+
+	var region types.String
+	if diags := state.GetAttribute(ctx, path.Root("config").AtName("region"), &region); diags.HasError() {
+		t.Fatalf("reading region: %v", diags)
+	}
+	if region.ValueString() != "eu-west-2" {
+		t.Errorf("expected region preserved as eu-west-2, got %q", region.ValueString())
+	}
+}
+
 // TestAwscredentialUpgrade_DropsRemovedAttributes covers the passthrough-style
 // upgrader on a non-compute-env resource. Real v0.25.x seqera_aws_credential
 // state carries attributes since removed from the schema (`deleted`, `keys`,

--- a/internal/provider/stateupgrader_all_test.go
+++ b/internal/provider/stateupgrader_all_test.go
@@ -1,0 +1,108 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestAllRegisteredUpgradersDropUnknownAttributes drives EVERY registered state
+// upgrader of EVERY resource through the exact check the framework performs: run
+// the upgrader, then strictly decode its returned DynamicValue against the
+// current schema (no IgnoreUndefinedAttributes). Before the default
+// lenient-decode pattern, an upgrader that returned prior state still carrying an
+// attribute since removed from the schema failed here with "unsupported
+// attribute" (issue #228).
+//
+// The fixture injects unknown attributes at the top level AND inside every
+// top-level object attribute, standing in for attributes removed from the schema
+// since the prior state was written. A correct upgrader drops them all (at any
+// depth) so the state decodes cleanly. Enumerating resources via Resources() and
+// their upgraders via UpgradeState() keeps this exhaustive as resources are added.
+func TestAllRegisteredUpgradersDropUnknownAttributes(t *testing.T) {
+	ctx := context.Background()
+
+	p := &SeqeraProvider{}
+	var providerMeta provider.MetadataResponse
+	p.Metadata(ctx, provider.MetadataRequest{}, &providerMeta)
+
+	upgradersSeen := 0
+
+	for _, newResource := range p.Resources(ctx) {
+		res := newResource()
+
+		upgradeable, ok := res.(resource.ResourceWithUpgradeState)
+		if !ok {
+			continue
+		}
+
+		var meta resource.MetadataResponse
+		res.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: providerMeta.TypeName}, &meta)
+
+		var schemaResp resource.SchemaResponse
+		res.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			t.Fatalf("%s: schema errors: %v", meta.TypeName, schemaResp.Diagnostics)
+		}
+		schemaType := schemaResp.Schema.Type().TerraformType(ctx)
+
+		// Build a prior-state fixture full of attributes the current schema does
+		// not define — one at the top level and one inside each top-level object
+		// attribute — to exercise recursive dropping.
+		fixture := map[string]interface{}{
+			"__removed_top_level_attribute": "should be dropped by the upgrade",
+		}
+		if obj, ok := schemaType.(tftypes.Object); ok {
+			for name, attrType := range obj.AttributeTypes {
+				if _, isObject := attrType.(tftypes.Object); isObject {
+					fixture[name] = map[string]interface{}{
+						"__removed_nested_attribute": "should be dropped by the upgrade",
+					}
+				}
+			}
+		}
+
+		priorJSON, err := json.Marshal(fixture)
+		if err != nil {
+			t.Fatalf("%s: marshal fixture: %v", meta.TypeName, err)
+		}
+
+		for version, upgrader := range upgradeable.UpgradeState(ctx) {
+			upgradersSeen++
+			name := fmt.Sprintf("%s/v%d", meta.TypeName, version)
+			t.Run(name, func(t *testing.T) {
+				if upgrader.StateUpgrader == nil {
+					t.Fatalf("no StateUpgrader function registered")
+				}
+
+				req := resource.UpgradeStateRequest{RawState: &tfprotov6.RawState{JSON: priorJSON}}
+				resp := &resource.UpgradeStateResponse{}
+				upgrader.StateUpgrader(ctx, req, resp)
+
+				if resp.Diagnostics.HasError() {
+					t.Fatalf("upgrader diagnostics: %v", resp.Diagnostics)
+				}
+				if resp.DynamicValue == nil {
+					t.Fatalf("upgrader returned no DynamicValue")
+				}
+
+				// The exact strict decode the framework performs on an upgrader's
+				// returned DynamicValue. Any undropped unknown attribute fails here.
+				if _, err := resp.DynamicValue.Unmarshal(schemaType); err != nil {
+					t.Fatalf("upgraded state failed to decode against current schema: %v", err)
+				}
+			})
+		}
+	}
+
+	if upgradersSeen == 0 {
+		t.Fatal("no registered upgraders were exercised; enumeration is broken")
+	}
+	t.Logf("exercised %d registered upgraders", upgradersSeen)
+}

--- a/internal/provider/stateupgrader_schemas.go
+++ b/internal/provider/stateupgrader_schemas.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	stateupgraders "github.com/seqeralabs/terraform-provider-seqera/internal/stateupgraders"
+)
+
+// The state upgraders live in the stateupgraders package because the
+// Speakeasy-generated UpgradeState() registrations reference them by name. To
+// drop attributes removed from a schema since a prior state was written, those
+// upgraders need the current resource schema. The generated registrations cannot
+// set StateUpgrader.PriorSchema, and stateupgraders cannot import this package
+// (import cycle), so we register every upgradeable resource's current schema
+// type here at package initialization. See docs-internal/STATE_UPGRADER_GUIDE.md.
+func init() {
+	ctx := context.Background()
+
+	p := &SeqeraProvider{}
+	var providerMeta provider.MetadataResponse
+	p.Metadata(ctx, provider.MetadataRequest{}, &providerMeta)
+
+	for _, newResource := range p.Resources(ctx) {
+		res := newResource()
+
+		// Only resources with state upgraders need their schema registered.
+		if _, ok := res.(resource.ResourceWithUpgradeState); !ok {
+			continue
+		}
+
+		var metaResp resource.MetadataResponse
+		res.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: providerMeta.TypeName}, &metaResp)
+
+		var schemaResp resource.SchemaResponse
+		res.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+		if schemaResp.Diagnostics.HasError() {
+			continue
+		}
+
+		stateupgraders.RegisterSchemaType(metaResp.TypeName, schemaResp.Schema.Type().TerraformType(ctx))
+	}
+}

--- a/internal/sdk/seqera.go
+++ b/internal/sdk/seqera.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.159.0 and generator version 2.912.1
+// Generated from OpenAPI doc version 1.159.0 and generator version 2.916.2
 
 import (
 	"context"
@@ -175,7 +175,7 @@ func New(opts ...SDKOption) *Seqera {
 	sdk := &Seqera{
 		SDKVersion: "0.40.2",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.40.2 2.912.1 1.159.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.40.2 2.916.2 1.159.0 github.com/seqeralabs/terraform-provider-seqera/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/internal/stateupgraders/action_v0.go
+++ b/internal/stateupgraders/action_v0.go
@@ -2,52 +2,15 @@ package stateupgraders
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// ActionStateUpgraderV0 migrates the state from version 0 to version 1
-// This handles the field rename from nvnme_storage_enabled to nvme_storage_enabled in compute_env config
+// ActionStateUpgraderV0 migrates seqera_action state from schema version 0 to the
+// current schema. It renames the misspelled `nvnme_storage_enabled` flag in the
+// embedded compute-env config, then re-decodes against the current schema,
+// dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func ActionStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// Unmarshal the raw state (JSON format from Terraform state file)
-	var rawState map[string]interface{}
-	err := json.Unmarshal(req.RawState.JSON, &rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Unmarshal Prior State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Navigate to the launch -> compute_env -> config object and perform the migration
-	if launch, ok := rawState["launch"].(map[string]interface{}); ok {
-		if computeEnv, ok := launch["compute_env"].(map[string]interface{}); ok {
-			if config, ok := computeEnv["config"].(map[string]interface{}); ok {
-				if oldValue, exists := config["nvnme_storage_enabled"]; exists {
-					// Copy the value to the new field name
-					config["nvme_storage_enabled"] = oldValue
-					// Remove the old field name
-					delete(config, "nvnme_storage_enabled")
-				}
-			}
-		}
-	}
-
-	// Marshal the updated state back to JSON
-	upgradedStateJSON, err := json.Marshal(rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Marshal Upgraded State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Set the upgraded state as raw JSON
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: upgradedStateJSON,
-	}
+	upgradeToCurrentSchema("seqera_action", req, resp, renameNvmeStorageFlag)
 }

--- a/internal/stateupgraders/awsbatchce_v0.go
+++ b/internal/stateupgraders/awsbatchce_v0.go
@@ -2,86 +2,22 @@ package stateupgraders
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// AwsbatchceStateUpgraderV0 migrates the state from version 0 to version 1
-// This handles the field rename from nvnme_storage_enabled to nvme_storage_enabled
+// AwsbatchceStateUpgraderV0 migrates seqera_aws_batch_ce state from schema
+// version 0 to the current schema: it renames the misspelled
+// `nvnme_storage_enabled` flag, then re-decodes against the current schema,
+// dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AwsbatchceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// Unmarshal the raw state (JSON format from Terraform state file)
-	var rawState map[string]interface{}
-	err := json.Unmarshal(req.RawState.JSON, &rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Unmarshal Prior State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Navigate to the config object and perform the migration
-	if config, ok := rawState["config"].(map[string]interface{}); ok {
-		if oldValue, exists := config["nvnme_storage_enabled"]; exists {
-			// Copy the value to the new field name
-			config["nvme_storage_enabled"] = oldValue
-			// Remove the old field name
-			delete(config, "nvnme_storage_enabled")
-		}
-	}
-
-	// Marshal the updated state back to JSON
-	upgradedStateJSON, err := json.Marshal(rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Marshal Upgraded State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Set the upgraded state as raw JSON
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: upgradedStateJSON,
-	}
+	upgradeToCurrentSchema("seqera_aws_batch_ce", req, resp, renameNvmeStorageFlag)
 }
 
-// AwsbatchceStateUpgraderV1 migrates the state from version 1 to version 2
-// This handles the field rename from compute_env_id to id
+// AwsbatchceStateUpgraderV1 migrates seqera_aws_batch_ce state by renaming the
+// root `compute_env_id` attribute to `id`, then re-decoding against the current
+// schema.
 func AwsbatchceStateUpgraderV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// Unmarshal the raw state (JSON format from Terraform state file)
-	var rawState map[string]interface{}
-	err := json.Unmarshal(req.RawState.JSON, &rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Unmarshal Prior State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Rename compute_env_id to id at the root level
-	if oldValue, exists := rawState["compute_env_id"]; exists {
-		// Copy the value to the new field name
-		rawState["id"] = oldValue
-		// Remove the old field name
-		delete(rawState, "compute_env_id")
-	}
-
-	// Marshal the updated state back to JSON
-	upgradedStateJSON, err := json.Marshal(rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Marshal Upgraded State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Set the upgraded state as raw JSON
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: upgradedStateJSON,
-	}
+	upgradeToCurrentSchema("seqera_aws_batch_ce", req, resp, renameComputeEnvIDToID)
 }

--- a/internal/stateupgraders/awscloudce_v0.go
+++ b/internal/stateupgraders/awscloudce_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// AwscloudceStateUpgraderV0 upgrades seqera_aws_cloud_ce state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AwscloudceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_aws_cloud_ce", req, resp, nil)
 }

--- a/internal/stateupgraders/awscomputeenv_v0.go
+++ b/internal/stateupgraders/awscomputeenv_v0.go
@@ -2,86 +2,22 @@ package stateupgraders
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// AwscomputeenvStateUpgraderV0 migrates the state from version 0 to version 1
-// This handles the field rename from nvnme_storage_enabled to nvme_storage_enabled
+// AwscomputeenvStateUpgraderV0 migrates seqera_aws_compute_env state from schema
+// version 0 to the current schema: it renames the misspelled
+// `nvnme_storage_enabled` flag, then re-decodes against the current schema,
+// dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AwscomputeenvStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// Unmarshal the raw state (JSON format from Terraform state file)
-	var rawState map[string]interface{}
-	err := json.Unmarshal(req.RawState.JSON, &rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Unmarshal Prior State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Navigate to the config object and perform the migration
-	if config, ok := rawState["config"].(map[string]interface{}); ok {
-		if oldValue, exists := config["nvnme_storage_enabled"]; exists {
-			// Copy the value to the new field name
-			config["nvme_storage_enabled"] = oldValue
-			// Remove the old field name
-			delete(config, "nvnme_storage_enabled")
-		}
-	}
-
-	// Marshal the updated state back to JSON
-	upgradedStateJSON, err := json.Marshal(rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Marshal Upgraded State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Set the upgraded state as raw JSON
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: upgradedStateJSON,
-	}
+	upgradeToCurrentSchema("seqera_aws_compute_env", req, resp, renameNvmeStorageFlag)
 }
 
-// AwscomputeenvStateUpgraderV1 migrates the state from version 1 to version 2
-// This handles the field rename from compute_env_id to id
+// AwscomputeenvStateUpgraderV1 migrates seqera_aws_compute_env state by renaming
+// the root `compute_env_id` attribute to `id`, then re-decoding against the
+// current schema.
 func AwscomputeenvStateUpgraderV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// Unmarshal the raw state (JSON format from Terraform state file)
-	var rawState map[string]interface{}
-	err := json.Unmarshal(req.RawState.JSON, &rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Unmarshal Prior State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Rename compute_env_id to id at the root level
-	if oldValue, exists := rawState["compute_env_id"]; exists {
-		// Copy the value to the new field name
-		rawState["id"] = oldValue
-		// Remove the old field name
-		delete(rawState, "compute_env_id")
-	}
-
-	// Marshal the updated state back to JSON
-	upgradedStateJSON, err := json.Marshal(rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Marshal Upgraded State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Set the upgraded state as raw JSON
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: upgradedStateJSON,
-	}
+	upgradeToCurrentSchema("seqera_aws_compute_env", req, resp, renameComputeEnvIDToID)
 }

--- a/internal/stateupgraders/awscredential_v0.go
+++ b/internal/stateupgraders/awscredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// AwscredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// AwscredentialStateUpgraderV0 upgrades seqera_aws_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AwscredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_aws_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/azurebatchce_v0.go
+++ b/internal/stateupgraders/azurebatchce_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// AzurebatchceStateUpgraderV0 upgrades seqera_azure_batch_ce state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AzurebatchceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_azure_batch_ce", req, resp, nil)
 }

--- a/internal/stateupgraders/azurecloudce_v0.go
+++ b/internal/stateupgraders/azurecloudce_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// AzurecloudceStateUpgraderV0 upgrades seqera_azure_cloud_ce state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AzurecloudceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_azure_cloud_ce", req, resp, nil)
 }

--- a/internal/stateupgraders/azurecloudcredential_v0.go
+++ b/internal/stateupgraders/azurecloudcredential_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// AzurecloudcredentialStateUpgraderV0 upgrades seqera_azure_cloud_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AzurecloudcredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_azure_cloud_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/azurecredential_v0.go
+++ b/internal/stateupgraders/azurecredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// AzurecredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// AzurecredentialStateUpgraderV0 upgrades seqera_azure_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AzurecredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_azure_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/azureentracredential_v0.go
+++ b/internal/stateupgraders/azureentracredential_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// AzureentracredentialStateUpgraderV0 upgrades seqera_azure_entra_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func AzureentracredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_azure_entra_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/bitbucketcredential_v0.go
+++ b/internal/stateupgraders/bitbucketcredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// BitbucketcredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// BitbucketcredentialStateUpgraderV0 upgrades seqera_bitbucket_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func BitbucketcredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_bitbucket_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/codecommitcredential_v0.go
+++ b/internal/stateupgraders/codecommitcredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// CodecommitcredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// CodecommitcredentialStateUpgraderV0 upgrades seqera_codecommit_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func CodecommitcredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_codecommit_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/computeenv_v0.go
+++ b/internal/stateupgraders/computeenv_v0.go
@@ -2,48 +2,31 @@ package stateupgraders
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// ComputeenvStateUpgraderV0 migrates the state from version 0 to version 1
-// This handles the field rename from nvnme_storage_enabled to nvme_storage_enabled
+// ComputeenvStateUpgraderV0 migrates seqera_compute_env state from schema
+// version 0 (e.g. provider v0.25.x) directly to the current schema. The plugin
+// framework does not chain upgraders, so this applies every migration between v0
+// and the current schema:
+//
+//   - v0 -> v1: rename the misspelled `nvnme_storage_enabled` flag to
+//     `nvme_storage_enabled` (renameNvmeStorageFlag).
+//   - v1 -> current: derive the Azure Batch delete_jobs_on_completion boolean
+//     (applyComputeEnvV2Migrations).
+//
+// Attribute removals are not enumerated — upgradeToCurrentSchema drops every
+// attribute absent from the current schema.
 func ComputeenvStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// Unmarshal the raw state (JSON format from Terraform state file)
-	var rawState map[string]interface{}
-	err := json.Unmarshal(req.RawState.JSON, &rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Unmarshal Prior State",
-			err.Error(),
-		)
-		return
-	}
+	upgradeToCurrentSchema("seqera_compute_env", req, resp, func(rawState map[string]interface{}) {
+		// Rename the misspelled nvme flag before re-decoding; otherwise the
+		// misspelled key (absent from the current schema) would be dropped
+		// instead of carried to the new name.
+		renameNvmeStorageFlag(rawState)
 
-	// Navigate to the config object and perform the migration
-	if config, ok := rawState["config"].(map[string]interface{}); ok {
-		if oldValue, exists := config["nvnme_storage_enabled"]; exists {
-			// Copy the value to the new field name
-			config["nvme_storage_enabled"] = oldValue
-			// Remove the old field name
-			delete(config, "nvnme_storage_enabled")
+		if computeEnv, ok := rawState["compute_env"].(map[string]interface{}); ok {
+			applyComputeEnvV2Migrations(computeEnv)
 		}
-	}
-
-	// Marshal the updated state back to JSON
-	upgradedStateJSON, err := json.Marshal(rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Marshal Upgraded State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Set the upgraded state as raw JSON
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: upgradedStateJSON,
-	}
+	})
 }

--- a/internal/stateupgraders/computeenv_v1.go
+++ b/internal/stateupgraders/computeenv_v1.go
@@ -2,61 +2,66 @@ package stateupgraders
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// ComputeenvStateUpgraderV1 migrates the state from version 1 to version 2.
+// ComputeenvStateUpgraderV1 migrates seqera_compute_env state from schema
+// version 1 (e.g. provider v0.30.x) to the current schema (issue #228).
 //
-// Azure Batch breaking change: in v0.30.x, `config.azure_batch.delete_jobs_on_completion`
-// was a settable string field (e.g. "on_success", "on_failure"). In v0.40.0 the field
-// is read-only and is replaced by three new boolean fields:
-//   - delete_jobs_on_completion_enabled
-//   - delete_pools_on_completion
-//   - delete_tasks_on_completion
+// Two classes of change occur between v1 and the current schema:
 //
-// Without this upgrader, users carrying old state would see a spurious "null -> true"
-// diff on `delete_jobs_on_completion_enabled` after they update their config, which
-// would force a resource replacement. We translate any non-empty old string value
-// into delete_jobs_on_completion_enabled = true so the plan stays clean.
+//   - Attribute removals — the top-level `compute_env.deleted` bool, and various
+//     per-platform config fields (e.g. `config.aws_cloud.enable_fusion`,
+//     `enable_wave`). These are NOT handled explicitly; upgradeToCurrentSchema
+//     re-decodes against the current schema and drops every removed attribute at
+//     any nesting depth.
+//
+//   - Value transforms — the Azure Batch `delete_jobs_on_completion` string was
+//     superseded by the boolean `delete_jobs_on_completion_enabled`, which needs
+//     an explicit derivation (applyComputeEnvV2Migrations).
 func ComputeenvStateUpgraderV1(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	var rawState map[string]interface{}
-	err := json.Unmarshal(req.RawState.JSON, &rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Unmarshal Prior State",
-			err.Error(),
-		)
-		return
-	}
-
-	// Navigate to config.azure_batch and migrate delete_jobs_on_completion.
-	if config, ok := rawState["config"].(map[string]interface{}); ok {
-		if azureBatch, ok := config["azure_batch"].(map[string]interface{}); ok {
-			if oldValue, exists := azureBatch["delete_jobs_on_completion"]; exists {
-				if s, ok := oldValue.(string); ok && s != "" {
-					// Only set the new flag if the user previously asked for cleanup.
-					// Don't overwrite an explicit false the user may have set.
-					if _, alreadySet := azureBatch["delete_jobs_on_completion_enabled"]; !alreadySet {
-						azureBatch["delete_jobs_on_completion_enabled"] = true
-					}
-				}
-			}
+	upgradeToCurrentSchema("seqera_compute_env", req, resp, func(rawState map[string]interface{}) {
+		if computeEnv, ok := rawState["compute_env"].(map[string]interface{}); ok {
+			applyComputeEnvV2Migrations(computeEnv)
 		}
-	}
+	})
+}
 
-	upgradedStateJSON, err := json.Marshal(rawState)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Marshal Upgraded State",
-			err.Error(),
-		)
+// applyComputeEnvV2Migrations performs the *value* transforms needed to carry a
+// prior `compute_env` object forward to the current schema. Attribute *removals*
+// are intentionally not handled here — upgradeToCurrentSchema drops every
+// attribute absent from the current schema automatically. This function only
+// handles changes that derive a new value from an old one, and is shared by the
+// v0 and v1 upgraders (the framework does not chain upgraders, so each migrates
+// its version directly to the current schema).
+func applyComputeEnvV2Migrations(computeEnv map[string]interface{}) {
+	config, ok := computeEnv["config"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	azureBatch, ok := config["azure_batch"].(map[string]interface{})
+	if !ok {
 		return
 	}
 
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: upgradedStateJSON,
+	// Azure Batch: the legacy settable string `delete_jobs_on_completion`
+	// ("on_success", "always", "never") was replaced by the boolean
+	// `delete_jobs_on_completion_enabled`. Derive the boolean from the old string
+	// so the plan stays clean, but never overwrite a value the user already set.
+	oldValue, exists := azureBatch["delete_jobs_on_completion"]
+	if !exists {
+		return
+	}
+	if _, alreadySet := azureBatch["delete_jobs_on_completion_enabled"]; alreadySet {
+		return
+	}
+	if s, ok := oldValue.(string); ok {
+		switch s {
+		case "always", "on_success":
+			azureBatch["delete_jobs_on_completion_enabled"] = true
+		case "never":
+			azureBatch["delete_jobs_on_completion_enabled"] = false
+		}
 	}
 }

--- a/internal/stateupgraders/containerregistrycredential_v0.go
+++ b/internal/stateupgraders/containerregistrycredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// ContainerregistrycredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// ContainerregistrycredentialStateUpgraderV0 upgrades seqera_container_registry_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func ContainerregistrycredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_container_registry_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/credential_v0.go
+++ b/internal/stateupgraders/credential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// CredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// CredentialStateUpgraderV0 upgrades seqera_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func CredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/customrole_v0.go
+++ b/internal/stateupgraders/customrole_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// CustomroleStateUpgraderV0 upgrades seqera_custom_role state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func CustomroleStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_custom_role", req, resp, nil)
 }

--- a/internal/stateupgraders/gcpbatchce_v0.go
+++ b/internal/stateupgraders/gcpbatchce_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// GcpbatchceStateUpgraderV0 upgrades seqera_gcp_batch_ce state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func GcpbatchceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_gcp_batch_ce", req, resp, nil)
 }

--- a/internal/stateupgraders/gcpcloudce_v0.go
+++ b/internal/stateupgraders/gcpcloudce_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// GcpcloudceStateUpgraderV0 upgrades seqera_gcp_cloud_ce state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func GcpcloudceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_gcp_cloud_ce", req, resp, nil)
 }

--- a/internal/stateupgraders/giteacredential_v0.go
+++ b/internal/stateupgraders/giteacredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// GiteacredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// GiteacredentialStateUpgraderV0 upgrades seqera_gitea_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func GiteacredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_gitea_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/githubappcredential_v0.go
+++ b/internal/stateupgraders/githubappcredential_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// GithubappcredentialStateUpgraderV0 upgrades seqera_github_app_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func GithubappcredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_github_app_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/githubcredential_v0.go
+++ b/internal/stateupgraders/githubcredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// GithubcredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// GithubcredentialStateUpgraderV0 upgrades seqera_github_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func GithubcredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_github_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/gitlabcredential_v0.go
+++ b/internal/stateupgraders/gitlabcredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// GitlabcredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// GitlabcredentialStateUpgraderV0 upgrades seqera_gitlab_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func GitlabcredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_gitlab_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/googlecredential_v0.go
+++ b/internal/stateupgraders/googlecredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// GooglecredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// GooglecredentialStateUpgraderV0 upgrades seqera_google_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func GooglecredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_google_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/kubernetescredential_v0.go
+++ b/internal/stateupgraders/kubernetescredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// KubernetescredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// KubernetescredentialStateUpgraderV0 upgrades seqera_kubernetes_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func KubernetescredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_kubernetes_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/managedcomputece_v0.go
+++ b/internal/stateupgraders/managedcomputece_v0.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
+// ManagedcomputeceStateUpgraderV0 upgrades seqera_managed_compute_ce state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func ManagedcomputeceStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	// No-op
+	upgradeToCurrentSchema("seqera_managed_compute_ce", req, resp, nil)
 }

--- a/internal/stateupgraders/sshcredential_v0.go
+++ b/internal/stateupgraders/sshcredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// SshcredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// SshcredentialStateUpgraderV0 upgrades seqera_ssh_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func SshcredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_ssh_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/toweragentcredential_v0.go
+++ b/internal/stateupgraders/toweragentcredential_v0.go
@@ -4,14 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 )
 
-// ToweragentcredentialStateUpgraderV0 migrates the state from version 0 to version 1
-// This is a no-op upgrade: the credential id field mapping changed at the SDK
-// layer (JSON tag), but the Terraform attribute name remains credentials_id.
+// ToweragentcredentialStateUpgraderV0 upgrades seqera_tower_agent_credential state to the current schema by re-decoding prior state
+// against it, dropping any attribute the schema no longer defines. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
 func ToweragentcredentialStateUpgraderV0(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
-	resp.DynamicValue = &tfprotov6.DynamicValue{
-		JSON: req.RawState.JSON,
-	}
+	upgradeToCurrentSchema("seqera_tower_agent_credential", req, resp, nil)
 }

--- a/internal/stateupgraders/upgrade.go
+++ b/internal/stateupgraders/upgrade.go
@@ -1,0 +1,143 @@
+package stateupgraders
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// schemaTypes maps a resource type name (e.g. "seqera_compute_env") to the
+// tftypes.Type of its current schema. It is populated at init() by the provider
+// package via RegisterSchemaType (see internal/provider/stateupgrader_schemas.go).
+//
+// Why injection: the upstream best practice for dropping attributes removed from
+// a schema during a state upgrade is StateUpgrader.PriorSchema, which Speakeasy
+// does not emit. These upgraders must live in this package (the generated
+// UpgradeState() registrations reference them by name) but they need the current
+// schema to re-decode against — and this package cannot import the provider
+// package to build it (import cycle). So the provider package injects the schema
+// types here. See docs-internal/STATE_UPGRADER_GUIDE.md.
+var schemaTypes = map[string]tftypes.Type{}
+
+// RegisterSchemaType records a resource's current schema type for use by its
+// state upgraders. It is intended to be called only during package
+// initialization (before any UpgradeResourceState RPC is served).
+func RegisterSchemaType(resourceTypeName string, schemaType tftypes.Type) {
+	schemaTypes[resourceTypeName] = schemaType
+}
+
+// upgradeToCurrentSchema is the default state-upgrade implementation for every
+// resource in this provider. It decodes prior raw state, applies an optional
+// in-place value transform (renames and derived values — the only things the
+// framework can't do on its own), then re-encodes the state against the current
+// schema, dropping any attribute the schema no longer defines.
+//
+// The re-decode uses IgnoreUndefinedAttributes, which recurses to every nesting
+// depth — the same behavior the framework applies on its PriorSchema/passthrough
+// paths, but NOT on the DynamicValue path an upgrader returns. Handling removals
+// this way (rather than deleting attributes by name) is comprehensive and
+// future-proof: it drops whatever the current schema no longer has, including
+// attributes removed by later schema regenerations. See
+// docs-internal/STATE_UPGRADER_GUIDE.md.
+func upgradeToCurrentSchema(
+	resourceTypeName string,
+	req resource.UpgradeStateRequest,
+	resp *resource.UpgradeStateResponse,
+	transform func(rawState map[string]interface{}),
+) {
+	var rawState map[string]interface{}
+	if err := json.Unmarshal(req.RawState.JSON, &rawState); err != nil {
+		resp.Diagnostics.AddError("Unable to Unmarshal Prior State", err.Error())
+		return
+	}
+
+	if transform != nil {
+		transform(rawState)
+	}
+
+	finalizeUpgradedState(resourceTypeName, rawState, resp)
+}
+
+// finalizeUpgradedState re-encodes a migrated raw state so it is valid under the
+// current schema and stores it on the response.
+func finalizeUpgradedState(resourceTypeName string, rawState map[string]interface{}, resp *resource.UpgradeStateResponse) {
+	schemaType, ok := schemaTypes[resourceTypeName]
+	if !ok || schemaType == nil {
+		resp.Diagnostics.AddError(
+			"Resource Schema Not Registered",
+			"No current schema type was registered for "+resourceTypeName+" before state upgrade. "+
+				"This is always a bug in the provider and should be reported to the provider developer.",
+		)
+		return
+	}
+
+	upgradedStateJSON, err := json.Marshal(rawState)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to Marshal Upgraded State", err.Error())
+		return
+	}
+
+	rawUpgraded := tfprotov6.RawState{JSON: upgradedStateJSON}
+	value, err := rawUpgraded.UnmarshalWithOpts(
+		schemaType,
+		tfprotov6.UnmarshalOpts{
+			ValueFromJSONOpts: tftypes.ValueFromJSONOpts{IgnoreUndefinedAttributes: true},
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Decode Upgraded State",
+			"After applying the state migration for "+resourceTypeName+", the state could not be decoded "+
+				"against the current schema. This is always a bug in the provider and should be reported "+
+				"to the provider developer:\n\n"+err.Error(),
+		)
+		return
+	}
+
+	dynamicValue, err := tfprotov6.NewDynamicValue(schemaType, value)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to Encode Upgraded State", err.Error())
+		return
+	}
+	resp.DynamicValue = &dynamicValue
+}
+
+// renameNvmeStorageFlag recursively renames the misspelled `nvnme_storage_enabled`
+// key to `nvme_storage_enabled` at any nesting depth under the given node. It is
+// shared by the compute-env family upgraders (compute_env, aws_compute_env,
+// aws_batch_ce, and action, which embeds a compute env config). The exact nesting
+// of the flag is not relied upon, so the rename walks the whole subtree.
+func renameNvmeStorageFlag(node map[string]interface{}) {
+	if v, exists := node["nvnme_storage_enabled"]; exists {
+		if _, taken := node["nvme_storage_enabled"]; !taken {
+			node["nvme_storage_enabled"] = v
+		}
+		delete(node, "nvnme_storage_enabled")
+	}
+
+	for _, child := range node {
+		switch c := child.(type) {
+		case map[string]interface{}:
+			renameNvmeStorageFlag(c)
+		case []interface{}:
+			for _, item := range c {
+				if m, ok := item.(map[string]interface{}); ok {
+					renameNvmeStorageFlag(m)
+				}
+			}
+		}
+	}
+}
+
+// renameComputeEnvIDToID renames the root-level `compute_env_id` attribute to
+// `id`. Shared by the aws_batch_ce / aws_compute_env upgraders.
+func renameComputeEnvIDToID(rawState map[string]interface{}) {
+	if oldValue, exists := rawState["compute_env_id"]; exists {
+		if _, taken := rawState["id"]; !taken {
+			rawState["id"] = oldValue
+		}
+		delete(rawState, "compute_env_id")
+	}
+}


### PR DESCRIPTION
# Background

resolves https://github.com/seqeralabs/terraform-provider-seqera/issues/228

Currently we take the approach of using state-upgraders without prior schema references, resulting in a failure to unmarshal state when a field is dropped or removed — for example the `deleted` field on a compute env, or `enable_fusion`.

The following changes move to re-decoding prior state against the current resource schema during upgrade, so attributes that no longer exist in the schema are dropped automatically instead of being passed through and rejected. The root cause is an unmarshalling contract in the framework: when an upgrader returns raw JSON (`resp.DynamicValue`), `terraform-plugin-framework` re-decodes it **strictly** against the current schema (no `IgnoreUndefinedAttributes`), so any attribute left in the returned state that no longer exists errors with `unsupported attribute`. Its passthrough/`PriorSchema` paths, by contrast, decode leniently. We reproduce that lenient decode inside the upgrader.

This was not caught in our E2E test suite because we test against incremental provider releases and upgrade sequentially, where state changes due to field removal are independent of state migrations — e.g. 0.30.1 -> 0.30.2 -> 0.30.3. The failure only manifests on a **direct jump** across a version bump that also removed attributes (the reporter went 0.30.2 -> 0.40.1).

https://developer.hashicorp.com/terraform/plugin/framework/resources/state-upgrade

## What changed

- New shared helper `upgradeToCurrentSchema` (`internal/stateupgraders/upgrade.go`): applies any value transforms (renames / derived values), then re-decodes the state against the current schema with `IgnoreUndefinedAttributes`, dropping every removed attribute at any nesting depth.
- The current schema type is registered per resource at `init()` (`internal/provider/stateupgrader_schemas.go`). Speakeasy generates the `UpgradeState()` registration and does not emit `StateUpgrader.PriorSchema`, and the `stateupgraders` package cannot import the provider package (import cycle) — so the provider injects each resource's schema type by type name.
- Applied to **all** resource state upgraders, since the same latent bug affects every raw-JSON passthrough upgrader (not just `compute_env`).
- Value transforms retained: `compute_env`/`aws_compute_env`/`aws_batch_ce`/`action` `nvnme_storage_enabled` → `nvme_storage_enabled` rename, and `azure_batch.delete_jobs_on_completion` (string) → `delete_jobs_on_completion_enabled` (bool) derivation.
- Default pattern documented in `docs-internal/STATE_UPGRADER_GUIDE.md`.

## Testing & Validation

### Unit tests — against the real resource schemas (`internal/provider`)
- **All registered upgraders** (`TestAllRegisteredUpgradersDropUnknownAttributes`): enumerates every resource via `Resources()`, pulls each `UpgradeState()` map, and drives all 27 registered upgraders through the framework's exact strict `DynamicValue.Unmarshal`. The fixture injects unknown attributes at the top level **and** nested inside object attributes; every upgrader drops them and produces schema-valid state. Self-maintaining as resources are added.
- **compute_env**: nested removed-attribute drop (`deleted`, `config.aws_cloud.enable_fusion`/`enable_wave`); `nvnme_storage_enabled` → `nvme_storage_enabled` rename with value preserved; `azure_batch.delete_jobs_on_completion` string → `delete_jobs_on_completion_enabled` bool derivation (`on_success`/`always` → true, `never` → false, explicitly-set value not clobbered).
- **aws_credential**: passthrough drops attributes removed since v0.25.x (`keys`, `deleted`, `date_created`, `base_url`, …) while preserving `name`.
- **aws_compute_env**: `nvnme` rename + drops removed `fusion_enabled`/`fusion2_enabled`/`wave_enabled`, preserving `region`.

### End-to-end — real dev-seqera.io (build the old tagged provider, create real resources, upgrade with this branch)
- **v0.30.5 → this branch**: aws-cloud `compute_env` at schema v1 carrying `deleted` + `config.aws_cloud.enable_fusion`. On the pre-fix code this failed with `unsupported attribute "enable_fusion"`; with the fix, `terraform plan` reports **No changes** and `apply` upgrades state to v2 with the removed attributes dropped and `region` preserved — reproduces #228, then confirms the fix.
- **v0.30.0 → this branch** (the reporter's version range): aws-cloud `compute_env` (schema v1, `deleted`) + `aws_credential` (schema v0). Both upgrade cleanly — `compute_env` → v2 (`deleted` dropped), `aws_credential` → v1 — with no unsupported-attribute errors; clean `plan` + `apply`, then destroyed.
- **aws_credential**: a hand-crafted schema-v0 state carrying `keys`/`deleted`/`date_created`/… run through this branch's compiled binary; the upgrade succeeds where the previous passthrough would have failed with `unsupported attribute`.

All e2e runs were performed in an isolated working directory with local state so the shared remote state was untouched, and the test resources were destroyed afterwards.

### Regeneration
- Re-ran `speakeasy run --skip-versioning`: all hand-maintained upgrader/injector/test files (protected in `.genignore`) survive byte-identical, the generated `UpgradeState()` registrations still reference them, and the tree builds + all tests pass.

### Scope note (not e2e-testable by design)
- The split-CE resources (`aws_cloud_ce`, `aws_batch_ce`, `azure_batch_ce`, `azure_cloud_ce`, `gcp_batch_ce`, `gcp_cloud_ce`) and the newer credentials were introduced at schema v1 — no released provider ever wrote pre-v1 state for them, so their v0 upgraders never fire on real state (nothing to migrate from). They are covered by the all-upgraders decode test above.
